### PR TITLE
Comment Outlining

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -690,6 +690,18 @@
       </ItemGroup>
     </Otherwise>
   </Choose>
+  <PropertyGroup>
+    <ReferencePath>$(ReferencePath);$(MSBuildThisFileDirectory)..\..\lib\vs2012</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildThisFileDirectory)</SolutionDir>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <Import Project="$(SolutionDir)\.paket\paket.targets" />
   <ItemGroup>
     <None Include="paket.references" />
     <Compile Include="AssemblyInfo.fs">
@@ -843,12 +855,22 @@
     <Compile Include="TaskListCommentFilter.fs">
       <Link>TaskList/TaskListCommentFilter.fs</Link>
     </Compile>
+    <Compile Include="Outlining\OutliningParsers.fs" />
     <Compile Include="Outlining\CommentOutlining.fs" />
+    <Content Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     </Reference>
     <Reference Include="EnvDTE80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <Reference Include="FParsec">
+      <HintPath>..\..\packages\FParsec.1.0.1\lib\net40-client\FParsec.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FParsecCS">
+      <HintPath>..\..\packages\FParsec.1.0.1\lib\net40-client\FParsecCS.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
@@ -914,24 +936,10 @@
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     </Reference>
     <Reference Include="mscorlib" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\FSharpVSPowerTools.Core\FSharpVSPowerTools.Core.fsproj">
       <Name>FSharpVSPowerTools.Core</Name>
       <Project>{f3d0b372-3af7-49d9-98ed-5a78e9416098}</Project>
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup>
-    <ReferencePath>$(ReferencePath);$(MSBuildThisFileDirectory)..\..\lib\vs2012</ReferencePath>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildThisFileDirectory)</SolutionDir>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Import Project="$(SolutionDir)\.paket\paket.targets" />
 </Project>

--- a/src/FSharpVSPowerTools.Logic/Outlining/CommentOutlining.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/CommentOutlining.fs
@@ -1,154 +1,79 @@
 ﻿namespace FSharpVSPowerTools.Outlining
 
+open FSharpVSPowerTools.Outlining.Parsers
 open Microsoft.VisualStudio.Text
 open Microsoft.VisualStudio.Text.Tagging
 open Microsoft.VisualStudio.Utilities
 open System
-open System.Collections.Generic
 open System.ComponentModel.Composition
 open System.Linq
+open System.Text
 
 module Comments = 
-    /// <summary>
-    /// Holds the data that will be used to construct the IOutliningRegionTag
-    /// </summary>
+    let encompassedBy (rg : Region) (encomp : Region) = rg.StartLine > encomp.StartLine && rg.EndLine < encomp.EndLine
+    
     [<Struct>]
-    type Region (startline: int, endline:int, collapsed:string, contents:string) = 
-        /// Line number of the first line in the region
-        member __.StartLine = startline
-        /// Line number of the last line in the region
-        member __.EndLine = endline
-        /// The text displayed inline when a region is collapsed
-        member __.Collapsed = collapsed
-        /// The text displayed in the tooltip when a collapsed region is moused over
-        member __.Contents = contents
-
-        override x.ToString() = sprintf "[Region {ln %d - ln %d}]" x.StartLine x.EndLine
+    type private ParsedRegions = 
+        val DocBlocks : Region list
+        val ComBlocks : Region list
+        val StarBlocks : Region list
+        new(docBlocks, comBlocks, starBlocks) = 
+            { DocBlocks = docBlocks
+              ComBlocks = comBlocks
+              StarBlocks = starBlocks }
     
-    /// Check if the given string matches the start of the ITextSnapshotLine's trimmed text 
-    let private lineMatch (line : ITextSnapshotLine) start : bool = line.GetText().TrimStart().StartsWith(start)
+    let snapshotText (lines : seq<ITextSnapshotLine>) = 
+        let folder (sb : StringBuilder) (ln : ITextSnapshotLine) = sb.Append(ln.GetText() + "\n")
+        let sb = lines |> Seq.fold folder (StringBuilder())
+        sb.ToString()
     
