### PR TITLE
Fix missing declaration locations in type declarations

### DIFF
--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -1,6 +1,11 @@
 ﻿namespace FSharpVSPowerTools
 
 [<RequireQualifiedAccess>]
+module Seq =
+    let tryHead s =
+        if Seq.isEmpty s then None else Some (Seq.head s)
+
+[<RequireQualifiedAccess>]
 module Option =
     open System
 

--- a/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
@@ -104,7 +104,7 @@ type RenameCommandFilter(view: IWpfTextView, serviceProvider: System.IServicePro
                             |> Seq.toList)
 
             let isSymbolDeclaredInCurrentProject =
-                match symbol.DeclarationLocation with
+                match VSLanguageService.tryGetLocation symbol with
                 | Some loc ->
                     let filePath = Path.GetFullPath loc.FileName
                     // NB: this isn't a foolproof way to match two paths


### PR DESCRIPTION
Fix #95.

Currently F.C.S doesn't return declaration locations for types (classes, enums, records, structs, etc.). Frankly it returns locations for type members (union cases, fields, members, etc.). So we try to read member locations in these cases to determine whether the types belong to the current project.

`ImplementationLocation` should be prefered when there is an fsi file in scope.

We can use this workaround for now. I will report a bug upstream.
