### PR TITLE
Minor correction on syntax coloring

### DIFF
--- a/src/FSharpVSPowerTools.Logic/UnusedDeclarationMargin.fs
+++ b/src/FSharpVSPowerTools.Logic/UnusedDeclarationMargin.fs
@@ -66,11 +66,9 @@ type UnusedDeclarationMargin(textView: IWpfTextView, marginContainer: IWpfTextVi
             true
         
         member x.GetTextViewMargin(marginName: string): ITextViewMargin = 
-            match marginName with
-            | Constants.fsharpUnusedDeclarationMargin -> 
+            if marginName = Constants.fsharpUnusedDeclarationMargin then
                 x :> _
-             | _ -> 
-                null
+            else null
         
         member x.MarginSize: float = 
             x.ActualHeight


### PR DESCRIPTION
The semantics were changed a bit in https://github.com/fsprojects/VisualFSharpPowerTools/commit/30a73458fd890e20ca17f84097abf6c38a957eaa. The correction is that we construct the span on the old snapshot and translate it to a span on the new snapshot.
