### PR TITLE
Skip timer delay in order to do unit testing easier

### DIFF
--- a/tests/FSharpVSPowerTools.Tests/ResolveUnopenedNamespaceSmartTaggerTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/ResolveUnopenedNamespaceSmartTaggerTests.fs
@@ -33,7 +33,6 @@ type ResolveUnopenedNamespaceSmartTaggerHelper() =
                     None)
         |> Seq.concat
 
-[<TestFixture>]
 module ResolveUnopenedNamespaceSmartTaggerTests =
 #if APPVEYOR
     let timeout = 60000<ms>
@@ -44,9 +43,10 @@ module ResolveUnopenedNamespaceSmartTaggerTests =
     let helper = ResolveUnopenedNamespaceSmartTaggerHelper()
     let fileName = getTempFileName ".fsx"
 
-    [<SetUp>]
-    let deploy() =
+    [<TestFixtureSetUp>]
+    let setUp() =
         TestUtilities.AssertListener.Initialize()
+        DocumentEventListener.SkipTimerDelay <- true
 
     [<Test; Description "This test should be executed before others in order to build up LanguageService cache in the fastest way.">]
     let ``return nothing if tags not found``() = 
@@ -55,9 +55,9 @@ module ResolveUnopenedNamespaceSmartTaggerTests =
         helper.AddProject(VirtualProjectProvider(buffer, fileName))
         helper.SetActiveDocument(fileName)
         let view = helper.GetView(buffer)
-        view.Caret.MoveTo(snapshotPoint view.TextSnapshot 1 1) |> ignore
         let tagger = helper.GetTagger(buffer, view)
-        testEvent tagger.TagsChanged "Timed out before tags changed" timeout
+        testEventTrigger tagger.TagsChanged "Timed out before tags changed" timeout
+            (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 1 1) |> ignore)
             (fun () -> helper.TagsOf(buffer, tagger) |> Seq.concat |> Seq.toList |> assertEqual [])
 
     [<Test>]
@@ -67,9 +67,9 @@ module ResolveUnopenedNamespaceSmartTaggerTests =
         helper.AddProject(VirtualProjectProvider(buffer, fileName))
         helper.SetActiveDocument(fileName)
         let view = helper.GetView(buffer)
-        view.Caret.MoveTo(snapshotPoint view.TextSnapshot 1 17) |> ignore
         let tagger = helper.GetTagger(buffer, view)
-        testEvent tagger.TagsChanged "Timed out before tags changed" timeout
+        testEventTrigger tagger.TagsChanged "Timed out before tags changed" timeout
+            (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 1 17) |> ignore)
             (fun () -> helper.TagsOf(buffer, tagger) |> Seq.toList |> assertEqual [])
 
     [<Test; Category "AppVeyorLongRunning">]
@@ -79,9 +79,9 @@ module ResolveUnopenedNamespaceSmartTaggerTests =
         helper.AddProject(VirtualProjectProvider(buffer, fileName))
         helper.SetActiveDocument(fileName)
         let view = helper.GetView(buffer)
-        view.Caret.MoveTo(snapshotPoint view.TextSnapshot 1 1) |> ignore
         let tagger = helper.GetTagger(buffer, view)
