### PR TITLE
Avoid doing redundant work while cursor is still on current word

### DIFF
--- a/src/FSharpVSPowerTools.Logic/ImplementInterfaceSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/ImplementInterfaceSmartTagger.fs
@@ -33,7 +33,7 @@ type ImplementInterfaceSmartTagger(view: ITextView, buffer: ITextBuffer,
                                    editorOptionsFactory: IEditorOptionsFactoryService, textUndoHistory: ITextUndoHistory,
                                    vsLanguageService: VSLanguageService, serviceProvider: IServiceProvider) as self =
     let tagsChanged = Event<_, _>()
-    let mutable state = None
+    let mutable state: (SnapshotSpan * _) option = None
 
     let queryInterfaceState (point: SnapshotPoint) (doc: EnvDTE.Document) (project: IProjectProvider) =
         async {
@@ -61,44 +61,47 @@ type ImplementInterfaceSmartTagger(view: ITextView, buffer: ITextBuffer,
         r1.Start = r2.Start
 
     let updateAtCaretPosition() =
-        asyncMaybe {
-            let! point = buffer.GetSnapshotPoint view.Caret.Position |> liftMaybe
-            let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
-            let! doc = dte.GetActiveDocument() |> liftMaybe
-            let! project = ProjectProvider.createForDocument doc |> liftMaybe
-            let! newWord, symbol = vsLanguageService.GetSymbol(point, project) |> liftMaybe
-            match symbol.Kind with
-            | SymbolKind.Ident ->
-                let! interfaceState = queryInterfaceState point doc project
-                let! (fsSymbolUse, results) = 
-                    vsLanguageService.GetFSharpSymbolUse (newWord, symbol, doc.FullName, project, AllowStaleResults.MatchingSource)
-                // Recheck cursor position to ensure it's still in new word
+        match buffer.GetSnapshotPoint view.Caret.Position, state with
+        | Some point, Some (word, _) when word.Snapshot = view.TextSnapshot && point.InSpan word -> ()
+        | _ ->
+            asyncMaybe {
                 let! point = buffer.GetSnapshotPoint view.Caret.Position |> liftMaybe
-                return!
-                    (match fsSymbolUse.Symbol with
-                    | :? FSharpEntity as entity when point.InSpan newWord ->
-                        // The entity might correspond to another symbol so we check for symbol text and start ranges as well
-                        if InterfaceStubGenerator.isInterface entity && entity.DisplayName = symbol.Text 
-                            && hasSameStartPos fsSymbolUse.RangeAlternate interfaceState.InterfaceData.Range then
-                            Some (newWord, (interfaceState, fsSymbolUse.DisplayContext, entity, results))
-                        else None
-                    | _ -> None) |> liftMaybe
-            | _ -> return! liftMaybe None
-        }
-        |> Async.map (fun result -> 
-            let changed =
-                match state, result with
-                | None, None -> false
-                | Some (oldWord, _), Some(newWord, _) -> newWord <> oldWord
-                | _ -> true
-            state <- result
-            if changed then
-                let span = SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)
-                tagsChanged.Trigger(self, SnapshotSpanEventArgs(span)))
-        |> Async.StartImmediate
+                let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+                let! doc = dte.GetActiveDocument() |> liftMaybe
+                let! project = ProjectProvider.createForDocument doc |> liftMaybe
+                let! newWord, symbol = vsLanguageService.GetSymbol(point, project) |> liftMaybe
+                match symbol.Kind with
+                | SymbolKind.Ident ->
+                    let! interfaceState = queryInterfaceState point doc project
+                    let! (fsSymbolUse, results) = 
+                        vsLanguageService.GetFSharpSymbolUse (newWord, symbol, doc.FullName, project, AllowStaleResults.MatchingSource)
+                    // Recheck cursor position to ensure it's still in new word
+                    let! point = buffer.GetSnapshotPoint view.Caret.Position |> liftMaybe
+                    return!
+                        (match fsSymbolUse.Symbol with
+                        | :? FSharpEntity as entity when point.InSpan newWord ->
+                            // The entity might correspond to another symbol so we check for symbol text and start ranges as well
+                            if InterfaceStubGenerator.isInterface entity && entity.DisplayName = symbol.Text 
+                                && hasSameStartPos fsSymbolUse.RangeAlternate interfaceState.InterfaceData.Range then
+                                Some (newWord, (interfaceState, fsSymbolUse.DisplayContext, entity, results))
+                            else None
+                        | _ -> None) |> liftMaybe
+                | _ -> return! liftMaybe None
+            }
+            |> Async.map (fun result -> 
+                let changed =
+                    match state, result with
+                    | None, None -> false
+                    | Some (oldWord, _), Some(newWord, _) -> newWord <> oldWord
+                    | _ -> true
+                state <- result
+                if changed then
+                    let span = SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)
+                    tagsChanged.Trigger(self, SnapshotSpanEventArgs(span)))
+            |> Async.StartImmediate
 
     let _ = DocumentEventsListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
-                                    200us, updateAtCaretPosition)
+                                    500us, updateAtCaretPosition)
 
     let getLineIdent (lineStr: string) =
         lineStr.Length - lineStr.TrimStart(' ').Length


### PR DESCRIPTION
A few changes to reduce pressure of Implement interface and Record stub generation on VS editors.
