### PR TITLE
Fixed comments with text between comment marker and task marker

### DIFF
--- a/src/FSharpVSPowerTools.Core/TaskListCommentExtractor.fs
+++ b/src/FSharpVSPowerTools.Core/TaskListCommentExtractor.fs
@@ -46,30 +46,36 @@ module private Utils =
             else lines.[lineNumber + 1]
         sourceTok.CreateLineTokenizer(nextLine)
 
-    let trimChars = [| ' '; '\t'; '/'; '*' |]
+    let trimChars = [| ' '; '\t'; '/'; '('; ')'; '*' |]
     let isFirstToken (tokenText: string) =
         tokenText.TrimStart(trimChars) <> String.Empty
 
-    let tokenizeFirstToken (tokText: string) =
-        let rec tokenize (tokenizer: LineTokenizer) state =
+    let tryTokenizeFirstToken (tokText: string) =
+        let rec tryTokenize (tokenizer: LineTokenizer) state =
             match tokenizer.ScanToken(state) with
-            | Some tok, state when not <| isFirstToken (tok.Text([| tokText |], 0)) -> tokenize tokenizer state
-            | Some tok, _ -> (tok, tokText.Substring(tok.LeftColumn, tok.FullMatchedLength))
-            | None, _ -> (Unchecked.defaultof<_>, String.Empty)
+            | Some tok, state when not <| isFirstToken (tok.Text([| tokText |], 0)) -> tryTokenize tokenizer state
+            | Some tok, _ -> Some (tok, tokText.Substring(tok.LeftColumn, tok.FullMatchedLength))
+            | None, _ -> None
         let tokenizer = sourceTok.CreateLineTokenizer(tokText)
-        tokenize tokenizer 0L
+        tryTokenize tokenizer 0L
 
-    let rec tryFindLineCommentTaskToken tasks (lines: string[], lineNumber: int, tokenizer: LineTokenizer, state) =
-        match tokenizer.ScanToken(state) with
-        | Some tok, state ->
-            let tokText = tok.Text(lines, lineNumber).ToLowerInvariant()
-            let tok2, tokenizedText = tokenizeFirstToken tokText
-            if isFirstToken tokenizedText && tasks |> Array.exists ((=) tokenizedText) then
-                let pos = { Line = lineNumber; Column = tok.LeftColumn + tok2.LeftColumn }
-                (Some (tokenizedText, pos), state)
-            else
-                tryFindLineCommentTaskToken tasks (lines, lineNumber, tokenizer, state)
-        | _ -> None, state
+    let tryFindLineCommentTaskToken tasks (lines: string[], lineNumber: int, tokenizer: LineTokenizer, state) =
+        let rec tryFindLineCommentTaskToken' state =
+            match tokenizer.ScanToken(state) with
+            | Some tok, state ->
+                let tokText = tok.Text(lines, lineNumber).ToLowerInvariant()
+                match tryTokenizeFirstToken tokText with
+                | Some (tok2, tokenizedText) ->
+                    if isFirstToken tokenizedText && tasks |> Array.exists ((=) tokenizedText) then
+                        let pos = { Line = lineNumber; Column = tok.LeftColumn + tok2.LeftColumn }
+                        (Some (tokenizedText, pos), state)
+                    elif tok2.CharClass = TokenCharKind.Identifier then
+                        None, state
+                    else
+                        tryFindLineCommentTaskToken' state
+                | None -> tryFindLineCommentTaskToken' state
+            | _ -> None, state
+        tryFindLineCommentTaskToken' state |> fst
 
     let rec tryFindMultilineCommentTaskToken tasks (lines: string[], lineNumber: int, tokenizer: LineTokenizer, state) =
         let rec scanMultilineComments (tokenizer: LineTokenizer) acc state nestLevel lineNumber =
