### PR TITLE
Classification tags should not be visible on top of breakpoint tags

### DIFF
--- a/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
@@ -225,7 +225,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpReferenceType)]
         [Name(ClassificationTypes.FSharpReferenceType)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpReferenceTypeFormat : ClassificationFormatDefinition
         {
             [ImportingConstructor]
@@ -242,7 +242,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpValueType)]
         [Name(ClassificationTypes.FSharpValueType)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpValueTypeFormat : ClassificationFormatDefinition
         {
             [ImportingConstructor]
@@ -259,7 +259,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpPatternCase)]
         [Name(ClassificationTypes.FSharpPatternCase)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpPatternCaseFormat : ClassificationFormatDefinition
         {
             [ImportingConstructor]
@@ -276,7 +276,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpFunction)]
         [Name(ClassificationTypes.FSharpFunction)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpFunctionFormat : ClassificationFormatDefinition
         {
             [ImportingConstructor]
@@ -293,7 +293,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpMutableVar)]
         [Name(ClassificationTypes.FSharpMutableVar)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpMutableVarFormat : ClassificationFormatDefinition
         {
             [ImportingConstructor]
@@ -310,7 +310,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpQuotation)]
         [Name(ClassificationTypes.FSharpQuotation)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpQuotationFormat : ClassificationFormatDefinition
         {
             [ImportingConstructor]
@@ -328,7 +328,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpModule)]
         [Name(ClassificationTypes.FSharpModule)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpModuleFormat : ClassificationFormatDefinition
         {
             [ImportingConstructor]
@@ -345,7 +345,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpUnused)]
         [Name(ClassificationTypes.FSharpUnused)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpUnusedFormat : ClassificationFormatDefinition
         {
             [ImportingConstructor]
@@ -362,7 +362,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpPrintf)]
         [Name(ClassificationTypes.FSharpPrintf)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpPrintfFormat : ClassificationFormatDefinition
         {
              [ImportingConstructor]
@@ -379,7 +379,7 @@ namespace FSharpVSPowerTools
         [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpEscaped)]
         [Name(ClassificationTypes.FSharpEscaped)]
         [UserVisible(true)]
-        [Order(After = Priority.Default, Before = Priority.High)]
+        [Order(Before = Priority.Default)]
         internal sealed class FSharpEscapedFormat : ClassificationFormatDefinition
         {
              [ImportingConstructor]
@@ -411,7 +411,7 @@ namespace FSharpVSPowerTools
         [Import]
         internal ProjectFactory projectFactory = null;
 
-        private readonly Type serviceType = typeof(SyntaxConstructClassifier);
+        private static readonly Type serviceType = typeof(SyntaxConstructClassifier);
 
         private readonly IServiceProvider serviceProvider = null;
         private readonly ClassificationColorManager classificationColorManager = null;


### PR DESCRIPTION
Fix #859.

The question now is: will this change the ordering of format specifier tags vs. string tags?
