### PR TITLE
Handle record fields while checking unused open declarations

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -460,12 +460,12 @@ type LanguageService (dirtyNotify, ?fileSystem: IFileSystem) =
                                         Some [|String.Join (".", fullNameWithoutClassName)|]
                                     else None
                                 | _ -> None
-                        // operators
+                        // Operators
                         | MemberFunctionOrValue func ->
                             match func with
                             | Constructor _ -> None
                             | _ ->
-                                // for operator ++ displayName = ( ++ ), compiledName = op_PlusPlus
+                                // For operator ++ displayName = ( ++ ), compiledName = op_PlusPlus
                                 if TypedAstUtils.isOperator func.DisplayName && func.DisplayName <> func.CompiledName then
                                     Option.attempt (fun _ -> func.EnclosingEntity)
                                     |> Option.bind (fun e -> e.TryGetFullName())
@@ -479,13 +479,14 @@ type LanguageService (dirtyNotify, ?fileSystem: IFileSystem) =
                                 |> Option.map (fun fullName ->
                                     [| fullName; fullName.Substring(0, fullName.Length - "Attribute".Length) |])
                             | e, _, _ -> 
-                                e.TryGetFullName() |> Option.map (fun x -> [| x |])
-                        | UnionCase uc ->
-                            Some [| let fullName = uc.FullName
+                                e.TryGetFullName() |> Option.map (fun fullName -> [| fullName |])
+                        | RecordField _
+                        | UnionCase _ as symbol ->
+                            Some [| let fullName = symbol.FullName
                                     yield fullName
                                     let idents = fullName.Split '.'
-                                    // Union cases can be accessible without mention the DU type. 
-                                    // So, we add a FullName with the DU type part removed.
+                                    // Union cases/Record fields can be accessible without mention the type. 
+                                    // So we add a FullName with the type part removed.
                                     if idents.Length > 1 then
                                         yield String.Join (".", Array.append idents.[0..idents.Length - 3] idents.[idents.Length - 1..])
                                  |]   

--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -142,7 +142,7 @@ module SourceCodeClassifier =
         |> Array.filter (fun symbolUse ->
             let res = 
                 match symbolUse.SymbolUse.Symbol with
-                | UnionCase _ 
+                | Pattern | RecordField _
                 | Entity (Class | (FSharpType | ValueType | FSharpModule | Array), _, _)
                 | Entity (_, _, Tuple)
                 | MemberFunctionOrValue (Constructor _ | ExtensionMember) -> true
@@ -197,8 +197,8 @@ module SourceCodeClassifier =
                 |> List.rev
                 |> List.toArray
                             
-            //debug "[SourceCodeClassifier] QualifiedSymbol: FullName = %A, Symbol end pos = (%d, %d), Res = %A" 
-            //      fullName endPos.Line endPos.Column prefix
+//            debug "[SourceCodeClassifier] QualifiedSymbol: FullName = %A, Symbol end pos = (%d, %d), Res = %A" 
+//                  fullName endPos.Line endPos.Column prefix
             Some prefix
         | _ -> None
 
@@ -319,7 +319,7 @@ module SourceCodeClassifier =
 //            debug "[SourceCodeClassifier] %s SymbolUses:" msg
 //            for sUse in symbolUses do
 //                let r = sUse.SymbolUse.RangeAlternate
-//                debug "%A (%d, %d) -- (%d, %d)" sUse.FullNames.Value r.StartLine r.StartColumn r.EndLine r.EndColumn
+//                debug "%A (%d, %d) -- (%d, %d)" sUse.FullNames r.StartLine r.StartColumn r.EndLine r.EndColumn
 //            symbolUses
 
         let symbolPrefixes: (Range.range * Idents) [] =

--- a/src/FSharpVSPowerTools.Core/TypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/TypedAstUtils.fs
@@ -178,6 +178,12 @@ let (|UnionCase|_|) (e: FSharpSymbol) =
     | :? FSharpUnionCase as uc -> Some uc
     | _ -> None
 
+let (|RecordField|_|) (e: FSharpSymbol) =
+    match e with
+    | :? FSharpField as field ->
+        if field.DeclaringEntity.IsFSharpRecord then Some field else None
+    | _ -> None
+
 let (|Interface|_|) (e: FSharpEntity) = if e.IsInterface then Some() else None
         
 let (|FSharpType|_|) (e: FSharpEntity) = 

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -146,7 +146,9 @@ let internal getLongIdents (input: ParsedInput option) : IDictionary<Range.pos, 
         | SynExpr.Tuple(es, _, _) -> List.iter walkExpr es
         | SynExpr.ArrayOrList(_, es, _) -> List.iter walkExpr es
         | SynExpr.Record(_, _, fields, _) -> 
-            fields |> List.iter (fun (_, e, _) -> e |> Option.iter walkExpr)
+            fields |> List.iter (fun ((ident, _), e, _) -> 
+                        addLongIdentWithDots ident
+                        e |> Option.iter walkExpr)
         | SynExpr.New(_, t, e, _) -> 
             walkExpr e
             walkType t

--- a/tests/FSharpVSPowerTools.Core.Tests/OpenDeclarationsGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/OpenDeclarationsGetterTests.fs
@@ -78,7 +78,7 @@ let ``OpenDecl stays used if any of its declarations is used``() =
     assertEqual [true; false] (updatedDecl.Declarations |> List.map (fun decl -> decl.IsUsed))
 
 [<Test>]
-let ``OpenDecl marks matching child decl even thoug another one is already marked as used``() =
+let ``OpenDecl marks matching child decl even though another one is already marked as used``() =
     let decl = { openDecl
                   [ { openDeclWithAutoOpens ["System.IO"] with IsUsed = true }
                     openDeclWithAutoOpens ["Top.Module"]] 

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -1327,3 +1327,13 @@ module Module =
     let _ = System.String("")
 """
     => [ 3, [Category.Unused, 9, 26]]
+
+let ``record fields should be taken into account``() = 
+    """
+module M1 =
+    type Record = { Field: int }
+module M2 =
+    open M1
+    let x = { Field = 0 }
+"""
+    => [ 5, []]


### PR DESCRIPTION
Fix #661.

Two sources of bugs:
- Record fields' symbols are excluded while checking unused open declarations.
- Record fields are excluded while collecting long identifiers from ASTs.