-    /// Uses the functions matchToken and notMatchToken to determine which
-    /// lines will be collected into region blocks
-    let private takeBlocksOf (lines : seq<ITextSnapshotLine>) (matchToken : ITextSnapshotLine -> bool) 
-        (notMatchToken : ITextSnapshotLine -> bool) = 
-        let rec loop (lines : seq<ITextSnapshotLine>) = 
-            seq {   if lines.Count() = 0 then () else
-                    /// List of consequtive ITextSnapshotLines that begin with a token
-                    let block = lines |> Seq.skipWhile notMatchToken // skip lines that satisfy notMatchToken
-                                      |> Seq.takeWhile matchToken    // take all consequtive lines that satisfy matchToken
-                    /// sequence of elements in 'lines' following the block
-                    let rest  = lines |> Seq.skipWhile notMatchToken
-                                      |> Seq.skip (Seq.length block)
-                    yield  block
-                    yield! loop rest
-                }
-        loop lines |> Seq.map (List.ofSeq) |> List.ofSeq
-    
-    /// Token that indicates the start of a documentation comment line ' /// '
-    let private doccom = "///"
-    
-    /// Token that indicates the start of a single line comment ' // '
-    let private comment = "//"
-    
-    let private matchDoccom ln = lineMatch ln doccom
-    let private matchComment ln = lineMatch ln comment && (matchDoccom >> not) ln
-    let private notMatchComment ln = (not <| lineMatch ln comment) || matchDoccom ln
-    let private doccomBlocks lines = takeBlocksOf lines matchDoccom (matchDoccom >> not) 
-    let private commentBlocks lines = takeBlocksOf lines matchComment notMatchComment
-    let private trimLineStart (ln : ITextSnapshotLine) = ln.GetText().TrimStart([| ' ' |])
-    
-    let private removeToken (str : string) (token : string) = 
-        let idx = str.IndexOf(token)
-        str.Remove(idx, token.Length)
-    
-    let private removeDoccom str = removeToken str doccom
-    let private removeComment str = removeToken str comment
-    let private filterWhitespace (ln : ITextSnapshotLine) = 
-        String(ln.GetText().ToCharArray() |> Array.filter (fun ch -> ch <> ' '))
-    
-    /// <summary>
-    /// <para> Construct a string that will be displayed when the mouse is over the region's collapse string </para>
-    /// <para> 'removeFunc' is used cut the comment tokens out of the tooltip string </para>
-    /// </summary>
-    let private getTooltipOf (lines : ITextSnapshotLine list) (removeFunc : string -> string) = 
-        match lines with
-        | [] -> ""
-        | lns -> lns |> List.map (trimLineStart >> removeFunc)
-                     |> String.concat "\n"
-    
-    let private getDoccomTooltip lines = getTooltipOf lines removeDoccom
-    let private getCommentTooltip lines = getTooltipOf lines removeComment
-    let private summary = "<summary>"
-    let private ellipsis = "..."
-    
-    /// Given a list of lines that comprise a documentation comment region, determine 
-    /// the string to display when the region is collapsed
-    let private getDoccomCollapsed (lines : ITextSnapshotLine list) : string = 
-        if lines = [] then ellipsis else
-        let fstLineText = lines.[0].GetText()
-        match lines.[0] |> filterWhitespace |> removeDoccom with
-        // if the filtered first line is shorter than summary, use that line
-        | ffln when ffln.Length < summary.Length -> fstLineText + ellipsis
-        // if the first line of the doc comment is only "<summary>", take the next line
-        | ffln when ffln = summary &&
-            lines.Length > 1 -> (lines.[1].GetText()) + ellipsis
-        // if the description follows the <summary> tag on the same line drop the tag and take the rest
-        | ffln when ffln.[0..summary.Length - 1] = summary -> 
-            let sumStart = fstLineText.IndexOf(summary) + summary.Length
-            /// whitespace preceeding the doccom token
-            //let indent = fstLineText.Substring(0, fstLineText.IndexOf(doccom) + doccom.Length)
-            let indent = fstLineText.[0..fstLineText.IndexOf(doccom) + doccom.Length]
-            indent + fstLineText.[sumStart..fstLineText.Length - sumStart] + ellipsis
-        // if xml tags aren't used, take the first line of the doc comment
-        | _ -> fstLineText + ellipsis
-    
-    /// Given a list of lines that comprise a comment region, determine the string to display when the
-    /// region is collapsed
-    let private getCommentCollapsed (lines : ITextSnapshotLine list) : string = 
-        match lines with 
-        | [] -> ellipsis
-        | _ -> lines.[0].GetText() + ellipsis
-    
-    /// <summary>
-    /// <para> Takes an ITextSnapshotline list list, where each inner list comprises the scope of a region and  </para>
-    /// <para> constructs a Region using the linenumber of the first and last line of the inner list            </para>
-    /// </summary>
-    let inline private parseRegionsOf (regionls : ITextSnapshotLine list list) 
-               (getCollapsed : ITextSnapshotLine list -> string) (getTooltip : ITextSnapshotLine list -> string) : Region list = 
-        let build (ls : ITextSnapshotLine list) = 
-            match ls with
-            | [] -> None
-            | _  -> let fstline = ls.[0].LineNumber
-                    let lstline = ls.[ls.Length - 1].LineNumber
-                    if fstline = lstline then None else 
-                    let collapsed = getCollapsed ls
-                    let contents = getTooltip ls
-                    Some <| Region(fstline, lstline, collapsed, contents)
-        regionls
-        |> List.map build
-        |> List.choose id
-    
-    let private buildDoccomRegions ls = (doccomBlocks ls |> parseRegionsOf) getDoccomCollapsed getDoccomTooltip
-    let private buildCommentRegions ls = (commentBlocks ls |> parseRegionsOf) getCommentCollapsed getCommentTooltip
+    let private constructAllRegions fileText = 
+        let findInText psr = findInString fileText psr |> List.choose id
+        let docCandidates = findInText docBlock
+        let comCandidates = findInText comBlock
+        let starCandidates = findInText starBlock
+        let triStrings = findInText skipTriString
+        let multiStrings = findInText skipMultiString
+        let folder (rg : Region) (isEncompassed : bool) (encomp : Region) = isEncompassed || encompassedBy rg encomp
+        let inline regionFilter (filterls : Region list) (rgls : Region list) = 
+            rgls |> List.filter (fun rg -> not <| List.fold (folder rg) false filterls)
+        let doubleFilter = regionFilter triStrings >> regionFilter multiStrings
+        let starBlocksFinal = doubleFilter starCandidates
+        let tripleFilter = doubleFilter >> regionFilter starBlocksFinal
+        let docBlocksFinal = tripleFilter docCandidates
+        let comBlocksFinal = tripleFilter comCandidates
+        ParsedRegions(docBlocksFinal, comBlocksFinal, starBlocksFinal)
     
     let private asSnapshotSpan (region : Region) (snapshot : ITextSnapshot) = 
