### PR TITLE
Fix few swallowed first-chance exceptions

### DIFF
--- a/src/FSharpVSPowerTools.Logic/ProjectProvider.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectProvider.fs
@@ -66,13 +66,19 @@ module ProjectProvider =
                 getProperty "TargetFSharpCoreVersion"
 
             member x.TargetFramework = 
-                match getProperty "TargetFrameworkVersion" with
-                | null | "v4.5" | "v4.5.1" -> FSharpTargetFramework.NET_4_5
-                | "v4.0" -> FSharpTargetFramework.NET_4_0
-                | "v3.5" -> FSharpTargetFramework.NET_3_5
-                | "v3.0" -> FSharpTargetFramework.NET_3_5
-                | "v2.0" -> FSharpTargetFramework.NET_2_0
-                | _ -> invalidArg "prop" "Unsupported .NET framework version"
+                match getProperty "TargetFrameworkMoniker" with
+                | null -> FSharpTargetFramework.NET_4_5
+                | x -> 
+                    try
+                        let frameworkName = new Runtime.Versioning.FrameworkName(x)
+                        match frameworkName.Version.Major, frameworkName.Version.Minor with
+                        | 4, 5 -> FSharpTargetFramework.NET_4_5
+                        | 4, 0 -> FSharpTargetFramework.NET_4_0
+                        | 3, 5 -> FSharpTargetFramework.NET_3_5
+                        | 3, 0 -> FSharpTargetFramework.NET_3_0
+                        | 2, 0 -> FSharpTargetFramework.NET_2_0
+                        | _ -> invalidArg "prop" "Unsupported .NET framework version" 
+                    with :? ArgumentException -> FSharpTargetFramework.NET_4_5
 
             member x.CompilerOptions = 
                 match getSourcesAndFlags() with

--- a/src/FSharpVSPowerTools/GeneralOptionsPage.cs
+++ b/src/FSharpVSPowerTools/GeneralOptionsPage.cs
@@ -22,10 +22,8 @@ namespace FSharpVSPowerTools
             {
                 var config = ConfigurationManager.OpenExeConfiguration(Application.ExecutablePath);
                 var configValue = config.AppSettings.Settings[navBarConfig];
-                var b = configValue.Value;
                 bool result;
-                var res = b != null && bool.TryParse(b, out result) ? result : false;
-                return res;
+                return configValue != null && bool.TryParse(configValue.Value, out result) ? result : false;
             }
             catch
             {


### PR DESCRIPTION
Fix a few annoying first chance exceptions.
1. Correct null check in `GetNavigationBarConfig`
2. Use `TargetFrameworkMoniker` instead of `TargetFrameworkVersion` to deduce project target framework since the latter one is not exposed as DTE project property 
