### PR TITLE
RenameFolder - UI + Command

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FolderNameDialog.fs
+++ b/src/FSharpVSPowerTools.Logic/FolderNameDialog.fs
@@ -15,11 +15,12 @@ type NewFolderNameDialog = FsXaml.XAML<"FolderNameDialog.xaml">
 [<NoEquality; NoComparison>]
 type NewFolderNameDialogResources =
     { WindowTitle : string
-      FolderNames : Set<string> }
+      FolderNames : Set<string>
+      OriginalName : string }
 
 type NewFolderNameDialogModel(resources :NewFolderNameDialogResources) =
 
-    let mutable name = ""
+    let mutable name = resources.OriginalName
 
     let validate (name :string) =
         let name = name.Trim()

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.vsct
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.vsct
@@ -116,6 +116,13 @@
         </Strings>
       </Button>
 
+      <Button guid="guidNewFolderCmdSet" id="cmdRenameFolder" priority="0x0102" type="Button">
+        <Parent guid="guidSolutionExplorerCmdSet" id="FSPowerToolsNewFolderGroup"/>
+        <Strings>
+          <ButtonText>Rename Folder</ButtonText>
+        </Strings>
+      </Button>
+
       <Button guid="guidMoveCmdSet" id="cmdMoveFolderUp" priority="0x0110" type="Button">
         <Parent guid="guidSolutionExplorerCmdSet" id="FSPowerToolsMoveGroup"/>
         <Strings>
@@ -236,6 +243,7 @@
     <GuidSymbol name="guidNewFolderCmdSet" value="{9EDC1279-C317-43A6-B554-3A4D7853D55E}">
       <IDSymbol name="FSPowerToolsMenuGroup" value="0x1070" />
       <IDSymbol name="cmdNewFolder" value="0x1071" />
+      <IDSymbol name="cmdRenameFolder" value="0x1072"/>
     </GuidSymbol>
 
     <GuidSymbol name="guidMoveCmdSet" value="{7B573ACF-2772-4F46-B290-9B0EA94CBFAB}">


### PR DESCRIPTION
I'm quite busy lately and that's all I can contribute for now. I'm sorry I can't do more now.
- **UI** - the same dialog which was already there for _New Folder_ command, with the same validation (folder name duplication within solution). Added `OriginalName` to show folder name as default textbox value when renaming (empty string for _New Folder_ command)
- **Command** - _Rename Folder_ under _F# Power Tools_, active only when single folder is selected within Solution Explorer. When used, _Rename Folder_ dialog is shown.

Rename logic should be plugged on line 248. Right now there is just a mesage box with new folder name.
