### PR TITLE
What explains the tests bugs

### DIFF
--- a/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
@@ -84,10 +84,9 @@ type CodeGenerationTestService(languageService: LanguageService, compilerOptions
 type MockDocument(src: string) =
     let lines =
         ResizeArray<_>(src.Split([|"\r\n"; "\n"|], StringSplitOptions.None))
-    let fullName = String.Format(@"C:\file{0}.fs", Guid.NewGuid())
 
     interface IDocument with
-        member x.FullName = fullName
+        member x.FullName = @"C:\file.fs"
         member x.LineCount = lines.Count
         member x.GetText() = src
         member x.GetLineText0(line0: int<Line0>) = lines.[int line0]

--- a/tests/FSharpVSPowerTools.Core.Tests/RecordStubGeneratorTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/RecordStubGeneratorTests.fs
@@ -41,7 +41,7 @@ let args =
     |]
 
 let languageService = LanguageService(fun _ -> ())
-let project: ProjectOptions =
+let project() =
     let fileName = @"C:\file.fs"
     let projFileName = @"C:\Project.fsproj"
     let files = [| fileName |]
@@ -69,8 +69,7 @@ let project: ProjectOptions =
 // [ ] Handle record pattern maching: let { Field1 = _; Field2 = _ } = x
 
 let tryFindRecordDefinitionFromPos codeGenInfra (pos: pos) (document: IDocument) =
-    let project = { project with ProjectFileNames = [| document.FullName |] }
-    tryFindRecordDefinitionFromPos codeGenInfra project pos document
+    tryFindRecordDefinitionFromPos codeGenInfra (project()) pos document
     |> Async.RunSynchronously
 
 let insertStubFromPos caretPos src =

--- a/tests/FSharpVSPowerTools.Core.Tests/UnionPatternMatchCaseGeneratorTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/UnionPatternMatchCaseGeneratorTests.fs
@@ -41,7 +41,7 @@ let args =
     |]
 
 let languageService = LanguageService(fun _ -> ())
-let project: ProjectOptions =
+let project() =
     let fileName = @"C:\file.fs"
     let projFileName = @"C:\Project.fsproj"
     let files = [| fileName |]
@@ -55,8 +55,7 @@ let project: ProjectOptions =
       UnresolvedReferences = None }
 
 let tryFindUnionDefinition codeGenService (pos: pos) (document: IDocument) =
-    let project = { project with ProjectFileNames = [| document.FullName |] }
-    tryFindUnionDefinitionFromPos codeGenService project pos document
+    tryFindUnionDefinitionFromPos codeGenService (project()) pos document
     |> Async.RunSynchronously
 
 let insertCasesFromPos caretPos src =
@@ -86,7 +85,7 @@ let insertCasesFromPos caretPos src =
 
 module ClausesAnalysisTests =
     let tryFindPatternMatchExpr codeGenService (pos: pos) (document: IDocument) =
-        tryFindPatternMatchExprInBufferAtPos codeGenService project pos document
+        tryFindPatternMatchExprInBufferAtPos codeGenService (project()) pos document
         |> Async.RunSynchronously
 
 


### PR DESCRIPTION
We used to always use the same file name `C:\file.fs`.

If we use a different filename + project for each test, then the language doesn't have problems with the tests.

How can we explain this new FCS behavior?
Did we exploit an accidental behavior of FCS? Or is it a regression from their part?

(note: this code is not necessarily meant to be merged)
