### PR TITLE
Amend project load time for each ProjectProvider instance

### DIFF
--- a/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
@@ -112,7 +112,7 @@ type ProjectFactory
 
     default x.CreateForProject (project: Project): IProjectProvider = 
         cache.Get project.FullName (fun _ ->
-            new ProjectProvider (project, x.CreateForProject, onProjectChanged)) :> _
+            new ProjectProvider (project, x.CreateForProject, onProjectChanged, vsLanguageService.FixProjectLoadTime)) :> _
 
     member x.CreateForFileInProject (buffer: ITextBuffer) (filePath: string) project: IProjectProvider option =
         if not (project === null) && not (filePath === null) && isFSharpProject project then
@@ -169,7 +169,7 @@ type ProjectFactory
         if isPrivateToFile then 
             Some SymbolDeclarationLocation.File 
         else 
-            match symbol.TryGetLocation() with
+            match Option.orElse symbol.ImplementationLocation symbol.DeclarationLocation with
             | Some loc ->
                 let filePath = Path.GetFullPathSafe loc.FileName
                 if currentProject.IsForStandaloneScript && filePath = currentFile then 


### PR DESCRIPTION
Close #596.

Before https://github.com/vasily-kirichenko/FSharpVSPowerTools/commit/86e10470432da11d55117bec7be8cee9322dfded, we amended project load time upon any text change. Find All References were slow but there was no weird issue with FCS exceptions.

Now I recover that part but fixing project load time only occurs when `ProjectProvider` instances are created. It means that we may unload projects from FCS caches whenever there are files added to or removed from projects, etc. 

I hope this makes intermittent failures less likely to happen and we still return answers fast enough in most use cases.
