### PR TITLE
Fix loading issues of the extension in VS2012

### DIFF
--- a/src/FSharpVSPowerTools.Logic/Resource.fs
+++ b/src/FSharpVSPowerTools.Logic/Resource.fs
@@ -7,6 +7,7 @@ module Resource =
     let [<Literal>] formattingErrorMessage = "Unable to format. "
 
     let [<Literal>] renameErrorMessage = "Unable to rename. The symbol hasn't been declared in current solution."
+    
     let [<Literal>] validatingEmptyName = "Empty names are not allowed."
     let [<Literal>] validatingOriginalName = "New name should not be the same as the original one."
     let [<Literal>] validatingUnionCase = "Invalid name for union cases."
@@ -24,7 +25,7 @@ module Resource =
     let [<Literal>] navBarUnauthorizedMessage = "Unauthorized access to navigation bar configuration. Please try again after restarting Visual Studio from Administrator."
     let [<Literal>] navBarErrorMessage = "Error occurs while saving navigation bar configuration."
 
-    let [<Literal>] newFolderDialogTitle = vsPackageTitle + " - New Folder"
-    let [<Literal>] renameFolderDialogTitle = vsPackageTitle + " - Rename Folder"
+    let newFolderDialogTitle = vsPackageTitle + " - New Folder"
+    let renameFolderDialogTitle = vsPackageTitle + " - Rename Folder"
 
     let [<Literal>] implementInterfaceErrorMessage = "All members of this interface have been implemented."

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -68,14 +68,15 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\vs2012\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\vs2012\Microsoft.VisualStudio.CoreUtility.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\vs2012\Microsoft.VisualStudio.Language.Intellisense.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.NavigateTo.Interfaces" />
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Editor, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
     </Reference>
     <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />


### PR DESCRIPTION
Syntax coloring fails to load in VS2012 due to mismatched dlls.