-        let startLine = snapshot.GetLineFromLineNumber(region.StartLine)
-        
-        let endLine = 
-            if region.StartLine = region.EndLine then startLine
-            else snapshot.GetLineFromLineNumber(region.EndLine)
-        SnapshotSpan(startLine.Start, endLine.End)
+        if region.StartLine > snapshot.Length || region.EndLine > snapshot.Length then None
+        else 
+            let startLine = snapshot.GetLineFromLineNumber(region.StartLine)
+            
+            let endLine = 
+                if region.StartLine = region.EndLine then startLine
+                else snapshot.GetLineFromLineNumber(region.EndLine)
+            Some <| SnapshotSpan(startLine.End - region.StartOffset, 
+                                 if region.EndOffset = -1 then endLine.End
+                                 else endLine.Start + region.EndOffset)
     
-    let private parse (buffer : ITextBuffer) (oldSnapshot : ITextSnapshot) (oldRegions : Region list) 
+    let private parse (newSnapshot : ITextSnapshot) (oldSnapshot : ITextSnapshot) (oldRegions : Region list) 
         (newRegions : Region list) = 
-        let newSnapshot = buffer.CurrentSnapshot
         let oldSpans : Span list = 
-            oldRegions 
-            |> List.map 
-                   (fun r -> 
-                   (asSnapshotSpan r oldSnapshot).TranslateTo(newSnapshot, SpanTrackingMode.EdgeExclusive).Span)
-        let newSpans : Span list = newRegions |> List.map (fun r -> (asSnapshotSpan r newSnapshot).Span)
+            oldRegions
+            |> List.map (fun r -> 
+                   let rs = (asSnapshotSpan r oldSnapshot)
+                   if rs.IsSome then Some <| rs.Value.TranslateTo(newSnapshot, SpanTrackingMode.EdgeExclusive).Span
+                   else None)
+            |> List.choose id
+        
+        let newSpans : Span list = 
+            newRegions
+            |> List.map (fun r -> 
+                   let rs = (asSnapshotSpan r newSnapshot)
+                   if rs.IsNone then None
+                   else Some rs.Value.Span)
+            |> List.choose id
+        
         let oldSpanCollection = NormalizedSpanCollection oldSpans
         let newSpanCollection = NormalizedSpanCollection newSpans
         let removed = NormalizedSpanCollection.Difference(oldSpanCollection, newSpanCollection)
