### PR TITLE
Fix AppVeyor build and disable pattern colors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,7 +38,10 @@
 
 #### 0.5.0 - Unreleased
 * Improve Rename dialog
-* Add indexing for NavigateTo command
+* Improve performance of NavigateTo feature
 * Implement semantic highlighting
+* Migrate to FsXaml
+* Improve lexing performance
+* Fix intermittent navigation bar configration 
 
 

--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -98,7 +98,7 @@ let getCategoriesAndLocations (allSymbolsUses: FSharpSymbolUse[], getLexerSymbol
     // index all symbol usages by LineNumber 
     let wordSpans = 
         allSymbolsUses
-        |> Array.map (fun su -> 
+        |> Seq.map (fun su -> 
             su.RangeAlternate.StartLine, 
             { Start = su.RangeAlternate.StartColumn; End = su.RangeAlternate.EndColumn })
         |> Seq.groupBy fst
@@ -106,7 +106,7 @@ let getCategoriesAndLocations (allSymbolsUses: FSharpSymbolUse[], getLexerSymbol
         |> Map.ofSeq
 
     allSymbolsUses
-    |> Array.map (fun x ->
+    |> Seq.map (fun x ->
         let r = x.RangeAlternate
         let span = { Start = r.StartColumn; End = r.EndColumn }
         

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -8,14 +8,6 @@
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '12.0' ">
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <!-- This is needed to prevent forced migrations when opening the project in Vs2012 -->
-  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '11.0' ">
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-  </PropertyGroup>
-  <!-- This is needed to prevent forced migrations when opening the project in Vs2013 -->
-  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '12.0' ">
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
-  </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -45,6 +37,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DeployExtension>True</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,6 +46,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DeployExtension>False</DeployExtension>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
@@ -57,8 +57,8 @@ namespace FSharpVSPowerTools
             var lightAndBlueColors = new Dictionary<string, Color>()
             {
                 { ClassificationTypes.FSharpReferenceType, Color.FromRgb(0, 0, 140) },
-                { ClassificationTypes.FSharpValueType, Color.FromRgb(0, 0, 140)},
-                { ClassificationTypes.FSharpPatternCase, Color.FromRgb(132, 0, 132) },
+                { ClassificationTypes.FSharpValueType, Color.FromRgb(0, 0, 140) },
+                { ClassificationTypes.FSharpPatternCase, Colors.Black },
                 { ClassificationTypes.FSharpFunction, Color.FromRgb(49, 140, 140) }
             };
 
@@ -71,7 +71,7 @@ namespace FSharpVSPowerTools
             {
                 { ClassificationTypes.FSharpReferenceType, Color.FromRgb(173, 222, 231) },
                 { ClassificationTypes.FSharpValueType, Color.FromRgb(173, 222, 231) },
-                { ClassificationTypes.FSharpPatternCase, Color.FromRgb(181, 132, 181) },
+                { ClassificationTypes.FSharpPatternCase, Color.FromRgb(220, 220, 220) },
                 { ClassificationTypes.FSharpFunction, Color.FromRgb(0, 255, 255) }
             };
 

--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="0.4.2" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="0.4.3" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A colllection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>


### PR DESCRIPTION
After using colored patterns for a while, I find it distracting. It isn't complete since record and enum fields are not supported. Let's give it black/white colors for now.
