### PR TITLE
fixed: SourceCodeClassifier fails to return anything if an exception occurred while getting FSharpMemberFunctionOrValue.FullType

### DIFF
--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -28,11 +28,14 @@ let internal getCategory (symbolUse: FSharpSymbolUse) =
     | Entity (_, Module, _) -> Category.Module
     | Entity (_, _, Tuple) -> Category.ReferenceType
     | Entity (_, (FSharpType | ProvidedType | ByRef | Array), _) -> Category.ReferenceType
-    | MemberFunctionOrValue (Constructor ValueType, _) -> Category.ValueType
-    | MemberFunctionOrValue (Constructor _, _) -> Category.ReferenceType
-    | MemberFunctionOrValue (Function symbolUse.IsFromComputationExpression, _) -> Category.Function
-    | MemberFunctionOrValue (MutableVar, _) -> Category.MutableVar
-    | MemberFunctionOrValue (_, Some RefCell) -> Category.MutableVar
+    | MemberFunctionOrValue (Constructor ValueType) -> Category.ValueType
+    | MemberFunctionOrValue (Constructor _) -> Category.ReferenceType
+    | MemberFunctionOrValue (Function symbolUse.IsFromComputationExpression) -> Category.Function
+    | MemberFunctionOrValue MutableVar -> Category.MutableVar
+    | MemberFunctionOrValue func ->
+        match func.SafeFullType with
+        | Some RefCell -> Category.MutableVar
+        | _ -> Category.Other
     | _ ->
         //debug "Unknown symbol: %A (type: %s)" symbol (symbol.GetType().Name)
         Category.Other 

--- a/src/FSharpVSPowerTools.Core/TypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/TypedAstUtils.fs
@@ -34,6 +34,10 @@ let isOperator (name: string) =
     name.StartsWith "( " && name.EndsWith " )" && name.Length > 4
         && name.Substring (2, name.Length - 4) |> String.forall ((<>) ' ')
         
+type FSharpMemberFunctionOrValue with
+    // FullType may fail with exception. 
+    member x.SafeFullType = Option.attempt (fun _ -> x.FullType)
+
 let (|AbbreviatedType|_|) (entity: FSharpEntity) =
     if entity.IsFSharpAbbreviation then Some entity.AbbreviatedType
     else None
@@ -129,10 +133,7 @@ let (|Tuple|_|) (ty: FSharpType option) =
 /// Func (memberFunctionOrValue, fullType)
 let (|MemberFunctionOrValue|_|) (symbol: FSharpSymbol) =
     match symbol with
-    | :? FSharpMemberFunctionOrValue as func -> 
-        // FullType may fail with exception. 
-        // However it does not mean we should not match the symbol as MemberFucntionOrValue.
-        Some (func, Option.attempt (fun _ -> func.FullType))
+    | :? FSharpMemberFunctionOrValue as func -> Some func
     | _ -> None
 
 /// Constructor (enclosingEntity)


### PR DESCRIPTION
This was a very severe bug. We must merge this before 1.3.0
