### PR TITLE
replace FSharpX.Xaml with FsXaml

### DIFF
--- a/src/FSharpVSPowerTools.Logic.VS2013/FSharpVSPowerTools.Logic.VS2013.fsproj
+++ b/src/FSharpVSPowerTools.Logic.VS2013/FSharpVSPowerTools.Logic.VS2013.fsproj
@@ -79,8 +79,12 @@
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
-    <Reference Include="FSharpx.TypeProviders.Xaml">
-      <HintPath>..\..\packages\FSharpx.TypeProviders.Xaml.1.8.41\lib\40\FSharpx.TypeProviders.Xaml.dll</HintPath>
+    <Reference Include="FsXaml.Wpf">
+      <HintPath>..\..\packages\FsXaml.Wpf.0.9.0\lib\net45\FsXaml.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsXaml.Wpf.TypeProvider">
+      <HintPath>..\..\packages\FsXaml.Wpf.0.9.0\lib\net45\FsXaml.Wpf.TypeProvider.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build" />
@@ -134,6 +138,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Interactivity">
+      <HintPath>..\..\packages\Expression.Blend.Sdk.1.0.2\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xaml" />
     <Reference Include="UIAutomationTypes" />

--- a/src/FSharpVSPowerTools.Logic.VS2013/packages.config
+++ b/src/FSharpVSPowerTools.Logic.VS2013/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Expression.Blend.Sdk" version="1.0.2" targetFramework="net45" />
   <package id="FSharp.Compiler.Service" version="0.0.36" targetFramework="net45" />
+  <package id="FsXaml.Wpf" version="0.9.0" targetFramework="net45" />
 </packages>

--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -92,8 +92,12 @@
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
-    <Reference Include="FSharpx.TypeProviders.Xaml">
-      <HintPath>..\..\packages\FSharpx.TypeProviders.Xaml.1.8.41\lib\40\FSharpx.TypeProviders.Xaml.dll</HintPath>
+    <Reference Include="FsXaml.Wpf">
+      <HintPath>..\..\packages\FsXaml.Wpf.0.9.0\lib\net45\FsXaml.Wpf.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsXaml.Wpf.TypeProvider">
+      <HintPath>..\..\packages\FsXaml.Wpf.0.9.0\lib\net45\FsXaml.Wpf.TypeProvider.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build" />
@@ -150,6 +154,10 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Interactivity">
+      <HintPath>..\..\packages\Expression.Blend.Sdk.1.0.2\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xaml" />
     <Reference Include="UIAutomationTypes" />

--- a/src/FSharpVSPowerTools.Logic/RenameDialog.fs
+++ b/src/FSharpVSPowerTools.Logic/RenameDialog.fs
@@ -10,7 +10,7 @@ open FSharpVSPowerTools.ProjectSystem
 open FSharpVSPowerTools
 open FSharp.CompilerBinding
 
-type RenameDialog = FSharpx.XAML<"RenameDialog.xaml">
+type RenameDialog = FsXaml.XAML<"RenameDialog.xaml">
 
 type RenameDialogModel(originalName: string, symbol: Symbol, fSharpSymbol: FSharpSymbol) =
     let mutable name = originalName