@@ -89,7 +95,7 @@ module private Utils =
                     (lineNumber, acc, tokenizer, state)
                 else
                     let tokenizer = sourceTok.CreateLineTokenizer(lines.[lineNumber + 1])
-                    scanMultilineComments tokenizer acc state nestLevel (lineNumber + 1)
+                    (lineNumber + 1, acc, tokenizer, state)
 
         let nextLineNumber, lineNumAndTokens, tokenizer, state = scanMultilineComments tokenizer [] state 0 lineNumber
         match lineNumAndTokens |> List.rev |> List.tryFind (fun (ln, tok) -> isFirstToken (tok.Text(lines, ln))) with
@@ -110,13 +116,13 @@ module private Utils =
             match tok.CharClass with
             | TokenCharKind.LineComment ->
                 let tokText = tok.Text(lines, lineNumber)
-                if tokText |> String.forall (function '/' | '*' | ' ' | '\t' -> true | _ -> false) then
+                if tokText |> String.forall (function '/' | '(' | ')' | '*' | ' ' | '\t' -> true | _ -> false) then
                     match tryFindLineCommentTaskToken tasks (lines, lineNumber, tokenizer, state) with
-                    | Some (task, pos), _ ->
+                    | Some (task, pos) ->
                         let pos = OnelineTaskListCommentPos (task, pos)
                         Some (pos, (lines, lineNumber + 1, createNewLineTokenizer lines lineNumber, firstState))
-                    | None, state ->
-                        nextTaskListCommentPos tasks (lines, lineNumber, tokenizer, state)
+                    | None ->
+                        nextTaskListCommentPos tasks (lines, lineNumber + 1, createNewLineTokenizer lines lineNumber, firstState)
                 else
                     let tokenizer = createNewLineTokenizer lines lineNumber
                     nextTaskListCommentPos tasks (lines, lineNumber + 1, tokenizer, firstState)
@@ -183,4 +189,3 @@ module CommentExtractor =
         fileLines
         |> collectTaskListComments options filePath
         |> Seq.toArray
-            

--- a/tests/FSharpVSPowerTools.Core.Tests/TaskListCommentExtractorTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/TaskListCommentExtractorTests.fs
@@ -52,9 +52,20 @@ let ``should match nested comments``() =
     => [| (2, "TODO (* (* nested *) nested *) nested", "File1.fs", 0, 3); (2, "TODO something // TODO nested", "File1.fs", 1, 3) |]
 
 [<Test>]
-let ``line comments only allow asterisk, slash, or whitespace between // and token``() = 
-    (defaultOptions, "File1.fs", [| "//*/  /* TODO stuff"; "//+ TODO something else"; "// *TODO other" |])
-    => [| (2, "TODO stuff", "File1.fs", 0, 9); (2, "TODO other", "File1.fs", 2, 4) |]
+let ``line comments only allow asterisk, slash, parenthesis, or whitespace between // and token``() = 
+    (defaultOptions, "File1.fs", [| "//*) // (* TODO stuff"
+                                    "//+ TODO something else"
+                                    "// *TODO other"
+                                    "// another TODO xxx" |])
+    => [| (2, "TODO stuff", "File1.fs", 0, 11); (2, "TODO other", "File1.fs", 2, 4) |]
+
+[<Test>]
+let ``multiline comments only allow asterisk, slash, parenthesis, or whitespace between line head and first other token``() =
+    (defaultOptions, "File1.fs", [| "(*(* // *) TODO stuff*)"
+                                    "(*+ TODO something else *)"
+                                    "(* *TODO other *)"
+                                    "(* another TODO xxx *)" |])
+    => [| (2, "TODO stuff", "File1.fs", 0, 11); (2, "TODO other", "File1.fs", 2, 4) |]
 
 [<Test>]
 let ``tokens can only be immediately followed by chars other than space that aren't alphanumeric or underscore``() = 


### PR DESCRIPTION
Comments like `// text TODO stuff` were treated as task list comments but they shouldn't be
