### PR TITLE
Fix union case generation crash

### DIFF
--- a/src/FSharpVSPowerTools.Core/UnionPatternMatchCaseGenerator.fs
+++ b/src/FSharpVSPowerTools.Core/UnionPatternMatchCaseGenerator.fs
@@ -1,6 +1,5 @@
 ﻿module FSharpVSPowerTools.CodeGeneration.UnionPatternMatchCaseGenerator
 
-open System.Text.RegularExpressions
 open FSharpVSPowerTools
 open FSharpVSPowerTools.AsyncMaybe
 open FSharpVSPowerTools.CodeGeneration
@@ -386,14 +385,14 @@ let getWrittenCases (patMatchExpr: PatternMatchExpr) =
         match pat with
         | SynPat.LongIdent(LongIdentWithDots(unionCaseLongIdent, _), _, _,
                            constructorArgs, _, _) ->
-          // Get list of qualifiers, this can be checked for length later.
-          let reversedIdents =
-            unionCaseLongIdent
-            |> List.map (fun id -> id.idText)
-            |> List.rev
-          match reversedIdents with
-          | [] -> []
-          | name::quals ->
+            // Get list of qualifiers, this can be checked for length later.
+            let reversedIdents =
+                unionCaseLongIdent
+                |> List.map (fun id -> id.idText)
+                |> List.rev
+            match reversedIdents with
+            | [] -> []
+            | name::quals ->
                 getIfArgsAreFree constructorArgs (fun () ->
                     [ (name, quals |> List.rev) ]
                 )
@@ -619,12 +618,15 @@ let formatMatchExpr insertionParams (caseDefaultValue: string)
     
     // Use the shortest qualified style for further cases
     let shortestQualifier =
-        casesWritten
-        |> Seq.minBy (fun (_, lst) -> lst.Length)
-        |> snd
-        |> function
-           | [] -> None
-           | lst -> Some (String.concat "." lst)
+        if casesWritten.IsEmpty
+        then None
+        else
+            casesWritten
+            |> Seq.minBy (fun (_, lst) -> lst.Length)
+            |> snd
+            |> function
+               | [] -> None
+               | lst -> Some (String.concat "." lst)
 
     let ctxt =
         { UnionTypeName = entity.DisplayName

--- a/tests/FSharpVSPowerTools.Core.Tests/UnionPatternMatchCaseGeneratorTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/UnionPatternMatchCaseGeneratorTests.fs
@@ -18,38 +18,21 @@ module FSharpVSPowerTools.Core.Tests.UnionPatternMatchCaseGeneratorTests
 
 open NUnit.Framework
 open System
-open System.IO
-open System.Collections.Generic
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open FSharpVSPowerTools
-open FSharpVSPowerTools.AsyncMaybe
 open FSharpVSPowerTools.CodeGeneration
 open FSharpVSPowerTools.CodeGeneration.UnionPatternMatchCaseGenerator
 open FSharpVSPowerTools.Core.Tests.CodeGenerationTestInfrastructure
-open Microsoft.FSharp.Compiler.Ast
-
-let args = 
-    [|
-        "--noframework"; "--debug-"; "--optimize-"; "--tailcalls-"
-        @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\FSharp\.NETFramework\v4.0\4.3.0.0\FSharp.Core.dll"
-        @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\mscorlib.dll"
-        @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.dll"
-        @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Core.dll"
-        @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Drawing.dll"
-        @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Numerics.dll"
-        @"-r:C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Windows.Forms.dll"
-    |]
 
 let languageService = LanguageService(fun _ -> ())
 let project() =
     let fileName = @"C:\file.fs"
     let projFileName = @"C:\Project.fsproj"
-    let files = [| fileName |]
     { ProjectFileName = projFileName
       ProjectFileNames = [| fileName |]
-      ProjectOptions = args
+      ProjectOptions = LanguageServiceTestHelper.args
       ReferencedProjects = Array.empty
       IsIncompleteTypeCheckEnvironment = false
       UseScriptResolutionRules = false
@@ -62,11 +45,11 @@ let tryFindUnionDefinition codeGenService (pos: pos) (document: IDocument) =
 
 let insertCasesFromPos caretPos src =
     let document: IDocument = upcast MockDocument(src)
-    let codeGenService: ICodeGenerationService<_, _, _> = upcast CodeGenerationTestService(languageService, args)
+    let codeGenService: ICodeGenerationService<_, _, _> = upcast CodeGenerationTestService(languageService, LanguageServiceTestHelper.args)
     let unionTypeDefFromPos = tryFindUnionDefinition codeGenService caretPos document
     match unionTypeDefFromPos with
     | None -> src
-    | Some(range, matchExpr, entity, insertionParams) ->
+    | Some(_range, matchExpr, entity, insertionParams) ->
         let insertionPos = insertionParams.InsertionPos
         let insertColumn = insertionPos.Column
         let caseValue = "failwith \"\""
@@ -92,7 +75,7 @@ module ClausesAnalysisTests =
 
 
     let private tryGetWrittenCases (pos: pos) (src: string) =
-        let codeGenService: ICodeGenerationService<_, _, _> = upcast CodeGenerationTestService(LanguageService(fun _ -> ()), args)
+        let codeGenService: ICodeGenerationService<_, _, _> = upcast CodeGenerationTestService(LanguageService(fun _ -> ()), LanguageServiceTestHelper.args)
         src
         |> asDocument
         |> tryFindPatternMatchExpr codeGenService pos
@@ -322,6 +305,52 @@ let f union =
     | Case1 -> ()
     | Case1 when 1 = 2 -> ()
     | Case2 -> failwith ""
+"""
+
+[<Test>]
+let ``union match case generation with single case + nested constant binding`` () =
+    """
+type Name = { First:string; Last:string }
+type Person = 
+    | Basic of Name * int
+
+let f1 x =
+    match x with
+    | Basic({First = "joe"}, _) -> ()
+"""
+    |> insertCasesFromPos (Pos.fromZ 7 6)
+    |> assertSrcAreEqual """
+type Name = { First:string; Last:string }
+type Person = 
+    | Basic of Name * int
+
+let f1 x =
+    match x with
+    | Basic({First = "joe"}, _) -> ()
+    | Basic(_, _) -> failwith ""
+"""
+
+[<Test>]
+let ``union match case generation with single case + guard`` () =
+    """
+type Name = { First:string; Last:string }
+type Person = 
+    | Basic of Name * int
+
+let f1 x = 
+    match x with
+    | Basic(name, age) when age > 10 -> ()
+"""
+    |> insertCasesFromPos (Pos.fromZ 7 6)
+    |> assertSrcAreEqual """
+type Name = { First:string; Last:string }
+type Person = 
+    | Basic of Name * int
+
+let f1 x = 
+    match x with
+    | Basic(name, age) when age > 10 -> ()
+    | Basic(_, _) -> failwith ""
 """
 
 [<Test>]


### PR DESCRIPTION
When only one single case is written and it is not "pure": some inner
arguments in the pattern match case are bound to constants or there are
guards associated with the case...
Some sequence was empty while it was assumed to be non-empty

Fixes #700 
