### PR TITLE
Add color options for reference types, value types and patterns

### DIFF
--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -28,12 +28,17 @@ let internal getCategory (symbolUse: FSharpSymbolUse) =
 
     | :? FSharpEntity as e ->
         debug "%A (type: %s)" e (e.GetType().Name)
-        if e.IsClass || e.IsDelegate || e.IsFSharpAbbreviation || e.IsFSharpExceptionDeclaration
+        if e.IsEnum || e.IsValueType then
+            ValueType
+        elif e.IsFSharpAbbreviation then
+            let typ = e.AbbreviatedType
+            if typ.HasTypeDefinition && (typ.TypeDefinition.IsEnum || typ.TypeDefinition.IsValueType) then
+                ValueType
+            else ReferenceType
+        elif e.IsClass || e.IsDelegate || e.IsFSharpExceptionDeclaration
            || e.IsFSharpRecord || e.IsFSharpUnion || e.IsInterface || e.IsMeasure || e.IsProvided
            || e.IsProvidedAndErased || e.IsProvidedAndGenerated then
             ReferenceType
-        elif e.IsEnum || e.IsValueType then
-            ValueType
         else Other
     
     | :? FSharpMemberFunctionOrValue as mfov ->

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -21,15 +21,14 @@ type SyntaxConstructClassifier (buffer: ITextBuffer, classificationRegistry: ICl
     
     let referenceType = classificationRegistry.GetClassificationType "FSharp.ReferenceType"
     let valueType = classificationRegistry.GetClassificationType "FSharp.ValueType"
-    let parameterType = classificationRegistry.GetClassificationType "FSharp.TypeParameter"
     let patternType = classificationRegistry.GetClassificationType "FSharp.PatternCase"
 
     let getClassficationType cat =
         match cat with
         | ReferenceType -> Some referenceType
         | ValueType -> Some valueType
-        | TypeParameter -> Some parameterType
         | PatternCase -> Some patternType
+        | TypeParameter -> None
         | Other -> None
     
     let synchronousUpdate (newSpans: (Category * SnapshotSpan) []) = 

--- a/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
@@ -71,20 +71,6 @@ namespace FSharpVSPowerTools
         }
 
         [Export(typeof(EditorFormatDefinition))]
-        [ClassificationType(ClassificationTypeNames = "FSharp.TypeParameter")]
-        [Name("FSharp.TypeParameter")]
-        [UserVisible(true)]
-        sealed class FSharpTypeParameterFormat : ClassificationFormatDefinition
-        {
-            public FSharpTypeParameterFormat()
-            {
-                this.DisplayName = "F# Type Parameters";
-                var color = System.Drawing.Color.FromArgb(0x00C4716C);
-                this.ForegroundColor = Color.FromArgb(color.A, color.R, color.G, color.B);
-            }
-        }
-
-        [Export(typeof(EditorFormatDefinition))]
         [ClassificationType(ClassificationTypeNames = "FSharp.PatternCase")]
         [Name("FSharp.PatternCase")]
         [UserVisible(true)]


### PR DESCRIPTION
I made a few changes so that color options now are available in Tools --> Options --> Environment --> Fonts and Colors --> Display items.

There are three defined colors: 'F# User Types', 'F# User Types (Value types)', and 'F# Patterns'. 
In C#, there are 6 colors which are available in Display items under `User Types` prefix. So we probably have a few more colors to put into good use.

Here is current screenshot. Feel free to adjust the colors (I chose different ones for easy testing)

![image](https://f.cloud.github.com/assets/941060/2426825/ecb85cc8-abcc-11e3-9bdf-c43a2b66febc.png)
