### PR TITLE
Use DisplayContext for type parameters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -45,4 +45,8 @@
 * Fix intermittent navigation bar configuration 
 * Setup integration tests
 
+#### 0.6.0 - Unreleased
+* Add folder organization support
+* Add "Implement Interface" feature
+
 

--- a/src/FSharpVSPowerTools.Logic/ImplementInterfaceSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/ImplementInterfaceSmartTagger.fs
@@ -82,7 +82,8 @@ type ImplementInterfaceSmartTagger(view: ITextView, buffer: ITextBuffer,
                                 match results, buffer.GetSnapshotPoint view.Caret.Position with
                                 | Some (fsSymbolUse, _), Some point when (fsSymbolUse.Symbol :? FSharpEntity) && point.InSpan newWord ->
                                     let entity = fsSymbolUse.Symbol :?> FSharpEntity
-                                    if entity.IsInterface then
+                                    // The entity might correspond to another symbol 
+                                    if entity.IsInterface && entity.DisplayName = symbol.Text then
                                         interfaceDefinition <- Some (interfaceData, fsSymbolUse.DisplayContext, entity)
                                         currentWord <- Some newWord
                                         let span = SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)

--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="0.5.0" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="0.5.1" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A colllection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>

--- a/tests/FSharpVSPowerTools.Core.Tests/InterfaceSampleFile.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/InterfaceSampleFile.fs
@@ -159,3 +159,33 @@ let _ =
         member x.GetEnumerator(): System.Collections.IEnumerator = 
             raise (System.NotImplementedException())
  }
+
+let xx =
+    { new System.Collections.ICollection with
+        member x.CopyTo(array: System.Array, index: int): unit = 
+            raise (System.NotImplementedException())
+        
+        member x.get_Count(): int = 
+            raise (System.NotImplementedException())
+        
+        member x.get_SyncRoot(): obj = 
+            raise (System.NotImplementedException())
+        
+        member x.get_IsSynchronized(): bool = 
+            raise (System.NotImplementedException())
+        
+        member x.GetEnumerator(): System.Collections.IEnumerator = 
+            raise (System.NotImplementedException())
+ }
+
+let yy = { new IA<_> with
+    member x.M
+        with get (): 'a = 
+            raise (System.NotImplementedException())
+    
+    member x.N
+        with get (): 'a = 
+            raise (System.NotImplementedException())
+}
+
+


### PR DESCRIPTION
Fix #278.
Fix #279.

Now type annotations follow the following rule:

> If there are open statements in scope, they are given short names; otherwise, fully-qualified names are returned.