@@ -171,16 +96,14 @@ module Comments =
         
         let eventSpan : SnapshotSpan option = 
             if changeStart' > changeEnd' then None
-            else Some <| SnapshotSpan(oldSnapshot, Span.FromBounds(changeStart', changeEnd'))
+            else Some <| SnapshotSpan(newSnapshot, Span.FromBounds(changeStart', changeEnd'))
         
         (newSnapshot, eventSpan)
     
     let private generateTags (spans : NormalizedSnapshotSpanCollection) (currentSnapshot : ITextSnapshot) 
-        (currentRegions : Region list) : IEnumerable<ITagSpan<IOutliningRegionTag>> = 
-        seq { // If there are no spans yield an empty ITagSpan
-            if spans.Count = 0 then 
-                yield TagSpan(SnapshotSpan(), OutliningRegionTag() :> IOutliningRegionTag) :> ITagSpan<IOutliningRegionTag>
-            /// SnapshotSpan for the entire textbuffer
+        (currentRegions : Region list) : seq<ITagSpan<IOutliningRegionTag>> = 
+        if spans.Count = 0 then [] :> seq<_>
+        else 
             let snapEntire = 
                 SnapshotSpan(spans.[0].Start, spans.[spans.Count - 1].End)
                     .TranslateTo(currentSnapshot, SpanTrackingMode.EdgeExclusive)
@@ -191,30 +114,37 @@ module Comments =
             /// EndLineNumber for the entire textbuffer
             let endLineNum = snapEntire.End.GetContainingLine().LineNumber
             
-            // Yield a TagSpan for every region that was parsed
-            for rg in currentRegions do
-                if rg.StartLine <= endLineNum && rg.EndLine >= startLineNum then 
+            let rec loop (acc : ITagSpan<IOutliningRegionTag> list) (currgs : Region list) = 
+                match currgs with
+                | rg :: tl when rg.StartLine <= endLineNum && rg.EndLine >= startLineNum -> 
                     let startLine = currentSnapshot.GetLineFromLineNumber(rg.StartLine)
                     let endLine = currentSnapshot.GetLineFromLineNumber(rg.EndLine)
-                    yield TagSpan<IOutliningRegionTag>
-                              (SnapshotSpan(startLine.Start, endLine.End), 
-                               OutliningRegionTag(false, false, rg.Collapsed, rg.Contents)) :> ITagSpan<IOutliningRegionTag>
-        }
+                    
+                    let tag = 
+                        TagSpan<IOutliningRegionTag>
+                            (//( SnapshotSpan(startLine.Start + rg.StartOffset, 
+                             SnapshotSpan(startLine.End - rg.StartOffset, 
+                                          if rg.EndOffset = -1 then endLine.End
+                                          else endLine.Start + rg.EndOffset), 
+                             OutliningRegionTag(false, false, rg.Collapsed, rg.Contents)) :> ITagSpan<IOutliningRegionTag>
+                    loop (tag :: acc) tl
+                | _ :: tl -> loop acc tl
+                | [] -> acc
+            
+            loop [] currentRegions :> seq<_>
     
     [<NoComparison>]
-    type TaggerState = 
-        { DocRegions : Region list
-          ComRegions : Region list
-          DocSnapshot : ITextSnapshot
-          ComSnapshot : ITextSnapshot }
+    type private TaggerState = 
+        { OutlineRegions : Region list
+          Snapshot : ITextSnapshot }
     
     type OutliningTagger(buffer : ITextBuffer) as self = 
         let tagsChanged = Event<EventHandler<SnapshotSpanEventArgs>, SnapshotSpanEventArgs>()
+        
         let mutable taggerState = 
-            { DocRegions = []
-              ComRegions = []
-              DocSnapshot = buffer.CurrentSnapshot
-              ComSnapshot = buffer.CurrentSnapshot }  
+            { OutlineRegions = []
+              Snapshot = buffer.CurrentSnapshot }
+        
         do 
             self.Reparse()
             buffer.Changed.Add(self.BufferChanged)
