### PR TITLE
Don't gray out override members

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -507,6 +507,8 @@ type LanguageService (dirtyNotify, ?fileSystem: IFileSystem) =
                         // inspecting all their inclosed entities (fields, cases and func / vals)
                         // for usefulness, which is too expensive to do. Hence we never gray them out.
                         | Entity ((Record | UnionType | Interface | FSharpModule), _, _) -> None
+                        // FCS returns inconsistent results for override members; we're going to skip these symbols.
+                        | MemberFunctionOrValue func when func.IsOverrideOrExplicitMember -> None
                         // Usage of DU case parameters does not give any meaningful feedback; we never gray them out.
                         | Parameter -> None
                         | _ ->

--- a/tests/FSharpVSPowerTools.Core.Tests/OpenDeclarationsGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/OpenDeclarationsGetterTests.fs
@@ -176,7 +176,7 @@ type OpenDecl = Parent option * Decl list
 
 let (=>) source (expected: (Line * (OpenDecl list)) list) = 
     let opts = opts source
-    let sourceLines = source.Replace("\r\n", "\n").Split([|"\n"|], System.StringSplitOptions.None)
+    let sourceLines = source.Replace("\r\n", "\n").Split('\n')
     let parseResults = languageService.ParseFileInProject(opts, fileName, source) |> Async.RunSynchronously
 
     let actualOpenDeclarations =

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -35,7 +35,7 @@ let opts source =
 let (=>) source (expected: (int * ((Category * int * int) list)) list) = 
     let opts = opts source
     
-    let sourceLines = source.Replace("\r\n", "\n").Split([|"\n"|], System.StringSplitOptions.None)
+    let sourceLines = source.Replace("\r\n", "\n").Split('\n')
 
     let lexer = 
         { new LexerBase() with
@@ -1363,3 +1363,17 @@ module Usage =
     let f (x:MyInt) = x
 """
     => [ 5, []]
+
+let ``handle override members``() = 
+    """
+type IInterface =
+    abstract Property: int
+
+type IClass() =
+    interface IInterface with
+        member __.Property = 0
+
+let f (x: IClass) = (x :> IInterface).Property
+"""
+    => [ 7, []]
+


### PR DESCRIPTION
Close #622.

FCS never returns more than one symbol for override members. We skip
these in checking unused symbols for now.
