### PR TITLE
Do not escape active pattern names

### DIFF
--- a/src/FSharpVSPowerTools.Core/SignatureGenerator.fs
+++ b/src/FSharpVSPowerTools.Core/SignatureGenerator.fs
@@ -666,7 +666,10 @@ and internal writeFunctionOrValue ctx (value: FSharpMemberFunctionOrValue) =
     writeDocs ctx value.XmlDoc (fun _ -> value.XmlDocSig)
 
     let constraints = getConstraints ctx value.GenericParameters
-    let valueName = if value.IsActivePattern then value.LogicalName else formatValueOrMemberName value.LogicalName
+    let valueName = 
+        if value.IsActivePattern then 
+            sprintf "(%s)" value.LogicalName 
+        else formatValueOrMemberName value.LogicalName
 
     if value.FullType.IsFunctionType then
         let inlineSpecifier = if needsInlineAnnotation value then "inline " else ""
@@ -743,11 +746,12 @@ and internal writeDocs ctx docs getXmlDocSig =
 and internal writeActivePattern ctx (case: FSharpActivePatternCase) =
     let group = case.Group
     writeDocs ctx case.XmlDoc (fun _ -> case.XmlDocSig)
-    ctx.Writer.Write("val |")
+    ctx.Writer.Write("val (|")
     for name in group.Names do
         ctx.Writer.Write("{0}|", name)
     if not group.IsTotal then
         ctx.Writer.Write("_|")
+    ctx.Writer.Write(")")
     ctx.Writer.Write(" : ")
     ctx.Writer.WriteLine("{0}", formatType ctx group.OverallType)
 

--- a/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.fs
@@ -347,7 +347,7 @@ let testNumber i =
     | Even -> printfn "%d is even" i
     | Odd -> printfn "%d is odd" i"""
     |> generateDefinitionFromPos (Pos.fromZ 6 7)
-    |> assertSrcAreEqual """val |Even|Odd| : int -> Choice<unit,unit>
+    |> assertSrcAreEqual """val (|Even|Odd|) : int -> Choice<unit,unit>
 """
 
 [<Test; Ignore("activate when it's possible to know in which module or namespace an active pattern is defined")>]
@@ -363,7 +363,7 @@ let testNumber i =
     |> generateDefinitionFromPos (Pos.fromZ 6 7)
     |> assertSrcAreEqual """module File
 
-val |Even|Odd| : int -> Choice<unit,unit>
+val (|Even|Odd|) : int -> Choice<unit,unit>
 """
 
 [<Test>]
@@ -378,7 +378,7 @@ let fizzBuzz = function
     | DivisibleBy 5 -> "Buzz" 
     | _ -> "" """
     |> generateDefinitionFromPos (Pos.fromZ 5 7)
-    |> assertSrcAreEqual """val |DivisibleBy|_| : int -> int -> unit option
+    |> assertSrcAreEqual """val (|DivisibleBy|_|) : int -> int -> unit option
 """
 
 [<Test; Ignore("We should not generate implicit interface member definition")>]
@@ -1465,7 +1465,7 @@ let ``handle active patterns as parts of module declarations`` () =
     """open Microsoft.FSharp.Quotations
 let f = Patterns.(|AddressOf|_|)"""
     |> generateDefinitionFromPos (Pos.fromZ 1 13)
-    |> fun str -> str.Contains("val |AddressSet|_| : input:Expr -> (Expr * Expr) option")
+    |> fun str -> str.Contains("val (|AddressSet|_|) : input:Expr -> (Expr * Expr) option")
     |> assertEqual true
 
 let generateFileNameForSymbol caretPos src =


### PR DESCRIPTION
Fix #740.