@@ -222,33 +152,27 @@ module Comments =
         member __.TagsChanged = tagsChanged.Publish
         
         member __.Reparse() = 
-            if buffer.CurrentSnapshot = null then () else 
-            let newDocRegions = buildDoccomRegions buffer.CurrentSnapshot.Lines
-            // parse the textbuffer to find any changes in the Documentation comment regions
-            let newDocSnapshot, docEventSpan = 
-                parse buffer taggerState.DocSnapshot taggerState.DocRegions newDocRegions
-            taggerState <- { taggerState with DocSnapshot = newDocSnapshot }
-            taggerState <- { taggerState with DocRegions = newDocRegions }
-            if docEventSpan.IsSome then tagsChanged.Trigger(self, SnapshotSpanEventArgs docEventSpan.Value)
-            let newComRegions = buildCommentRegions buffer.CurrentSnapshot.Lines
-            // parse the textbuffer to find any changes in the comment regions
-            let newComSnapshot, comEventSpan = 
-                parse buffer taggerState.ComSnapshot taggerState.ComRegions newComRegions
-            taggerState <- { taggerState with ComSnapshot = newComSnapshot }
-            taggerState <- { taggerState with ComRegions = newComRegions }
-            if comEventSpan.IsSome then tagsChanged.Trigger(self, SnapshotSpanEventArgs comEventSpan.Value)
+            if buffer.CurrentSnapshot = null then ()
+            else 
+                let regionRcd = 
+                    buffer.CurrentSnapshot.Lines
+                    |> snapshotText
+                    |> constructAllRegions
+                
+                let allRegions = List.concat [ regionRcd.DocBlocks; regionRcd.ComBlocks; regionRcd.StarBlocks ]
+                let newSnapshot, rgEventSpan = 
+                    parse buffer.CurrentSnapshot taggerState.Snapshot taggerState.OutlineRegions allRegions
+                taggerState <- { taggerState with Snapshot = newSnapshot
+                                                  OutlineRegions = allRegions }
+                if rgEventSpan.IsSome then tagsChanged.Trigger(self, SnapshotSpanEventArgs rgEventSpan.Value)
         
-        member __.BufferChanged(args : TextContentChangedEventArgs) = 
+        member __.BufferChanged(args) = 
             if args.After <> buffer.CurrentSnapshot then ()
             else self.Reparse()
         
         interface ITagger<IOutliningRegionTag> with
-            
-            member __.GetTags(spans : NormalizedSnapshotSpanCollection) : IEnumerable<ITagSpan<IOutliningRegionTag>> = 
-                let docTags = generateTags spans taggerState.DocSnapshot taggerState.DocRegions
-                let comTags = generateTags spans taggerState.ComSnapshot taggerState.ComRegions
-                Seq.append docTags comTags
-            
+            member __.GetTags(spans : NormalizedSnapshotSpanCollection) : seq<ITagSpan<IOutliningRegionTag>> = 
+                generateTags spans taggerState.Snapshot taggerState.OutlineRegions
             [<CLIEvent>]
             member __.TagsChanged : IEvent<EventHandler<SnapshotSpanEventArgs>, SnapshotSpanEventArgs> = 
                 tagsChanged.Publish
@@ -258,5 +182,5 @@ module Comments =
     [<ContentType("F#")>]
     type OutliningTaggerProvider() = 
         interface ITaggerProvider with
