### PR TITLE
fixed: Find all references displays duplicates in some cases

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FindReferencesFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/FindReferencesFilter.fs
@@ -85,6 +85,7 @@ type FindReferencesFilter(view: IWpfTextView, vsLanguageService: VSLanguageServi
                             // Sort symbols by positions
                             symbolUses 
                             |> Seq.map snd 
+                            |> Seq.distinctBy (fun s -> s.RangeAlternate)
                             |> Seq.sortBy (fun s -> s.RangeAlternate.StartLine, s.RangeAlternate.StartColumn))
                         |> Seq.concat)
                     |> fun opt -> defaultArg opt Seq.empty

--- a/src/FSharpVSPowerTools.Logic/Library.fs
+++ b/src/FSharpVSPowerTools.Logic/Library.fs
@@ -12,12 +12,13 @@ open Microsoft.VisualStudio.TextManager.Interop
 open Microsoft.VisualStudio.Language.Intellisense
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open FSharpVSPowerTools.ProjectSystem
+open FSharpVSPowerTools
 
 [<RequireQualifiedAccess>]
 module Constants =
     let [<Literal>] FindReferencesResults = 0x11223344u
 
-type FSharpLibraryNode(name, serviceProvider: System.IServiceProvider, ?symbolUse: FSharpSymbolUse) =
+type FSharpLibraryNode(name: string, serviceProvider: System.IServiceProvider, ?symbolUse: FSharpSymbolUse) =
     inherit LibraryNode(name)
     do
         base.CanGoToSource <- true
@@ -69,8 +70,8 @@ type FSharpLibraryNode(name, serviceProvider: System.IServiceProvider, ?symbolUs
             let line = range.StartLine-1
             let (_, lineLength) = vsTextBuffer.GetLengthOfLine(line)
             let (_, lineStr) = vsTextBuffer.GetLineText(line, 0, line, lineLength)
-            // Trimming for display purpose
-            let content = lineStr.Trim()
+            // Trimming for display purpose, but we should not touch the trailing spaces.
+            let content = lineStr.TrimStart()
             let numOfWhitespaces = lineStr.Length - content.Length
             let (_, rangeText) = vsTextBuffer.GetLineText(range.StartLine-1, range.StartColumn, range.EndLine-1, range.EndColumn)
             // We use name since ranges might not be correct on fully qualified symbols
@@ -78,7 +79,7 @@ type FSharpLibraryNode(name, serviceProvider: System.IServiceProvider, ?symbolUs
             // Get the index of symbol in the trimmed text
             let highlightStart = prefix.Length + range.StartColumn + offset - numOfWhitespaces
             let highlightLength = name.Length
-            let text = prefix + content
+            let text = prefix + content.Trim()
             Some (highlightStart, highlightLength, text)
         | _ -> None
 


### PR DESCRIPTION
fixed: Find all references highlight symbol inaccurately if the containing line has trailing spaces
