### PR TITLE
make DTE.GetActiveDocument safe

### DIFF
--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -135,7 +135,7 @@ type DTE with
     member x.GetActiveDocument() =
         let doc =
             maybe {
-                let! doc = Option.ofNull x.ActiveDocument
+                let! doc = Option.attempt (fun _ -> x.ActiveDocument) |> Option.bind Option.ofNull
                 let! item = Option.ofNull doc.ProjectItem 
                 let! _ = Option.ofNull item.ContainingProject 
                 return doc }


### PR DESCRIPTION
It fixes the following exception from VS log:

```
System.ArgumentException: Параметр задан неверно. (Исключение из HRESULT: 0x80070057 (E_INVALIDARG)) at EnvDTE._DTE.get_ActiveDocument() at 
FSharpVSPowerTools.ProjectSystem.VSUtils.doc@138.Invoke(Unit unitVar) at 
FSharpVSPowerTools.MaybeBuilder.Delay[T](FSharpFunc`2 f) at 
FSharpVSPowerTools.ProjectSystem.VSUtils.DTE.GetActiveDocument(DTE ) at 
<StartupCode$FSharpVSPowerTools-Logic>.$SyntaxConstructClassifier.clo@45-23.Invoke(Unit unitVar) at 
FSharpVSPowerTools.MaybeBuilder.Delay[T](FSharpFunc`2 f) at 
FSharpVSPowerTools.SyntaxColoring.SyntaxConstructClassifier.updateSyntaxConstructClassifiers() at 
<StartupCode$FSharpVSPowerTools-Logic>.$SyntaxConstructClassifier.-ctor@66-41.Invoke(Boolean _arg4) at FSharpVSPowerTools.ProjectSystem.VSUtils.DocumentEventsListener..ctor(FSharpList`1 events, TimeSpan delay, FSharpFunc`2 update) at 
FSharpVSPowerTools.SyntaxColoring.SyntaxConstructClassifier..ctor(ITextBuffer buffer, IClassificationTypeRegistryService classificationRegistry, VSLanguageService vsLanguageService, IServiceProvider serviceProvider) at FSharpVSPowerTools.SyntaxConstructClassifierProvider.<>c__DisplayClass1.<GetClassifier>b__0() at 
Microsoft.VisualStudio.Utilities.PropertyCollection.GetOrCreateSingletonProperty[T](Object key, Func`1 creator) at Microsoft.VisualStudio.Utilities.PropertyCollection.GetOrCreateSingletonProperty[T](Func`1 creator) at FSharpVSPowerTools.SyntaxConstructClassifierProvider.GetClassifier(ITextBuffer buffer) at 
Microsoft.VisualStudio.Text.Classification.Implementation.ClassifierTaggerProvider.<>c__DisplayClass1`1.<CreateTagger>b__0(IClassifierProvider provider) at 
Microsoft.VisualStudio.Text.Utilities.GuardedOperations.InvokeMatchingFactories[TExtensionInstance,TExtensionFactory,TMetadataView](IEnumerable`1 lazyFactories, Func`2 getter, IContentType dataContentType, Object errorSource) 
```
