### PR TITLE
Make XmlDocFilter asynchronous

### DIFF
--- a/src/FSharpVSPowerTools.Core/XmlDocParser.fs
+++ b/src/FSharpVSPowerTools.Core/XmlDocParser.fs
@@ -1,7 +1,7 @@
 ﻿namespace FSharpVSPowerTools.Core
 
 type XmlDocable =
-    | XmlDocable of line: int * indent: int * paramNames: string list
+    | XmlDocable of int * int * string list
 
 module internal XmlDocParsing =
     open Microsoft.FSharp.Compiler.Range
@@ -34,8 +34,8 @@ module internal XmlDocParsing =
         | SynPat.InstanceMember _
         | SynPat.FromParseError _ -> []
 
-    let getXmlDocablesImpl(sourceCodeLinesOfTheFile: string[], sourceCodeOfTheFile, filename, checker: InteractiveChecker) =
-        let indentOf (lineNum:int) =
+    let getXmlDocablesImpl(sourceCodeLinesOfTheFile: string [], sourceCodeOfTheFile, filename, checker: InteractiveChecker) =
+        let indentOf (lineNum: int) =
             let mutable i = 0
             let line = sourceCodeLinesOfTheFile.[lineNum-1] // -1 because lineNum reported by xmldocs are 1-based, but array is 0-based
             while i < line.Length && line.Chars(i) = ' ' do

--- a/src/FSharpVSPowerTools.Logic/XmlDocFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/XmlDocFilter.fs
@@ -39,38 +39,36 @@ type XmlDocFilter(textView: IVsTextView, wpfTextView: IWpfTextView, filename: st
 
                     match XmlDocComment.isBlank lineWithLastCharInserted with
                     | Some i when i = indexOfCaret ->
-                        let curLineNum = wpfTextView.Caret.Position.BufferPosition.GetContainingLine().LineNumber + 1 // XmlDocable line #1 are 1-based, editor is 0-based
-                        let xmlDocables = 
-                            XmlDocParser.GetXmlDocables(wpfTextView.TextSnapshot.GetText(), filename, languageService.Checker)
-                            |> Async.RunSynchronously
-                        let xmlDocablesBelowThisLine = 
-                            xmlDocables 
-                            |> List.filter (fun (XmlDocable(line,_indent,_paramNames)) -> line = curLineNum+1) // +1 because looking below current line for e.g. a 'member'
-                        let hr = passThruToEditor.Exec(&pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut) // parse it before we pass thru to editor, as we want to notice if no XmlDoc yet
-                        match xmlDocablesBelowThisLine with
-                        | [] -> ()
-                        | XmlDocable(_line,indent,paramNames)::_t ->
-                            // delete the slashes the user typed (they may be indented wrong)
-                            wpfTextView.TextBuffer.Delete(wpfTextView.Caret.Position.BufferPosition.GetContainingLine().Extent.Span) |> ignore
-                            // add the new xmldoc comment
-                            let toInsert = new System.Text.StringBuilder()
-                            toInsert.Append(' ', indent).AppendLine("/// <summary>")
-                                    .Append(' ', indent).AppendLine("/// ")
-                                    .Append(' ', indent).Append("/// </summary>") |> ignore
-                            for p in paramNames do
-                                toInsert.AppendLine().Append(' ', indent).Append(sprintf "/// <param name=\"%s\"></param>" p) |> ignore
-                            let _newSS = wpfTextView.TextBuffer.Insert(wpfTextView.Caret.Position.BufferPosition.Position, toInsert.ToString())
-                            // move the caret to between the summary tags
-                            let lastLine = wpfTextView.Caret.Position.BufferPosition.GetContainingLine()
-                            let middleSummaryLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(lastLine.LineNumber - 1 - paramNames.Length)
-                            let _newCaret = wpfTextView.Caret.MoveTo(wpfTextView.GetTextViewLineContainingBufferPosition(middleSummaryLine.Start))
-                            ()
-                        hr
-                    | _ -> passThruToEditor.Exec(&pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut)
-                | _ -> passThruToEditor.Exec(&pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut)
-            else
-                passThruToEditor.Exec(&pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut)
+                        async {
+                            // XmlDocable line #1 are 1-based, editor is 0-based
+                            let curLineNum = wpfTextView.Caret.Position.BufferPosition.GetContainingLine().LineNumber + 1 
+                            let! xmlDocables = XmlDocParser.GetXmlDocables(wpfTextView.TextSnapshot.GetText(), filename, languageService.Checker)
+                            let xmlDocablesBelowThisLine = 
+                                // +1 because looking below current line for e.g. a 'member'
+                                xmlDocables |> List.filter (fun (XmlDocable(line,_indent,_paramNames)) -> line = curLineNum+1) 
+                            match xmlDocablesBelowThisLine with
+                            | [] -> ()
+                            | XmlDocable(_line,indent,paramNames)::_t ->
+                                // delete the slashes the user typed (they may be indented wrong)
+                                wpfTextView.TextBuffer.Delete(wpfTextView.Caret.Position.BufferPosition.GetContainingLine().Extent.Span) |> ignore
+                                // add the new xmldoc comment
+                                let toInsert = new System.Text.StringBuilder()
+                                toInsert.Append(' ', indent).AppendLine("/// <summary>")
+                                        .Append(' ', indent).AppendLine("/// ")
+                                        .Append(' ', indent).Append("/// </summary>") |> ignore
+                                for p in paramNames do
+                                    toInsert.AppendLine().Append(' ', indent).Append(sprintf "/// <param name=\"%s\"></param>" p) |> ignore
+                                let _newSS = wpfTextView.TextBuffer.Insert(wpfTextView.Caret.Position.BufferPosition.Position, toInsert.ToString())
+                                // move the caret to between the summary tags
+                                let lastLine = wpfTextView.Caret.Position.BufferPosition.GetContainingLine()
+                                let middleSummaryLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(lastLine.LineNumber - 1 - paramNames.Length)
+                                let _newCaret = wpfTextView.Caret.MoveTo(wpfTextView.GetTextViewLineContainingBufferPosition(middleSummaryLine.Start))
+                                ()
+                            } |> Async.StartImmediate
+                    | _ -> ()
+                | _ -> ()
+            passThruToEditor.Exec(&pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut)
 
-        member x.QueryStatus(pguidCmdGroup: byref<Guid>, cCmds: uint32, prgCmds: OLECMD[], pCmdText: IntPtr) =
+        member x.QueryStatus(pguidCmdGroup: byref<Guid>, cCmds: uint32, prgCmds: OLECMD [], pCmdText: IntPtr) =
             passThruToEditor.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText)
 


### PR DESCRIPTION
And remove named union fields which aren't available in F# 3.0.
