### PR TITLE
FSharpLanguageService.GetColorStateAtStartOfLine() uses compiled expression instead of reflection

### DIFF
--- a/src/FSharpVSPowerTools.Logic/ProjectSystem.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectSystem.fs
@@ -95,16 +95,17 @@ type FSharpLanguageService [<ImportingConstructor>]
     let getColorStateAtStartOfLine = lazy (
         let ty = asm.Value.GetType("Microsoft.VisualStudio.FSharp.LanguageService.VsTextColorState")
         let m = ty.GetMethod ("GetColorStateAtStartOfLine", staticFlags)
-        let lambda = 
-            Expr.Lambda<Func<IVsTextColorState, int, int>>(
-                Expr.Call(m, Expr.Parameter(typeof<IVsTextColorState>), Expr.Parameter(typeof<int>)))
+        let stateParam = Expr.Parameter typeof<IVsTextColorState>
+        let lineParam = Expr.Parameter typeof<int>
+        let lambda = Expr.Lambda<Func<IVsTextColorState, int, int>>(Expr.Call(m, stateParam, lineParam), stateParam, lineParam)
         lambda.Compile().Invoke
     )
     
     let lexStateOfColorState = lazy (
         let ty = asm.Value.GetType("Microsoft.VisualStudio.FSharp.LanguageService.ColorStateLookup")
         let m = ty.GetMethod ("LexStateOfColorState", staticFlags)
-        let lambda = Expr.Lambda<Func<int, int64>>(Expr.Call(m, Expr.Parameter(typeof<int>)))
+        let lineParam = Expr.Parameter typeof<int>
+        let lambda = Expr.Lambda<Func<int, int64>>(Expr.Call(m, lineParam), lineParam)
         lambda.Compile().Invoke
     )
 

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -120,12 +120,11 @@ type SyntaxConstructClassifier (doc: ITextDocument, classificationRegistry: ICla
             spans
         | None -> [||]
 
-
     interface IClassifier with
         // it's called for each visible line of code
-        member x.GetClassificationSpans(snapshotSpan: SnapshotSpan) = 
+        member x.GetClassificationSpans(snapshotSpan: SnapshotSpan) =
             try getClassificationSpans snapshotSpan :> _
             with e -> Logging.logException e; upcast [||]
-        
+
         [<CLIEvent>]
         member x.ClassificationChanged = classificationChanged.Publish


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/873919/3095909/768ae3a0-e5cd-11e3-8264-045bb08d23cb.png)
