### PR TITLE
Replaced GUID for Solution Explorer menu to avoid clash with Web Essentials

### DIFF
--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.vsct
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.vsct
@@ -226,7 +226,7 @@
 
     </GuidSymbol>
 
-    <GuidSymbol name="guidSolutionExplorerCmdSet" value="{e396b698-e00e-444b-9f5f-3dcb1ef74e62}">
+    <GuidSymbol name="guidSolutionExplorerCmdSet" value="{1D4A7B65-A22C-4405-837B-4214C0BED3C5}">
       <IDSymbol name="FSPowerToolsMenuGroup" value="0x1060" />
       <IDSymbol name="FSPowerToolsSubMenuGroup" value="0x1061" />
       <IDSymbol name="FSPowerToolsNewFolderGroup" value="0x1063" />


### PR DESCRIPTION
I replaced the GUID for the menu in the VSCT; apparently that was all that was needed to fix #290. The menus for F# Power Tools and Web Essentials now peacefully coexist in both VS2012 and 2013, and F# folder operations work correctly.
