### PR TITLE
Display cleanup instructions in case of severe errors

### DIFF
--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -153,9 +153,9 @@ type GoToDefinitionFilter(view: IWpfTextView, vsLanguageService: VSLanguageServi
                         // Try to set buffer to read-only mode
                         vsTextBuffer.SetStateFlags(currentFlags ||| uint32 BUFFERSTATEFLAGS.BSF_USER_READONLY) |> ignore
                     | _ -> ()
-                    statusBar.SetText("Generated symbol metadata") |> ignore  
+                    statusBar.SetText(Resource.goToDefinitionStatusMessage) |> ignore  
             | None ->
-                statusBar.SetText("Can't generate metadata for this symbol.") |> ignore  
+                statusBar.SetText(Resource.goToDefinitionInvalidSymbolMessage) |> ignore  
 
     member val IsAdded = false with get, set
     member val NextTarget: IOleCommandTarget = null with get, set

--- a/src/FSharpVSPowerTools.Logic/Resource.fs
+++ b/src/FSharpVSPowerTools.Logic/Resource.fs
@@ -44,3 +44,14 @@ module Resource =
     let [<Literal>] implementInterfaceCommandName = "Explicitly implement interface"
     let [<Literal>] recordGenerationCommandName = "Generate record stubs"
     let [<Literal>] unionPatternMatchCaseCommandName = "Generate union pattern match cases"
+
+    let [<Literal>] goToDefinitionStatusMessage = "Generated symbol metadata"
+    let [<Literal>] goToDefinitionInvalidSymbolMessage = "Can't generate metadata for this symbol."
+
+    let [<Literal>] languageServiceErrorMessage = """
+Internal language services have encountered some severe errors.
+Syntax coloring or other features may stop working.
+
+If you experience such issues, they could be fixed as follows: (1) Clean current solution (2) Restart Visual Studio (3) Rebuild the solution.
+We're sorry for any convenience caused.
+"""


### PR DESCRIPTION
Related to #711.

The previous automatic cleanup doesn't work. Here we only suggest users to manually cleanup by displaying an error message box with instructions. To be not too annoying, this message box is displayed only once. We display these instructions in the status bar in every occurrence.

Perhaps we settle for this before finding a better way.
