### PR TITLE
Keep member operators in their compiled forms

### DIFF
--- a/src/FSharpVSPowerTools.Core/SignatureGenerator.fs
+++ b/src/FSharpVSPowerTools.Core/SignatureGenerator.fs
@@ -687,7 +687,8 @@ and internal writeMember ctx (mem: FSharpMemberFunctionOrValue) =
         ctx.Writer.WriteLine("{0} {1}{2} : {3}{4}{5}",
                              memberType,
                              inlineAnnotation,
-                             formatValueOrMemberName mem.LogicalName,
+                             // We don't need to demangle operator names since member operators should appear in their compiled forms
+                             QuoteIdentifierIfNeeded mem.LogicalName,
                              generateSignature ctx mem,
                              propertyType,
                              constraints)

--- a/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.fs
@@ -1210,6 +1210,13 @@ let ``type abbreviations for basic types`` () =
 type ResizeArray<'T> = System.Collections.Generic.List<'T>
 """
 
+[<Test>]
+let ``handle operators as compiled members`` () =
+    """let x: System.DateTime = failwith "" """
+    |> generateDefinitionFromPos (Pos.fromZ 0 20)
+    |> fun str -> str.Contains("static member op_GreaterThanOrEqual : t1:System.DateTime * t2:System.DateTime -> bool")
+    |> assertEqual true
+
 let generateFileNameForSymbol caretPos src =
     let document: IDocument = upcast MockDocument(src)
     let codeGenService: ICodeGenerationService<_, _, _> = upcast CodeGenerationTestService(languageService, LanguageServiceTestHelper.args)


### PR DESCRIPTION
Fix #731.