-            member __.CreateTagger buffer =
-                 buffer.Properties.GetOrCreateSingletonProperty( fun() -> OutliningTagger(buffer) :> obj :?> _ )
+            member __.CreateTagger buffer = 
+                buffer.Properties.GetOrCreateSingletonProperty(fun () -> OutliningTagger(buffer) :> obj :?> _)

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningParsers.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningParsers.fs
@@ -1,0 +1,262 @@
+﻿namespace FSharpVSPowerTools.Outlining
+
+open FParsec
+open Microsoft.FSharp.Collections
+open System
+open System.Text
+
+module Parsers = 
+    /// <summary>
+    /// Holds the data that will be used to construct the IOutliningRegionTag
+    /// </summary>
+    [<Struct>]
+    type Region = 
+        /// Line number of the first line in the region
+        val StartLine : int
+        /// Line number of the last line in the region
+        val EndLine : int
+        val StartOffset : int
+        // EndOffset is only used by the star comments
+        val EndOffset : int
+        /// The text displayed inline when a region is collapsed
+        val Collapsed : string
+        /// The text displayed in the tooltip when a collapsed region is moused over
+        val Contents : string
+        
+        new(startline, endline, startOffset, endOffset, collapsed, contents) = 
+            { StartLine = startline
+              EndLine = endline
+              StartOffset = startOffset
+              EndOffset = endOffset
+              Collapsed = collapsed
+              Contents = contents }
+        
+        override x.ToString() = sprintf "[Region {ln %d - ln %d}]" x.StartLine x.EndLine
+    
+    type lineNum = int64
+    
+    type blockLines = (lineNum * string) list
+    
+    /// "///"    
+    let private doccom = "///"
+    
+    /// "//"
+    let private comment = "//"
+    
+    let inline private trimLineStart (ln : string) = ln.TrimStart([| ' ' |])
+    
+    let inline private removeToken (str : string) (token : string) = 
+        let idx = str.IndexOf(token)
+        str.Remove(idx, token.Length)
+    
+    let private removeDoccom str = removeToken str doccom
+    let private removeComment str = removeToken str comment
+    
+    let private filterWhitespace (ln : string) = 
+        ln.ToCharArray()
+        |> Array.filter (fun ch -> ch <> ' ')
+        |> String.Concat
+    
+    /// <summary>
+    /// <para> Construct a string that will be displayed when the mouse is over the region's collapse string </para>
+    /// <para> 'removeFunc' is used cut the comment tokens out of the tooltip string </para>
+    /// </summary>
+    let inline getTooltipOf (lines : string list) (removeFunc : string -> string) = 
+        match lines with
+        | [] -> ""
+        | lns -> 
+            lns
+            |> List.map (trimLineStart >> removeFunc)
+            |> String.concat "\n"
+    
+    let getDocTooltip lines = getTooltipOf lines removeDoccom
+    let getComTooltip lines = getTooltipOf lines removeComment
+    let private summary = "<summary>"
+    let private ellipsis = "..."
+    
+    /// Given a list of lines that comprise a documentation comment region, determine 
+    /// the string to display when the region is collapsed
+    let getDocCollapsed (lines : string list) : string = 
+        if lines = [] then ellipsis
+        else 
+            let fstLineText = lines.[0]
+            match lines.[0]
+                  |> filterWhitespace
+                  |> removeDoccom with
+            // if the filtered first line is shorter than summary, use that line
+            | ffln when ffln.Length < summary.Length -> fstLineText + ellipsis |> trimLineStart
+            // if the first line of the doc comment is only "<summary>", take the next line
+            | ffln when ffln = summary && lines.Length > 1 -> (lines.[1]) + ellipsis |> trimLineStart
+            // if the description follows the <summary> tag on the same line drop the tag and take the rest
+            | ffln when ffln.[0..summary.Length - 1] = summary -> 
+                let sumStart = fstLineText.IndexOf(summary) + summary.Length
+                doccom + fstLineText.[sumStart..fstLineText.Length - 1] + ellipsis
+            // if xml tags aren't used, take the first line of the doc comment
+            | _ -> fstLineText + ellipsis |> trimLineStart
+    
+    /// Given a list of lines that comprise a comment region, determine the string to display when the
+    /// region is collapsed
+    let getComCollapsed (lines : string list) : string = 
+        match lines with
+        | [] -> ellipsis
+        | _ -> lines.[0] + ellipsis |> trimLineStart
+    
+    let inline private getStarCollapsed _ = "(*...*)"
+    
+    let stripLineNums (lines : blockLines) = 
+        let folder (text : string list) ((_, ln) : lineNum * string) = ln :: text
+        lines
+        |> List.rev
+        |> List.fold folder []
+    
+    let inline constructCommentRegion (getCollapsed : string list -> string) (getTooltip : string list -> string) 
+               (token : string) (ls : blockLines) = 
+        match ls with
+        | [] -> None
+        | _ -> 
+            let (fstLine, fstText) = ls.[0]
+            let (lstLine, _) = ls.[ls.Length - 1]
+            if fstLine = lstLine then None
+            else 
+                let text = stripLineNums ls
+                let collapsed = getCollapsed text
+                let contents = getTooltip text
+                Some 
+                <| Region(int fstLine, int lstLine, fstText.Length - fstText.IndexOf(token), -1, collapsed, contents)
+    
+    let private reduceStrList (lines : string list) = 
+        let folder (sb : StringBuilder) (ln : string) = sb.Append(ln + "\n")
+        let sb = lines |> List.fold folder (StringBuilder())
+        sb.ToString()
+    
+    let constructStarRegion (ls : blockLines) = 
+        match ls with
+        | [] -> None
+        | _ -> 
+            let (fstLine, fstText) = ls.[0]
+            let (lstLine, lstText) = ls.[ls.Length - 1]
+            if fstLine = lstLine then None
+            else 
+                let text = stripLineNums ls
+                let collapsed = getStarCollapsed text
+                let contents = reduceStrList text
+                
+                let sOff = 
+                    if fstText.Length = 0 then fstText.Length + 4
+                    else fstText.Length + 3
+                Some <| Region(int fstLine, int lstLine, sOff, // add three to backtrack to the index before the (*
+                               lstText.Length + 2, collapsed, contents)
+    
+    let private constructStringRegion (ls : blockLines) = 
+        match ls with
+        | [] -> None
+        | _ -> 
+            let (fstLine, _) = ls.[0]
+            let (lstLine, _) = ls.[ls.Length - 1]
+            if fstLine = lstLine then None
+            else 
+                let collapsed = ""
+                let contents = ""
+                // the offset of these regions will not be used so we default to 0
+                Some <| Region(int fstLine, int lstLine, 0, 0, collapsed, contents)
+    
+    let buildDocRegion = constructCommentRegion getDocCollapsed getDocTooltip doccom
+    let buildComRegion = constructCommentRegion getComCollapsed getComTooltip comment
+    let buildStarRegion = constructStarRegion
+    
+    type private UserState = unit
+    
+    type private Parser<'t> = Parser<'t, UserState>
+    
+    let private pullResult (res : ParserResult<'t, unit>) = 
+        let _, result = 
+            match res with
+            | Failure(errMsg, _, _) -> errMsg, None
+            | Success(result, _, _) -> "Success", Some result
+        match result with
+        | None -> failwithf "\n\n >>> Parser did not return a result <<<\n\n%A" res
+        | Some r -> r
+    
+    let private getLineNum : Parser<_> = getPosition |>> fun x -> x.Line - 1L
+    let private skipUntil token : Parser<_> = skipManyTill skipAnyChar token
+    let private skipToEOF : Parser<_> = skipUntil eof
+    let private takeUntil token : Parser<_> = manyCharsTill anyChar token
+    let private takeTillLineEnd : Parser<_> = takeUntil newline
+    let private attemptMany psr = many (attempt psr)
+    let private attemptMany1 psr = many1 (attempt psr)
+    let private parseNextMatch psr = (skipManyTill skipAnyChar (lookAhead psr) >>. psr)
+    let private parseString str psr = run psr str |> pullResult
+    let findInString str psr = attemptMany (parseNextMatch psr) .>> skipToEOF |> parseString str
+    let findInStringAsync str psr = async { return findInString str psr }
+    
+    /// Parse consecutive spaces as a string
+    let private getSpaces : Parser<_> = many <| pchar ' ' |>> (fun chls -> String.Concat(Array.ofList chls))
+    
+    let private dblQuote : Parser<_> = pchar '\"'
+    let private notDblQuote : Parser<_> = noneOf [ '"' ]
+    let private slash : Parser<_> = pchar '/'
+    let private equals : Parser<_> = pchar '='
+    let private triSlash : Parser<_> = pstring "///"
+    let private dblSlash : Parser<_> = pstring "//"
+    let private comOpen : Parser<_> = pstring "(*"
+    let private comClose : Parser<_> = pstring "*)"
+    let private quoteTri : Parser<_> = pstring "\"\"\""
+    let private strToken = dblQuote .>> notFollowedBy dblQuote .>> notFollowedBy dblQuote
+    let inline private flattenCom (((a, b), c) : (string * string) * string) = String.Concat [ a; b; c ]
+    let inline private appendElm (lns, lstln) = List.append lns [ lstln ]
+    let inline private consDbl ((l1, l2), ls) = l1 :: l2 :: ls
+    let private stringStart = skipMany1Till (noneOf [ '/' ]) (lookAhead equals) >>. skipChar '=' >>. spaces
+    
+    // a multiline string must end on a different line than it starts
+    let multiString = 
+        let multilns = attemptMany1 (getLineNum .>>. (manyCharsTill notDblQuote) newline)
+        let lstln = getLineNum .>>. manyCharsTill anyChar (lookAhead dblQuote)
+        let multiContent = (multilns .>>. lstln |>> appendElm) |> between strToken strToken
+        (stringStart >>. multiContent) |>> constructStringRegion
+    
+    let inline insertEmptyString _ = String.Empty
+    
+    let skipMultiString = 
+        let multilns = attemptMany1 (getLineNum .>>. (((skipManyTill notDblQuote) newline) |>> insertEmptyString))
+        let lstln = getLineNum .>>. (skipManyTill skipAnyChar (lookAhead dblQuote) |>> insertEmptyString)
+        let multiContent = (multilns .>>. lstln |>> appendElm) |> between strToken strToken
+        stringStart >>. multiContent |>> constructStringRegion
+    
+    // a multiline triple quote string must end on a different line than it starts
+    let triString = 
+        let lstln = 
+            (getLineNum .>>. (newline |>> fun _ -> "")) <|> (getLineNum .>>. manyCharsTill anyChar (lookAhead quoteTri))
+        let trilns = 
+            attemptMany1 
+                (getLineNum 
+                 .>>. (manyCharsTill (anyChar .>> notFollowedBy quoteTri)) (newline .>> notFollowedBy quoteTri))
+        let triContent = (trilns .>>. lstln |>> appendElm) |> between quoteTri quoteTri
+        stringStart >>. triContent |>> constructStringRegion
+    
+    let skipTriString = 
+        let lstln = 
+            (getLineNum .>>. (newline |>> insertEmptyString)) 
+            <|> (getLineNum .>>. ((skipManyTill skipAnyChar (lookAhead quoteTri)) |>> insertEmptyString))
+        let trilns = 
+            attemptMany1 
+                (getLineNum 
+                 .>>. ((skipManyTill (skipAnyChar .>> notFollowedBy quoteTri)) (newline .>> notFollowedBy quoteTri) 
+                       |>> insertEmptyString))
+        let triContent = (trilns .>>. lstln |>> appendElm) |> between quoteTri quoteTri
+        stringStart >>. triContent |>> constructStringRegion
+    
+    let private docLine = getLineNum .>>. (getSpaces .>>. triSlash .>>. takeTillLineEnd |>> flattenCom)
+    let private comLine = 
+        getLineNum .>>. (getSpaces .>>. (dblSlash .>> notFollowedBy slash) .>>. takeTillLineEnd |>> flattenCom)
+    // comment blocks must have at least 2 lines
+    let docBlock = (docLine .>>. docLine .>>. attemptMany docLine) |>> consDbl |>> buildDocRegion
+    let comBlock = (comLine .>>. comLine .>>. attemptMany comLine |>> consDbl) |>> buildComRegion
+    
+    let starBlock = 
+        let comOpen' = 
+            (notDblQuote >>. comOpen .>> notDblQuote) <|> (dblQuote >>. comOpen .>> notDblQuote) 
+            <|> (notDblQuote >>. comOpen .>> dblQuote)
+        let starLines = attemptMany1 (getLineNum .>>. (manyCharsTill (anyChar .>> notFollowedBy comClose) newline))
+        let lastLine = getLineNum .>>. (manyCharsTill anyChar (lookAhead comClose))
+        let starContent = (starLines .>>. lastLine |>> appendElm) |> between comOpen' comClose
+        starContent |>> buildStarRegion

--- a/src/FSharpVSPowerTools.Logic/packages.config
+++ b/src/FSharpVSPowerTools.Logic/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="FParsec" version="1.0.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Added OutliningTagger type that creates collapsible regions for blocks of single line comments and blocks of documentation comments. It works well as a complement to the [F# outlining extension](https://visualstudiogallery.msdn.microsoft.com/bec977b8-c9d9-4926-999e-e50c4498df8a).

![fsharp_comment_outlining](https://cloud.githubusercontent.com/assets/680051/5152580/219fb6d2-71c7-11e4-80e3-854e05b97ef3.png)

@vasily-kirichenko  sorry for how sloppy the last PR was
