### PR TITLE
Refactor to use FullTypeSafe property

### DIFF
--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -33,7 +33,7 @@ let internal getCategory (symbolUse: FSharpSymbolUse) =
     | MemberFunctionOrValue (Function symbolUse.IsFromComputationExpression) -> Category.Function
     | MemberFunctionOrValue MutableVar -> Category.MutableVar
     | MemberFunctionOrValue func ->
-        match func.SafeFullType with
+        match func.FullTypeSafe with
         | Some RefCell -> Category.MutableVar
         | _ -> Category.Other
     | _ ->


### PR DESCRIPTION
Rename 'SafeFullType' to 'FullTypeSafe' to be consistent with other '*Safe' functions.
