### PR TITLE
Fix NRE exception on syntax coloring

### DIFF
--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -40,6 +40,8 @@ type SyntaxConstructClassifier (doc: ITextDocument, classificationRegistry: ICla
         maybe {
             let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
             let! projectItem = Option.attempt (fun _ -> dte.Solution.FindProjectItem doc.FilePath) |> Option.bind Option.ofNull
+            // If there is no backing document, an ITextDocument instance might be null
+            let! _ = Option.ofNull doc
             return! projectFactory.CreateForFileInProject doc.TextBuffer doc.FilePath projectItem.ContainingProject }
 
     let updateSyntaxConstructClassifiers force =
@@ -49,7 +51,7 @@ type SyntaxConstructClassifier (doc: ITextDocument, classificationRegistry: ICla
             oldToken.Cancel()
             oldToken.Dispose())
 
-        let snapshot = doc.TextBuffer.CurrentSnapshot
+        let snapshot = if doc <> null then doc.TextBuffer.CurrentSnapshot else null
         let currentState = state.Value
         let needUpdate =
             match force, currentState with


### PR DESCRIPTION
Close #564.

I'm able to reproduce the stacktrace on VS unit tests using this code fragment:

![image](https://cloud.githubusercontent.com/assets/941060/3726659/961335a8-1695-11e4-932a-ef05914e88c4.png)

Here is the simulated stacktrace:

> Test Name:    should be able to get classification spans
> Test FullName:  FSharpVSPowerTools.Tests.SyntaxConstructClassifierTests.should be able to get classification spans
> Test Source:    C:\PowerTools\tests\FSharpVSPowerTools.Tests\SyntaxConstructClassifierTests.fs : line 58
> Test Outcome:   Failed
> Test Duration:  0:00:00.429
> Result Message: System.NullReferenceException : Object reference not set to an instance of an object.
> Result StackTrace:  
> at <StartupCode$FSharpVSPowerTools-Logic>.$SyntaxConstructClassifier.clo@43-47.Invoke(ProjectItem _arg1) in C:\PowerTools\src\FSharpVSPowerTools.Logic\SyntaxConstructClassifier.fs:line 44
> at <StartupCode$FSharpVSPowerTools-Logic>.$SyntaxConstructClassifier.clo@41-44.Invoke(Unit unitVar) in C:\PowerTools\src\FSharpVSPowerTools.Logic\SyntaxConstructClassifier.fs:line 42
> at FSharpVSPowerTools.MaybeBuilder.Delay[T](FSharpFunc`2 f) in C:\PowerTools\src\FSharpVSPowerTools.Core\Utils.fs:line 160
> at FSharpVSPowerTools.SyntaxColoring.SyntaxConstructClassifier.getProject() in C:\PowerTools\src\FSharpVSPowerTools.Logic\SyntaxConstructClassifier.fs:line 40
> at FSharpVSPowerTools.SyntaxColoring.SyntaxConstructClassifier.updateSyntaxConstructClassifiers(Boolean force) in C:\PowerTools\src\FSharpVSPowerTools.Logic\SyntaxConstructClassifier.fs:line 62
> at <StartupCode$FSharpVSPowerTools-Logic>.$SyntaxConstructClassifier.-ctor@131-67.Invoke(Unit unitVar0) in C:\PowerTools\src\FSharpVSPowerTools.Logic\SyntaxConstructClassifier.fs:line 131
> at FSharpVSPowerTools.ProjectSystem.VSUtils.DocumentEventListener..ctor(FSharpList`1 events, UInt16 delayMillis, FSharpFunc`2 update) in C:\PowerTools\src\FSharpVSPowerTools.Logic\VSUtils.fs:line 265
> at FSharpVSPowerTools.SyntaxColoring.SyntaxConstructClassifier..ctor(ITextDocument doc, IClassificationTypeRegistryService classificationRegistry, VSLanguageService vsLanguageService, IServiceProvider serviceProvider, ProjectFactory projectFactory, Boolean includeUnusedDeclarations) in C:\PowerTools\src\FSharpVSPowerTools.Logic\SyntaxConstructClassifier.fs:line 130
> at FSharpVSPowerTools.SyntaxConstructClassifierProvider.<>c__DisplayClass1.<GetClassifier>b__0() in C:\PowerTools\src\FSharpVSPowerTools\SyntaxConstructClassifierProvider.cs:line 390
> at Microsoft.VisualStudio.Utilities.PropertyCollection.GetOrCreateSingletonProperty[T](Object key, Func`1 creator)
> at FSharpVSPowerTools.SyntaxConstructClassifierProvider.GetClassifier(ITextBuffer buffer) in C:\PowerTools\src\FSharpVSPowerTools\SyntaxConstructClassifierProvider.cs:line 389
> at FSharpVSPowerTools.Tests.SyntaxConstructClassifierHelper.GetClassifier(ITextBuffer buffer) in C:\PowerTools\tests\FSharpVSPowerTools.Tests\SyntaxConstructClassifierTests.fs:line 24
> at FSharpVSPowerTools.Tests.SyntaxConstructClassifierTests.should be able to get classification spans() in C:\PowerTools\tests\FSharpVSPowerTools.Tests\SyntaxConstructClassifierTests.fs:line 62
