### PR TITLE
Fix first chance exceptions caused by FSharpEntity.FullName

### DIFF
--- a/src/FSharpVSPowerTools.Core/AssemblyContentProvider.fs
+++ b/src/FSharpVSPowerTools.Core/AssemblyContentProvider.fs
@@ -75,7 +75,7 @@ type Parent =
                 else idents
             else idents
 
-        entity.GetFullName()
+        entity.TryGetFullName()
         |> Option.bind (fun fullName -> 
             entity.GetFullDisplayName()
             |> Option.map (fun fullDisplayName ->
@@ -143,7 +143,7 @@ module AssemblyContentProvider =
 
                     if entity.IsFSharpModule then
                         for func in entity.MembersFunctionsAndValues do
-                            match func.GetFullDisplayName() with
+                            match func.TryGetFullDisplayName() with
                             | Some displayName ->
                                 yield
                                     { FullName = func.FullName

--- a/src/FSharpVSPowerTools.Core/InterfaceStubGenerator.fs
+++ b/src/FSharpVSPowerTools.Core/InterfaceStubGenerator.fs
@@ -208,7 +208,7 @@ module InterfaceStubGenerator =
                         typ.BaseType 
                         |> Option.bind (fun t -> 
                             if t.HasTypeDefinition then
-                                t.TypeDefinition.GetFullName()
+                                t.TypeDefinition.TryGetFullName()
                              else None)
                         |> Option.exists ((=) "System.MulticastDelegate")
                     if isEventHandler then sprintf "IEvent<%s, _>" coreType else coreType

--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -463,15 +463,18 @@ type LanguageService (dirtyNotify, ?fileSystem: IFileSystem) =
                             | _ ->
                                 // for operator ++ displayName = ( ++ ), compiledName = op_PlusPlus
                                 if func.DisplayName <> func.CompiledName then
-                                    Option.attempt (fun _ -> func.EnclosingEntity.FullName)
+                                    func.EnclosingEntity.TryGetFullName()
                                     |> Option.map (fun enclosingEntityFullName -> 
                                         [| enclosingEntityFullName + "." + func.CompiledName|])
                                 else None
                         | Entity e ->
                             match e with
                             | e, TypedAstUtils.Attribute, _ ->
-                                Some [| e.FullName; e.FullName.Substring(0, e.FullName.Length - (String.length "Attribute")) |]
-                            | e, _, _ -> Option.attempt (fun _ -> [| e.FullName |])
+                                e.TryGetFullName()
+                                |> Option.map (fun fullName ->
+                                    [| fullName; fullName.Substring(0, fullName.Length - "Attribute".Length) |])
+                            | e, _, _ -> 
+                                e.TryGetFullName() |> Option.map (fun x -> [| x |])
                         | UnionCase uc ->
                             Some [| let fullName = uc.FullName
                                     yield fullName


### PR DESCRIPTION
There are a large amount of these exceptions on current master.
