### PR TITLE
Fixed some issues that were causing rebuilds after the latest F# preview

### DIFF
--- a/src/FSharpVSPowerTools.Logic.VS2013/FSharpVSPowerTools.Logic.VS2013.fsproj
+++ b/src/FSharpVSPowerTools.Logic.VS2013/FSharpVSPowerTools.Logic.VS2013.fsproj
@@ -22,7 +22,7 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>5</WarningLevel>
-    <DocumentationFile>bin\Debug\FSharpVSPowerTools.Logic.XML</DocumentationFile>
+    <DocumentationFile>bin\Debug\FSharpVSPowerTools.Logic.VS2013.XML</DocumentationFile>
     <OtherFlags>--warnon:1182</OtherFlags>
     <NoWarn>52</NoWarn>
   </PropertyGroup>
@@ -33,7 +33,7 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>5</WarningLevel>
-    <DocumentationFile>bin\Release\FSharpVSPowerTools.Logic.XML</DocumentationFile>
+    <DocumentationFile>bin\Release\FSharpVSPowerTools.Logic.VS2013.XML</DocumentationFile>
     <OtherFlags>--warnon:1182</OtherFlags>
     <NoWarn>52</NoWarn>
   </PropertyGroup>

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -347,21 +347,21 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\LICENSE.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\..\docs\files\img\logo.png">
       <Link>logo.png</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\..\RELEASE_NOTES.md">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\..\docs\files\img\preview.png">
       <Link>preview.png</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <VSCTCompile Include="FSharpVSPowerTools.vsct">


### PR DESCRIPTION
With these fixes in place, 0 projects are rebuilt after issuing a second build command in VS
