### PR TITLE
Show union cases, enum fields and record fields in pattern matching as PatternCase

### DIFF
--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -53,10 +53,13 @@ let internal getCategory (symbolUse: FSharpSymbolUse) =
     | :? FSharpGenericParameter
     | :? FSharpStaticParameter -> 
         TypeParameter
-    | :? FSharpUnionCase
-    | :? FSharpActivePatternCase -> 
+    | :? FSharpActivePatternCase
+    | :? FSharpUnionCase when symbolUse.IsFromPattern ->
         PatternCase
-
+    | :? FSharpField as f 
+        when (f.DeclaringEntity.IsFSharpRecord || f.DeclaringEntity.IsEnum) && symbolUse.IsFromPattern ->
+        PatternCase
+        
     | :? FSharpField as f ->
         if f.IsMutable || isReferenceCell f.FieldType then MutableVar
         elif f.Accessibility.IsPublic then PublicField 

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -151,9 +151,9 @@ let ``value type``() =
 
 [<Test>]
 let ``DU case of function``() =
-    checkCategories 49 [ ReferenceType, 5, 19; PatternCase, 22, 30; ReferenceType, 35, 39; ReferenceType, 43, 47 ]
-    checkCategories 50 [ PatternCase, 5, 13; Function, 14, 22; PatternCase, 26, 34 ]
-    checkCategories 51 [ PatternCase, 6, 14; PatternCase, 34, 42; Function, 43, 47; Function, 51, 55 ]
+    checkCategories 49 [ ReferenceType, 5, 19; ReferenceType, 35, 39; ReferenceType, 43, 47 ]
+    checkCategories 50 [ PatternCase, 5, 13; Function, 14, 22 ]
+    checkCategories 51 [ PatternCase, 34, 42; Function, 43, 47; Function, 51, 55 ]
 
 [<Test>]
 let ``double quoted function without spaces``() = checkCategories 52 [ Function, 4, 45 ]


### PR DESCRIPTION
The use of these fields in other places will be skipped.

The idea is to distinguish pattern matching with their use in declaration and expressions.
Right now it looks like this:

![image](https://cloud.githubusercontent.com/assets/941060/2795617/f42c9018-cbfd-11e3-9af4-49138811a6c7.png)

Close #247.
