### PR TITLE
Attempt to catch exceptions inside async blocks

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -59,8 +59,8 @@
     <None Include="packages.config" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Resource.fs" />
-    <Compile Include="VSUtils.fs" />
     <Compile Include="Logger.fs" />
+    <Compile Include="VSUtils.fs" />
     <Compile Include="VisualStudioVersion.fs" />
     <Compile Include="ThemeManager.fs" />
     <Compile Include="ProjectSystem.fs" />

--- a/src/FSharpVSPowerTools.Logic/FindReferencesFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/FindReferencesFilter.fs
@@ -95,7 +95,7 @@ type FindReferencesFilter(view: IWpfTextView, vsLanguageService: VSLanguageServi
             | _ -> 
                 let statusBar = serviceProvider.GetService<IVsStatusbar, SVsStatusbar>()
                 statusBar.SetText(Resource.findAllReferencesStatusMessage) |> ignore 
-        } |> Async.StartImmediate
+        } |> Async.StartImmediateSafe
 
     member val IsAdded = false with get, set
     member val NextTarget: IOleCommandTarget = null with get, set

--- a/src/FSharpVSPowerTools.Logic/ImplementInterfaceSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/ImplementInterfaceSmartTagger.fs
@@ -106,7 +106,7 @@ type ImplementInterfaceSmartTagger(view: ITextView, buffer: ITextBuffer,
                         state <- result
                         let span = SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)
                         tagsChanged.Trigger(self, SnapshotSpanEventArgs(span)))
-                    |> Async.StartImmediate
+                    |> Async.StartImmediateSafe
                     currentWord <- Some newWord
             | _ -> ()
 
@@ -182,7 +182,7 @@ type ImplementInterfaceSmartTagger(view: ITextView, buffer: ITextBuffer,
                                                                getMemberByLocation displayContext state.InterfaceData
                         return handleImplementInterface snapshot state displayContext implementedMemberSignatures entity
                     }
-                    |> Async.StartImmediate
+                    |> Async.StartImmediateSafe
                 else
                     let statusBar = serviceProvider.GetService<IVsStatusbar, SVsStatusbar>()
                     statusBar.SetText(Resource.interfaceEmptyStatusMessage) |> ignore }

--- a/src/FSharpVSPowerTools.Logic/Logger.fs
+++ b/src/FSharpVSPowerTools.Logic/Logger.fs
@@ -27,10 +27,11 @@ type Logger
         | LogType.Warning -> OLEMSGICON.OLEMSGICON_WARNING
         | LogType.Error -> OLEMSGICON.OLEMSGICON_CRITICAL
 
-    let getShellService() = serviceProvider.GetService<IVsUIShell, SVsUIShell>()
+    let getShellService() = 
+        serviceProvider.GetService(typeof<SVsUIShell>) :?> IVsUIShell
 
     let getActivityLogService() =
-        let service = serviceProvider.GetService<IVsActivityLog, SVsActivityLog>()
+        let service = serviceProvider.GetService(typeof<SVsActivityLog>) :?> IVsActivityLog
         Option.ofNull service
 
     member x.Log logType message =
@@ -49,9 +50,9 @@ type Logger
     member x.MessageBox(logType, message) =
         let icon = getIcon logType
         let service = getShellService()
-        let result = 0
+        let result = ref 0
         service.ShowMessageBox(0u, ref Guid.Empty, Resource.vsPackageTitle, message, "", 0u, 
-            OLEMSGBUTTON.OLEMSGBUTTON_OK, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST, icon, 0, ref result)
+            OLEMSGBUTTON.OLEMSGBUTTON_OK, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST, icon, 0, result)
 
 [<AutoOpen; CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
 module Logging =

--- a/src/FSharpVSPowerTools.Logic/RecordStubGeneratorSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/RecordStubGeneratorSmartTagger.fs
@@ -77,7 +77,7 @@ type RecordStubGeneratorSmartTagger(view: ITextView,
                         recordDefinition <- result
                         let span = SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)
                         tagsChanged.Trigger(self, SnapshotSpanEventArgs(span)))
-                    |> Async.StartImmediate
+                    |> Async.StartImmediateSafe
                     currentWord <- Some newWord
             | _ -> ()
 

--- a/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
@@ -123,7 +123,7 @@ type RenameCommandFilter(view: IWpfTextView, vsLanguageService: VSLanguageServic
                     | _ -> return messageBoxError Resource.renameErrorMessage
                 | _ ->
                     return ()
-            } |> Async.StartImmediate
+            } |> Async.StartImmediateSafe
         | _ -> ()
 
     member x.ShowDialog (wnd: Window) =

--- a/src/FSharpVSPowerTools.Logic/UnionPatternMatchCaseGeneratorSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/UnionPatternMatchCaseGeneratorSmartTagger.fs
@@ -78,7 +78,7 @@ type UnionPatternMatchCaseGeneratorSmartTagger(view: ITextView,
                         unionDefinition <- result
                         let span = SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)
                         tagsChanged.Trigger(self, SnapshotSpanEventArgs(span)))
-                    |> Async.StartImmediate
+                    |> Async.StartImmediateSafe
 
                     currentWord <- Some newWord
             | _ -> ()

--- a/src/FSharpVSPowerTools.Logic/XmlDocFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/XmlDocFilter.fs
@@ -64,7 +64,8 @@ type XmlDocFilter(textView: IVsTextView, wpfTextView: IWpfTextView, filename: st
                                 let middleSummaryLine = wpfTextView.TextSnapshot.GetLineFromLineNumber(lastLine.LineNumber - 1 - paramNames.Length)
                                 let _newCaret = wpfTextView.Caret.MoveTo(wpfTextView.GetTextViewLineContainingBufferPosition(middleSummaryLine.Start))
                                 ()
-                            } |> Async.StartImmediate
+                        } 
+                        |> Async.StartImmediateSafe
                     | _ -> ()
                 | _ -> ()
             passThruToEditor.Exec(&pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut)


### PR DESCRIPTION
Related to #483.

Sometimes we've got `UnresolvedPathReferenceNoRange` from FCS. Since it's reraised by async implementation, I hope to catch it by `Async.Catch`. Let me know if it is of any help.

The ultimate solution of course is to protect against that exception in FCS.
