### PR TITLE
SignatureGenerator.Filterer

### DIFF
--- a/src/FSharpVSPowerTools.Core/CodeGeneration.fs
+++ b/src/FSharpVSPowerTools.Core/CodeGeneration.fs
@@ -51,6 +51,10 @@ module internal Utils =
         member x.WriteLine(s: string, [<ParamArray>] objs: obj []) =
             indentWriter.WriteLine(s, objs)
 
+        member x.WriteBlankLines count =
+            for i in 0 .. count - 1 do
+                x.WriteLine ""
+
         member x.Indent i = 
             indentWriter.Indent <- indentWriter.Indent + i
 

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -145,7 +145,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                 parseTree 
                 |> Option.map (OpenDeclarationGetter.getEffectiveOpenDeclarationsAtLocation pos) 
                 |> Option.getOrElse []
-            match SignatureGenerator.formatSymbol (getXmlDocBySignature fsSymbol) indentSize displayContext openDeclarations fsSymbol SignatureGenerator.Filterer.NoFilters with
+            match SignatureGenerator.formatSymbol (getXmlDocBySignature fsSymbol) indentSize displayContext openDeclarations fsSymbol SignatureGenerator.Filterer.NoFilters SignatureGenerator.BlankLines.None with
             | Some signature ->
                 let directoryPath = Path.GetDirectoryName(filePath)
                 Directory.CreateDirectory(directoryPath) |> ignore

--- a/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.fs
@@ -83,7 +83,7 @@ let tryGenerateDefinitionFromPos caretPos src =
                     []
             
         let openDeclarations = OpenDeclarationGetter.getEffectiveOpenDeclarationsAtLocation caretPos parseTree
-        let! generatedCode = liftMaybe <| formatSymbol getXmlDocBySignature 4 symbolUse.DisplayContext openDeclarations symbolUse.Symbol Filterer.NoFilters
+        let! generatedCode = liftMaybe <| formatSymbol getXmlDocBySignature 4 symbolUse.DisplayContext openDeclarations symbolUse.Symbol Filterer.NoFilters BlankLines.None
         return generatedCode
     }
     |> Async.RunSynchronously


### PR DESCRIPTION
I'm exploring ways to use the `SignatureGenerator`. There are several use cases where it would be good to only print a subset of the members/functions/values for an entity. This pull request enables that.

A fictional example is to print `Microsoft.FSharp.Linq.QueryBuilder` and all of its members/functions/values that begin with "Then":

```
let formatSymbol symbol =
    let xmlDoc xmlFile = []
    let openDeclarations = []
    let filterer = { 
        SignatureGenerator.Filterer.NoFilters with  
            MemberOrFunctionOrValueFilter = Some (fun m -> m.DisplayName.StartsWith "Then") }
    SignatureGenerator.formatSymbol xmlDoc 4 FSharpDisplayContext.Empty openDeclarations symbol filterer

let txt = formatSymbol entityQueryBuilder
```

```
[<Microsoft.FSharp.Core.Class>]
type QueryBuilder =
    [<Microsoft.FSharp.Core.CustomOperation("thenBy")>]
    member ThenBy : source:Microsoft.FSharp.Linq.QuerySource<'T,'Q> * keySelector:('T -> 'Key) -> Microsoft.FSharp.Linq.QuerySource<'T,'Q> when 'Key : comparison
    [<Microsoft.FSharp.Core.CustomOperation("thenByDescending")>]
    member ThenByDescending : source:Microsoft.FSharp.Linq.QuerySource<'T,'Q> * keySelector:('T -> 'Key) -> Microsoft.FSharp.Linq.QuerySource<'T,'Q> when 'Key : comparison
    [<Microsoft.FSharp.Core.CustomOperation("thenByNullable")>]
    member ThenByNullable : source:Microsoft.FSharp.Linq.QuerySource<'T,'Q> * keySelector:('T -> System.Nullable<'Key>) -> Microsoft.FSharp.Linq.QuerySource<'T,'Q> when 'Key : comparison and 'Key : (new : unit -> 'Key) and 'Key : struct and 'Key :> System.ValueType
    [<Microsoft.FSharp.Core.CustomOperation("thenByNullableDescending")>]
    member ThenByNullableDescending : source:Microsoft.FSharp.Linq.QuerySource<'T,'Q> * keySelector:('T -> System.Nullable<'Key>) -> Microsoft.FSharp.Linq.QuerySource<'T,'Q> when 'Key : comparison and 'Key : (new : unit -> 'Key) and 'Key : struct and 'Key :> System.ValueType
```

My immediate need is for diffing the public surface area of `FSharp.Core` `3.0`, `3.1` and `4.0`.
[Any benefit for targeting F# runtime for F# 4.0 or 3.1 instead of 3.0?](http://stackoverflow.com/questions/27363777/any-benefit-for-targeting-f-runtime-for-f-4-0-or-3-1-instead-of-3-0)

Other questions I have:
- How do I prevent the types from being fully qualified. I tried without luck variations of `
  let openDeclarations = [ "Microsoft.FSharp.Core"; "Microsoft.FSharp.Linq" ]`
- How do I control the formatting so that there is a blank between members/functions/values?
