### PR TITLE
Rename refactoring dialog does not appear if renaming symbol is not declared in the current project

### DIFF
--- a/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
@@ -101,13 +101,26 @@ type RenameCommandFilter(view: IWpfTextView, serviceProvider: System.IServicePro
                             |> Seq.groupBy (fst >> Path.GetFullPath)
                             |> Seq.map (fun (fileName, symbolUses) -> fileName, Seq.map snd symbolUses |> Seq.toList)
                             |> Seq.toList)
-            let model = RenameDialogModel (cw.GetText(), symbol, state.Project)
-            let wnd = UI.loadRenameDialog model
-            let hostWnd = Window.GetWindow(view.VisualElement)
-            wnd.WindowStartupLocation <- WindowStartupLocation.CenterOwner
-            wnd.Owner <- hostWnd
-            let! res = x.ShowDialog wnd
-            if res then rename currentName model.Name references } |> ignore
+
+            let isSymbolDeclaredInCurrentProject =
+                match symbol.DeclarationLocation with
+                | Some loc ->
+                    let filePath = Path.GetFullPath loc.FileName
+                    // NB: this isn't a foolproof way to match two paths
+                    state.Project.SourceFiles |> Array.exists ((=) filePath)
+                | _ -> false
+
+            if isSymbolDeclaredInCurrentProject then
+                let model = RenameDialogModel (cw.GetText(), symbol)
+                let wnd = UI.loadRenameDialog model
+                let hostWnd = Window.GetWindow(view.VisualElement)
+                wnd.WindowStartupLocation <- WindowStartupLocation.CenterOwner
+                wnd.Owner <- hostWnd
+                let! res = x.ShowDialog wnd
+                if res then rename currentName model.Name references
+            else
+                MessageBox.Show ("Can't rename. The symbol isn't defined in current project.", "F# Power Tools") |> ignore 
+        } |> ignore
 
     member x.ShowDialog (wnd: Window) =
         let vsShell = serviceProvider.GetService(typeof<SVsUIShell>) :?> IVsUIShell

--- a/src/FSharpVSPowerTools.Logic/RenameDialog.fs
+++ b/src/FSharpVSPowerTools.Logic/RenameDialog.fs
@@ -12,14 +12,9 @@ open FSharpVSPowerTools
 
 type RenameDialog = FSharpx.XAML<"RenameDialog.xaml">
 
-type RenameDialogModel(originalName: string, symbol: FSharpSymbol, project: ProjectProvider) =
+type RenameDialogModel(originalName: string, symbol: FSharpSymbol) =
     let mutable name = originalName
     let errorsChanged = Event<_,_>()
-
-    let isFileInCurrentProject ffileName =
-        let filePath = Path.GetFullPath ffileName
-        // NB: this isn't a foolproof way to match two paths
-        project.SourceFiles |> Array.exists ((=) filePath)
 
     let validate name = 
         let cleanUpSymbol (s: string) = s.Replace(")", "").Replace("(", "").Trim()
@@ -29,23 +24,18 @@ type RenameDialogModel(originalName: string, symbol: FSharpSymbol, project: Proj
         | "" -> Choice2Of2 "Empty names are not allowed."
         | _ when name = originalName -> Choice2Of2 "New name is the same as the original."
         | _ ->
-            match symbol.DeclarationLocation with
-            // TODO: this should be determined before opening rename dialog
-            | Some loc when not <| isFileInCurrentProject loc.FileName ->
-                Choice2Of2 "Can't rename. The symbol isn't defined in current project."
-            | _ ->
-                match symbol with
-                | :? FSharpUnionCase ->
-                    // Union case shouldn't be lowercase
-                    if isIdentifier name && not (String.IsNullOrEmpty(name) || Char.IsLower(name.[0])) then
-                        Choice1Of2()
-                    else
-                        Choice2Of2 "Invalid name for union cases."
-                | :? FSharpMemberFunctionOrValue as v when isOperator (cleanUpSymbol v.DisplayName)  ->
-                    if isOperator name then Choice1Of2() 
-                    else Choice2Of2 "Invalid name for operators."
-                | _ -> if isIdentifier name then Choice1Of2()
-                       else Choice2Of2 "Invalid name for identifiers."
+            match symbol with
+            | :? FSharpUnionCase ->
+                // Union case shouldn't be lowercase
+                if isIdentifier name && not (String.IsNullOrEmpty(name) || Char.IsLower(name.[0])) then
+                    Choice1Of2()
+                else
+                    Choice2Of2 "Invalid name for union cases."
+            | :? FSharpMemberFunctionOrValue as v when isOperator (cleanUpSymbol v.DisplayName)  ->
+                if isOperator name then Choice1Of2() 
+                else Choice2Of2 "Invalid name for operators."
+            | _ -> if isIdentifier name then Choice1Of2()
+                    else Choice2Of2 "Invalid name for identifiers."
 
     let mutable validationResult = validate name
     member x.Result = validationResult
@@ -88,5 +78,6 @@ module UI =
             window.Root.DialogResult <- Nullable false
             window.Root.Close())
         window.Root.DataContext <- viewModel
+        window.Root.Loaded.Add (fun _ -> window.txtName.SelectAll())
         window.Root
  


### PR DESCRIPTION
...and select the new symbol name text (mimic standard VS Rename refactoring dialog behaviour). 
