### PR TITLE
HighlightUsageTagger uses AllowStaleResults.No instead of MatchingSource

### DIFF
--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -65,7 +65,7 @@ type HighlightUsageTagger(view: ITextView, buffer: ITextBuffer,
         async {
             if currentRequest = requestedPoint then
                 try
-                    let! res = vsLanguageService.GetFSharpSymbolUse (newWord, symbol, fileName, projectProvider, AllowStaleResults.MatchingSource)
+                    let! res = vsLanguageService.GetFSharpSymbolUse (newWord, symbol, fileName, projectProvider, AllowStaleResults.No)
                     match res with
                     | Some (_, checkResults) ->
                         let! results = vsLanguageService.FindUsagesInFile (newWord, symbol, checkResults)


### PR DESCRIPTION
I've no idea why we use `AllowStaleResults.MatchingSource` here. I suspect that in FCS 0.0.54 behavior of `Checker.TryGetRecentTypeCheckResultsForFile` was changed and it now works as its xml doc promises. 