@@ -83,7 +83,7 @@ type RenameDialogModel(originalName: string, symbol: Symbol, fSharpSymbol: FShar
 [<RequireQualifiedAccess>]
 module UI =
     let loadRenameDialog (viewModel: RenameDialogModel) =
-        let window = RenameDialog()
+        let window = RenameDialog.Accessor (RenameDialog().CreateRoot())
         // Use this until we are able to do validation directly
         window.txtName.TextChanged.Add(fun _ ->
             window.btnOk.IsEnabled <- not (viewModel :> INotifyDataErrorInfo).HasErrors

--- a/src/FSharpVSPowerTools.Logic/packages.config
+++ b/src/FSharpVSPowerTools.Logic/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Expression.Blend.Sdk" version="1.0.2" targetFramework="net45" />
   <package id="Fantomas" version="1.0.7" targetFramework="net45" />
   <package id="FSharp.Compiler.Service" version="0.0.36" targetFramework="net45" />
-  <package id="FSharpx.TypeProviders.Xaml" version="1.8.41" targetFramework="net45" />
+  <package id="FsXaml.Wpf" version="0.9.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
will close #74

Unfortunate it currently throws an exception at `CreateRoot()`.
Maybe @ReedCopsey can look at it?

```
System.IO.IOException was unhandled by user code
  HResult=-2146232800
  Message=Assembly.GetEntryAssembly() returns null. Set the Application.ResourceAssembly property or use the pack://application:,,,/assemblyname;component/ syntax to specify the assembly to load the resource from.
  Source=PresentationFramework
  StackTrace:
       at MS.Internal.AppModel.ResourceContainer.GetResourceManagerWrapper(Uri uri, String& partName, Boolean& isContentFile)
       at MS.Internal.AppModel.ResourceContainer.GetPartCore(Uri uri)
       at System.IO.Packaging.Package.GetPartHelper(Uri partUri)
       at System.IO.Packaging.Package.GetPart(Uri partUri)
       at System.Windows.Application.GetResourceOrContentPart(Uri uri)
       at System.Windows.Application.LoadComponent(Uri resourceLocator, Boolean bSkipJournaledProperties)
       at System.Windows.Application.LoadComponent(Uri resourceLocator)
       at FsXaml.LoadXaml.from[a](String file)
       at FsXaml.XamlTypeFactory`1.CreateRoot()
       at FSharpVSPowerTools.Refactoring.UI.loadRenameDialog(RenameDialogModel viewModel) in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Logic\RenameDialog.fs:line 86
       at <StartupCode$FSharpVSPowerTools-Logic>.$RenameCommandFilter.HandleRename@97-3.Invoke(Tuple`2 _arg6) in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Logic\RenameCommandFilter.fs:line 107
       at <StartupCode$FSharpVSPowerTools-Logic>.$RenameCommandFilter.HandleRename@91-2.Invoke(Tuple`2 _arg5) in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Logic\RenameCommandFilter.fs:line 91
       at <StartupCode$FSharpVSPowerTools-Logic>.$RenameCommandFilter.HandleRename@90-1.Invoke(DocumentState _arg4) in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Logic\RenameCommandFilter.fs:line 90
       at <StartupCode$FSharpVSPowerTools-Logic>.$RenameCommandFilter.HandleRename@89.Invoke(Unit unitVar) in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Logic\RenameCommandFilter.fs:line 89
       at FSharpVSPowerTools.MaybeBuilder.Delay[T](FSharpFunc`2 f) in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Core\Utils.fs:line 55
       at FSharpVSPowerTools.Refactoring.RenameCommandFilter.HandleRename() in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Logic\RenameCommandFilter.fs:line 88
       at FSharpVSPowerTools.Refactoring.RenameCommandFilter.Microsoft-VisualStudio-OLE-Interop-IOleCommandTarget-Exec(Guid& pguidCmdGroup, UInt32 nCmdId, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Logic\RenameCommandFilter.fs:line 148
       at Microsoft.VisualStudio.Editor.Implementation.CommandChainNode.InnerExec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at Microsoft.VisualStudio.Editor.Implementation.CommandChainNode.Exec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at FSharpVSPowerTools.XmlDoc.XmlDocFilter.Microsoft-VisualStudio-OLE-Interop-IOleCommandTarget-Exec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) in D:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools.Logic\XmlDocFilter.fs:line 75
       at Microsoft.VisualStudio.Editor.Implementation.CommandChainNode.InnerExec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at Microsoft.VisualStudio.Editor.Implementation.CommandChainNode.Exec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at FSharpVSPowerTools.StandardCommandDispatcher.Exec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut) in d:\Dev\OpenSource\VisualFSharpPowerTools\src\FSharpVSPowerTools\StandardCommandDispatcher.cs:line 103
       at Microsoft.VisualStudio.Editor.Implementation.CommandChainNode.InnerExec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at Microsoft.VisualStudio.Editor.Implementation.CommandChainNode.InnerExec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at Microsoft.VisualStudio.Editor.Implementation.SimpleTextViewWindow.Exec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at Microsoft.VisualStudio.Editor.Implementation.CompoundTextViewWindow.Exec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at Microsoft.VisualStudio.Platform.WindowManagement.DocumentObjectSite.Exec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
       at Microsoft.VisualStudio.Platform.WindowManagement.WindowFrame.Exec(Guid& pguidCmdGroup, UInt32 nCmdID, UInt32 nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)
  InnerException: 
```
