### PR TITLE
Folder name validation

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FolderNameDialog.fs
+++ b/src/FSharpVSPowerTools.Logic/FolderNameDialog.fs
@@ -1,5 +1,6 @@
 ﻿namespace FSharpVSPowerTools.Folders
 
+open System.IO
 open FSharpVSPowerTools
 open FSharp.ViewModule
 open FSharp.ViewModule.Validation
@@ -15,6 +16,11 @@ type NewFolderNameDialogResources =
 type NewFolderNameDialogModel(resources: NewFolderNameDialogResources) as self = 
     inherit ViewModelBase()
     
+    let validateFolderName (folderName: string) =
+        if (folderName.IndexOfAny <| Path.GetInvalidFileNameChars()) >= 0
+        then Some Resource.validationInvalidFolderName
+        else None
+
     let validateExists (folderName: string) = 
         match folderName.Trim() with
         | a when resources.FolderNames.Contains(a) -> Some Resource.validationFolderWithGivenNameAlreadyExists
@@ -25,6 +31,7 @@ type NewFolderNameDialogModel(resources: NewFolderNameDialogResources) as self =
         >> notNullOrWhitespace
         >> fixErrorsWithMessage Resource.validatingEmptyName
         >> custom validateExists
+        >> custom validateFolderName
         >> result
     
     let name = self.Factory.Backing(<@@ self.Name @@>, resources.OriginalName, validateName)

--- a/src/FSharpVSPowerTools.Logic/Resource.fs
+++ b/src/FSharpVSPowerTools.Logic/Resource.fs
@@ -21,6 +21,7 @@ module Resource =
     let [<Literal>] validationDestinationFolderDoesNotExist = "Destination folder doesn't exist. Please try to create destination folder before moving files."
     let [<Literal>] validationCannotCreateFolder = "Unable to create folder. Please make sure you have enough privileges."
     let [<Literal>] validationExistingFolderOnDisk = "An existing folder has been added."
+    let [<Literal>] validationInvalidFolderName = "Invalid folder name."
     let [<Literal>] validationRenameFolderAlreadyExistsOnDisk = "Unable to rename folder. Folder with given name already exists on disk."
 
     let [<Literal>] navBarUnauthorizedMessage = "Unauthorized access to navigation bar configuration. Please try again after restarting Visual Studio from Administrator."


### PR DESCRIPTION
I've added a simple validation for created folder name so it won't fall to Visual Studio default event handler when adding a folder with invalid name (for example, previously if you try to add folder `/` to your project, it fails with two error messages).