-        testEvent tagger.TagsChanged "Timed out before tags changed" timeout
+        testEventTrigger tagger.TagsChanged "Timed out before tags changed" timeout
+            (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 1 1) |> ignore)
             (fun () -> 
                 helper.TagsOf(buffer, tagger) 
                 |> Seq.map (Seq.map (fun action -> action.DisplayText) >> Seq.toList)
@@ -98,9 +98,9 @@ TimeSpan
         helper.AddProject(VirtualProjectProvider(buffer, fileName))
         helper.SetActiveDocument(fileName)
         let view = helper.GetView(buffer)
-        view.Caret.MoveTo(snapshotPoint view.TextSnapshot 3 1) |> ignore
         let tagger = helper.GetTagger(buffer, view)
-        testEvent tagger.TagsChanged "Timed out before tags changed" timeout
+        testEventTrigger tagger.TagsChanged "Timed out before tags changed" timeout
+            (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 3 1) |> ignore)
             (fun () -> 
                 let tagToInsert =
                     helper.TagsOf(buffer, tagger)
@@ -126,9 +126,9 @@ DateTime
         helper.AddProject(VirtualProjectProvider(buffer, fileName))
         helper.SetActiveDocument(fileName)
         let view = helper.GetView(buffer)
-        view.Caret.MoveTo(snapshotPoint view.TextSnapshot 3 1) |> ignore
         let tagger = helper.GetTagger(buffer, view)
-        testEvent tagger.TagsChanged "Timed out before tags changed" timeout
+        testEventTrigger tagger.TagsChanged "Timed out before tags changed" timeout
+            (fun () ->  view.Caret.MoveTo(snapshotPoint view.TextSnapshot 3 1) |> ignore)
             (fun () -> 
                 let tagToInsert =
                     helper.TagsOf(buffer, tagger)

--- a/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
@@ -43,7 +43,6 @@ type SyntaxConstructClassifierHelper() =
         member __.Dispose() = 
             classifierProvider.Dispose()
 
-[<TestFixture>]
 module SyntaxConstructClassifierTests =
 #if APPVEYOR
     let timeout = 60000<ms>
@@ -54,10 +53,11 @@ module SyntaxConstructClassifierTests =
     let helper = new SyntaxConstructClassifierHelper()
     let fileName = getTempFileName ".fsx"
 
-    [<SetUp>]
-    let deploy() =
+    [<TestFixtureSetUp>]
+    let setUp() =
         TestUtilities.AssertListener.Initialize()
-    
+        DocumentEventListener.SkipTimerDelay <- true
+
     [<Test>]
     let ``should not return anything if the code doesn't contain semantic symbol``() = 
         let content = "let x = 0"

--- a/tests/FSharpVSPowerTools.Tests/TestHelpers.fs
+++ b/tests/FSharpVSPowerTools.Tests/TestHelpers.fs
@@ -59,15 +59,16 @@ let snapshotPoint (snapshot: ITextSnapshot) line (column: int) =
     let line = snapshot.GetLineFromLineNumber(line - 1)
     SnapshotSpan(line.Start, column).Start
 
-let testEvent event errorMessage (timeout: int<_>) predicate =
+let testEventTrigger event errorMessage (timeout: int<_>) triggerEvent predicate =
     let task =
         event
         |> Async.AwaitEvent
         |> Async.StartAsTask
     let sw = System.Diagnostics.Stopwatch()
     sw.Start()
+    triggerEvent()
     match task.Wait(TimeSpan.FromMilliseconds(float timeout)) with
-    | true -> 
+    | true ->         
         sw.Stop()
         Console.WriteLine(sprintf "Event took: %O s" (sw.ElapsedMilliseconds/1000L))
         predicate()
@@ -76,6 +77,8 @@ let testEvent event errorMessage (timeout: int<_>) predicate =
         Console.WriteLine(sprintf "Event took: %O s" (sw.ElapsedMilliseconds/1000L))
         Assert.Fail errorMessage
 
+let testEvent event errorMessage (timeout: int<_>) predicate =
+    testEventTrigger event errorMessage timeout id predicate
 
 /// Asserts that two strings are the same modulo new line format.
 let inline assertEquivString (expected: string) (actual: string) =

--- a/tests/TestUtilities/Mocks/MockMappingPoint.cs
+++ b/tests/TestUtilities/Mocks/MockMappingPoint.cs
@@ -18,9 +18,9 @@ using Microsoft.VisualStudio.Text;
 namespace TestUtilities.Mocks {
     public class MockMappingPoint : IMappingPoint {
 
-        private SnapshotPoint position;
+        private SnapshotPoint? position;
         public MockMappingPoint(SnapshotPoint _position) {
-            position = _position;
+            position = _position.Snapshot == null ? (SnapshotPoint?)null : _position;
         }
 
         public ITextBuffer AnchorBuffer {

--- a/tests/TestUtilities/Mocks/MockTextCaret.cs
+++ b/tests/TestUtilities/Mocks/MockTextCaret.cs
@@ -79,7 +79,16 @@ namespace TestUtilities.Mocks {
 
         public CaretPosition MoveTo(Microsoft.VisualStudio.Text.SnapshotPoint bufferPosition) {
             _view.Selection.Clear();
-            _position = bufferPosition;
+            if (_position != bufferPosition) {
+                var oldPosition = Position;
+                _position = bufferPosition;
+                var newPosition = Position;
+                var changed = PositionChanged;
+                if (changed != null) {
+                    changed(this, new CaretPositionChangedEventArgs(_view, oldPosition, newPosition));
+                }
+            }
+            
             return Position;
         }
 
@@ -123,12 +132,7 @@ namespace TestUtilities.Mocks {
             _position = position;
         }
 
-        public event System.EventHandler<CaretPositionChangedEventArgs> PositionChanged {
-            add {
-            }
-            remove {
-            }
-        }
+        public event System.EventHandler<CaretPositionChangedEventArgs> PositionChanged;
 
         public double Right {
             get { throw new System.NotImplementedException(); }


### PR DESCRIPTION
This should fix intermittent test failure on AppVeyor CI.
