### PR TITLE
Dispose leaked resources revealed by profiling

### DIFF
--- a/src/FSharpVSPowerTools.Logic/DepthTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/DepthTagger.fs
@@ -64,7 +64,7 @@ type DepthTagger(buffer: ITextBuffer, filename: string, fsharpLanguageService: V
         } 
         |> Async.StartImmediateSafe
     
-    let _ = DocumentEventsListener ([ViewChange.bufferChangedEvent buffer], 500us, refreshFileImpl) 
+    let docEventListener = new DocumentEventListener ([ViewChange.bufferChangedEvent buffer], 500us, refreshFileImpl) 
     
     let getTags (spans: NormalizedSnapshotSpanCollection) = 
         match spans |> Seq.toList, state with
@@ -90,3 +90,8 @@ type DepthTagger(buffer: ITextBuffer, filename: string, fsharpLanguageService: V
         
         [<CLIEvent>]
         member x.TagsChanged = tagsChanged.Publish
+
+    interface IDisposable with
+        member x.Dispose() = 
+            (docEventListener :> IDisposable).Dispose()
+         

--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -113,8 +113,8 @@ type HighlightUsageTagger(view: ITextView, buffer: ITextBuffer,
             |> Async.StartInThreadPoolSafe
         | _ -> ()
 
-    let _ = DocumentEventsListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 200us, 
-                                    updateAtCaretPosition)
+    let docEventListener = new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 200us, 
+                                                      updateAtCaretPosition)
 
     let tagSpan span = TagSpan<HighlightUsageTag>(span, HighlightUsageTag()) :> ITagSpan<_>
 
@@ -154,3 +154,7 @@ type HighlightUsageTagger(view: ITextView, buffer: ITextBuffer,
         
         [<CLIEvent>]
         member x.TagsChanged = tagsChanged.Publish
+
+    interface IDisposable with
+        member x.Dispose() = 
+            (docEventListener :> IDisposable).Dispose()

--- a/src/FSharpVSPowerTools.Logic/ImplementInterfaceSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/ImplementInterfaceSmartTagger.fs
@@ -110,7 +110,7 @@ type ImplementInterfaceSmartTagger(view: ITextView, buffer: ITextBuffer,
                     currentWord <- Some newWord
             | _ -> ()
 
-    let _ = DocumentEventsListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
+    let docEventListener = new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
                                     500us, updateAtCaretPosition)
 
     let getLineIdent (lineStr: string) =
@@ -210,3 +210,7 @@ type ImplementInterfaceSmartTagger(view: ITextView, buffer: ITextBuffer,
 
         [<CLIEvent>]
         member x.TagsChanged = tagsChanged.Publish
+
+    interface IDisposable with
+        member x.Dispose() = 
+            (docEventListener :> IDisposable).Dispose()

--- a/src/FSharpVSPowerTools.Logic/RecordStubGeneratorSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/RecordStubGeneratorSmartTagger.fs
@@ -81,7 +81,7 @@ type RecordStubGeneratorSmartTagger(view: ITextView,
                     currentWord <- Some newWord
             | _ -> ()
 
-    let _ = DocumentEventsListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
+    let docEventListener = new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
                                     500us, updateAtCaretPosition)
 
     // Check whether the record has been fully defined
@@ -137,3 +137,7 @@ type RecordStubGeneratorSmartTagger(view: ITextView,
 
         [<CLIEvent>]
         member x.TagsChanged = tagsChanged.Publish
+
+    interface IDisposable with
+        member x.Dispose() = 
+            (docEventListener :> IDisposable).Dispose()

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -101,7 +101,7 @@ type SyntaxConstructClassifier (doc: ITextDocument, classificationRegistry: ICla
 
     do events.BuildEvents.add_OnBuildProjConfigDone onBuildDoneHandler
     
-    let _ = DocumentEventsListener ([ViewChange.bufferChangedEvent doc.TextBuffer], 200us, 
+    let docEventListener = new DocumentEventListener ([ViewChange.bufferChangedEvent doc.TextBuffer], 200us, 
                                     fun() -> updateSyntaxConstructClassifiers false)
 
     let getClassificationSpans (snapshotSpan: SnapshotSpan) =
@@ -141,4 +141,5 @@ type SyntaxConstructClassifier (doc: ITextDocument, classificationRegistry: ICla
     interface IDisposable with
         member x.Dispose() = 
             events.BuildEvents.remove_OnBuildProjConfigDone onBuildDoneHandler
+            (docEventListener :> IDisposable).Dispose()
          

--- a/src/FSharpVSPowerTools.Logic/UnionPatternMatchCaseGeneratorSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/UnionPatternMatchCaseGeneratorSmartTagger.fs
@@ -83,7 +83,7 @@ type UnionPatternMatchCaseGeneratorSmartTagger(view: ITextView,
                     currentWord <- Some newWord
             | _ -> ()
 
-    let _ = DocumentEventsListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
+    let docEventListener = new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
                                     500us, updateAtCaretPosition)
 
     let handleGenerateUnionPatternMatchCases
@@ -138,3 +138,7 @@ type UnionPatternMatchCaseGeneratorSmartTagger(view: ITextView,
 
         [<CLIEvent>]
         member x.TagsChanged = tagsChanged.Publish
+
+    interface IDisposable with
+        member x.Dispose() = 
+            (docEventListener :> IDisposable).Dispose()


### PR DESCRIPTION
- Break references that ITextBuffer keeps to classifiers
- Cancel async runs and stop timers before disposing feature objects

A sample trace before this PR:

![image](https://cloud.githubusercontent.com/assets/941060/3278490/4a5aa60a-f3c2-11e3-906d-465b73f76e89.png)
