### PR TITLE
Updated to FsXaml 0.9.3

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -95,11 +95,11 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="FsXaml.Wpf">
-      <HintPath>..\..\packages\FsXaml.Wpf.0.9.2\lib\net45\FsXaml.Wpf.dll</HintPath>
+      <HintPath>..\..\packages\FsXaml.Wpf.0.9.3\lib\net45\FsXaml.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FsXaml.Wpf.TypeProvider">
-      <HintPath>..\..\packages\FsXaml.Wpf.0.9.2\lib\net45\FsXaml.Wpf.TypeProvider.dll</HintPath>
+      <HintPath>..\..\packages\FsXaml.Wpf.0.9.3\lib\net45\FsXaml.Wpf.TypeProvider.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Build" />

--- a/src/FSharpVSPowerTools.Logic/packages.config
+++ b/src/FSharpVSPowerTools.Logic/packages.config
@@ -3,5 +3,5 @@
   <package id="Expression.Blend.Sdk" version="1.0.2" targetFramework="net45" />
   <package id="Fantomas" version="1.0.7" targetFramework="net45" />
   <package id="FSharp.Compiler.Service" version="0.0.36" targetFramework="net45" />
-  <package id="FsXaml.Wpf" version="0.9.2" targetFramework="net45" />
+  <package id="FsXaml.Wpf" version="0.9.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The newer FsXaml should support VS 2012 / F# 4.3.0.0 correctly, which I believe resolves Issue #190 completely.
