### PR TITLE
Life easier for polyglot / C# / ES6 -developer to code F#

### DIFF
--- a/docs/content/commoncstypos.fsx
+++ b/docs/content/commoncstypos.fsx
@@ -1,0 +1,17 @@
+(*** hide ***)
+// This block of code is omitted in the generated HTML documentation. Use 
+// it to define helpers that you do not want to show in the documentation.
+#I "../../bin"
+
+(**
+
+Auto-correct common C#-/JavaScript-developer typos in F#-files
+-----------------------
+
+The idea is to correct most common polyglot- / C#- / JavaScript-developer typing errors while they write F#:
+
+ - Writing only ``"var "`` in the beginning of the line, it will be replaced to ``"let "``
+ - Writing C# / ES6 (JS) type lambda ``"(... => "`` it will be replaced to ``"(fun ... ->"``, e.g. in ``".Select(x => x + 1)"`` (only once per code line, and not in commented code)
+ - Writing only C#-style ``"using "`` in the beginning of the line, with no bracket, it will be replaced to "open "
+
+*)

--- a/docs/content/index.fsx
+++ b/docs/content/index.fsx
@@ -36,6 +36,7 @@ Here are currently supported features:
  * [Go to metadata](gotometadata.html)
  * [Task List comments](tasklistcomments.html)
  * [Generate references in F# Interactive](generatereferences.html)
+ * [Auto-correct common C#-/JavaScript-developer typos in F#-files](commoncstypos.html)
   
 Default Keymap
 --------------

--- a/src/FSharpVSPowerTools.Logic/CSharpToFSharpFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/CSharpToFSharpFilter.fs
@@ -50,12 +50,10 @@ type CSharpToFSharpFilter(textView: IVsTextView, wpfTextView: IWpfTextView, file
                         let quotes = newLine.Contains("\"") || newLine.Contains("'") || newLine.Contains("//") || newLine.Contains("(*") || newLine.Contains("``")
                         match indexBegin > startPos && ``typing after arrow`` && newLine.IndexOf("->")<0 && not(quotes) with
                         | true -> 
-                            let ``kleisli arrow`` = "->"
-                            let lambdaFun = "(fun "
                             let lambdaPart = Text.Span.FromBounds(indexArrow, indexArrow+2)
                             let beginPart = Text.Span.FromBounds(indexBegin, indexBegin+1)
-                            buffer.Replace(lambdaPart, ``kleisli arrow``) |> ignore
-                            buffer.Replace(beginPart, lambdaFun) |> ignore
+                            buffer.Replace(lambdaPart, "->") |> ignore
+                            buffer.Replace(beginPart, "(fun ") |> ignore
                             ()
                         | false -> ()
                 | _ -> ()

--- a/src/FSharpVSPowerTools.Logic/CSharpToFSharpFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/CSharpToFSharpFilter.fs
@@ -1,0 +1,65 @@
+﻿namespace FSharpVSPowerTools.CSharpToFSharp
+
+// This will make life easier for polyglot / C# / ES6 -developer to code F#
+// While you type it will first to replace:
+// "var "    to  "let "            (the whole line only)
+// "using "  to  "open "           (the whole line only and "using(" is not replaced)
+// "(... => "  to  "(fun ... -> "  (this is for lambdas like ".Select(x => ...)" when there is no "->"-arrow already)
+
+open System
+open System.Diagnostics
+open System.Runtime.InteropServices
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.OLE.Interop
+open Microsoft.VisualStudio.Text.Editor
+open Microsoft.VisualStudio.TextManager.Interop
+open FSharpVSPowerTools
+open FSharpVSPowerTools.ProjectSystem
+
+type CSharpToFSharpFilter(textView: IVsTextView, wpfTextView: IWpfTextView, filename: string, languageService: VSLanguageService) as self =
+    let mutable passThruToEditor: IOleCommandTarget = null
+    do if not (ErrorHandler.Succeeded(textView.AddCommandFilter(self, &passThruToEditor))) && Debugger.IsAttached then 
+           Debugger.Break()
+
+    /// Get the char for a <see cref="VSConstants.VSStd2KCmdID.TYPECHAR"/> command.
+    let getTypedChar(pvaIn: IntPtr) =
+        char (Marshal.GetObjectForNativeVariant(pvaIn) :?> uint16)
+
+    interface IOleCommandTarget with
+        member x.Exec(pguidCmdGroup: byref<Guid>, nCmdID: uint32, nCmdexecopt: uint32, pvaIn: IntPtr, pvaOut: IntPtr) =
+            if pguidCmdGroup = VSConstants.VSStd2K && nCmdID = uint32 VSConstants.VSStd2KCmdID.TYPECHAR then
+                match getTypedChar pvaIn with
+                | ' ' as lastChar ->
+                    let pos = wpfTextView.Caret.Position.BufferPosition
+                    let curLine = pos.GetContainingLine()
+                    let startPos = curLine.Start.Position
+                    let newLine = curLine.GetText().Insert(pos.Position - startPos, string lastChar)
+                    let buffer = wpfTextView.TextBuffer
+
+                    match newLine.TrimStart() with
+                    | "var " | "using " as cmd -> 
+                        let startIdx = newLine.IndexOf(cmd) + startPos
+                        let toFsharp = match cmd with "var " -> "let" | "using " -> "open" | _ -> ""
+                        let toReplace = Text.Span.FromBounds(startIdx, startIdx+cmd.Length-1)
+                        buffer.Replace(toReplace, toFsharp) |> ignore
+                        ()
+                    | _ ->
+                        let indexBegin = newLine.LastIndexOf('(') + startPos
+                        let indexArrow = newLine.LastIndexOf("=> ") + startPos
+                        let ``typing after arrow`` = indexArrow > indexBegin && pos.Position > indexArrow+1 
+                        let quotes = newLine.Contains("\"") || newLine.Contains("'") || newLine.Contains("//") || newLine.Contains("(*") || newLine.Contains("``")
+                        match indexBegin > startPos && ``typing after arrow`` && newLine.IndexOf("->")<0 && not(quotes) with
+                        | true -> 
+                            let ``kleisli arrow`` = "->"
+                            let lambdaFun = "(fun "
+                            let lambdaPart = Text.Span.FromBounds(indexArrow, indexArrow+2)
+                            let beginPart = Text.Span.FromBounds(indexBegin, indexBegin+1)
+                            buffer.Replace(lambdaPart, ``kleisli arrow``) |> ignore
+                            buffer.Replace(beginPart, lambdaFun) |> ignore
+                            ()
+                        | false -> ()
+                | _ -> ()
+            passThruToEditor.Exec(&pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut)
+
+        member x.QueryStatus(pguidCmdGroup: byref<Guid>, cCmds: uint32, prgCmds: OLECMD [], pCmdText: IntPtr) =
+            passThruToEditor.QueryStatus(ref pguidCmdGroup, cCmds, prgCmds, pCmdText)

--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -189,6 +189,9 @@
     <Compile Include="XmlDocFilter.fs">
       <Link>CodeGeneration/XmlDocFilter.fs</Link>
     </Compile>
+    <Compile Include="CSharpToFSharpFilter.fs">
+      <Link>CodeGeneration/CSharpToFSharpFilter.fs</Link>
+    </Compile>
     <Compile Include="ImplementInterfaceSmartTagger.fs">
       <Link>CodeGeneration/ImplementInterfaceSmartTagger.fs</Link>
     </Compile>

--- a/src/FSharpVSPowerTools.Logic/Setting.fs
+++ b/src/FSharpVSPowerTools.Logic/Setting.fs
@@ -20,6 +20,7 @@ type IGeneralOptions =
     abstract TaskListCommentsEnabled: bool with get, set
     abstract GoToMetadataEnabled: bool with get, set
     abstract GenerateReferencesEnabled: bool with get, set
+    abstract CSharpToFSharpEnabled: bool with get, set
 
 type IFormattingOptions =
     abstract PageWidth: int with get, set

--- a/src/FSharpVSPowerTools/CSharpToFSharpFilterProvider.cs
+++ b/src/FSharpVSPowerTools/CSharpToFSharpFilterProvider.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Diagnostics;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.Text;
+using FSharpVSPowerTools.ProjectSystem;
+using FSharpVSPowerTools.CSharpToFSharp;
+
+// Useful reference: http://msdn.microsoft.com/en-us/library/dd885243.aspx
+namespace FSharpVSPowerTools
+{
+    [Export(typeof(IVsTextViewCreationListener))]
+    [ContentType("F#")]
+    [TextViewRole(PredefinedTextViewRoles.Interactive)]
+    public class CSharpToFSharpFilterProvider : IVsTextViewCreationListener
+    {
+        [Import]
+        internal ITextDocumentFactoryService textDocumentFactoryService = null;
+
+        [Import]
+        internal IVsEditorAdaptersFactoryService editorFactory = null;
+
+        [Import]
+        internal VSLanguageService fsharpVsLanguageService = null;
+
+        [Import(typeof(SVsServiceProvider))]
+        internal System.IServiceProvider serviceProvider = null;
+
+        public void VsTextViewCreated(IVsTextView textViewAdapter)
+        {
+            var wpfTextView = editorFactory.GetWpfTextView(textViewAdapter);
+            if (wpfTextView == null) return;
+
+            var generalOptions = Setting.getGeneralOptions(serviceProvider);
+            if (generalOptions == null || !generalOptions.CSharpToFSharpEnabled) return;
+
+            ITextDocument doc;
+            if (textDocumentFactoryService.TryGetTextDocument(wpfTextView.TextBuffer, out doc))
+            {
+                Debug.Assert(doc != null, "Text document shouldn't be null.");
+                new CSharpToFSharpFilter(textViewAdapter, wpfTextView, doc.FilePath, fsharpVsLanguageService);
+            }
+        }
+    }
+}

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -130,6 +130,7 @@
     <Compile Include="CodeGenerationOptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="CSharpToFSharpFilterProvider.cs" />
     <Compile Include="GlobalOptionsPage.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/src/FSharpVSPowerTools/GeneralOptionsControl.Designer.cs
+++ b/src/FSharpVSPowerTools/GeneralOptionsControl.Designer.cs
@@ -54,11 +54,13 @@ namespace FSharpVSPowerTools
             this.chbFormatting = new System.Windows.Forms.CheckBox();
             this.chbXmlDoc = new System.Windows.Forms.CheckBox();
             this.chbGenerateReferences = new System.Windows.Forms.CheckBox();
+            this.chbCSharpTypos = new System.Windows.Forms.CheckBox();
             this.grbOptions.SuspendLayout();
             this.SuspendLayout();
             // 
             // grbOptions
             // 
+            this.grbOptions.Controls.Add(this.chbCSharpTypos);
             this.grbOptions.Controls.Add(this.chbGenerateReferences);
             this.grbOptions.Controls.Add(this.chbUnusedOpens);
             this.grbOptions.Controls.Add(this.chbTaskListComments);
@@ -82,9 +84,11 @@ namespace FSharpVSPowerTools
             this.grbOptions.Controls.Add(this.lblHome);
             this.grbOptions.Controls.Add(this.chbFormatting);
             this.grbOptions.Controls.Add(this.chbXmlDoc);
-            this.grbOptions.Location = new System.Drawing.Point(3, 3);
+            this.grbOptions.Location = new System.Drawing.Point(4, 4);
+            this.grbOptions.Margin = new System.Windows.Forms.Padding(4);
             this.grbOptions.Name = "grbOptions";
-            this.grbOptions.Size = new System.Drawing.Size(481, 293);
+            this.grbOptions.Padding = new System.Windows.Forms.Padding(4);
+            this.grbOptions.Size = new System.Drawing.Size(641, 375);
             this.grbOptions.TabIndex = 0;
             this.grbOptions.TabStop = false;
             this.grbOptions.Text = "Turn features on/off";
@@ -94,9 +98,10 @@ namespace FSharpVSPowerTools
             this.chbUnusedOpens.AutoSize = true;
             this.chbUnusedOpens.Checked = true;
             this.chbUnusedOpens.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbUnusedOpens.Location = new System.Drawing.Point(204, 156);
+            this.chbUnusedOpens.Location = new System.Drawing.Point(272, 192);
+            this.chbUnusedOpens.Margin = new System.Windows.Forms.Padding(4);
             this.chbUnusedOpens.Name = "chbUnusedOpens";
-            this.chbUnusedOpens.Size = new System.Drawing.Size(136, 17);
+            this.chbUnusedOpens.Size = new System.Drawing.Size(179, 21);
             this.chbUnusedOpens.TabIndex = 19;
             this.chbUnusedOpens.Text = "Gray out unused opens";
             this.chbUnusedOpens.UseVisualStyleBackColor = true;
@@ -106,9 +111,10 @@ namespace FSharpVSPowerTools
             this.chbTaskListComments.AutoSize = true;
             this.chbTaskListComments.Checked = true;
             this.chbTaskListComments.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbTaskListComments.Location = new System.Drawing.Point(204, 205);
+            this.chbTaskListComments.Location = new System.Drawing.Point(272, 252);
+            this.chbTaskListComments.Margin = new System.Windows.Forms.Padding(4);
             this.chbTaskListComments.Name = "chbTaskListComments";
-            this.chbTaskListComments.Size = new System.Drawing.Size(120, 17);
+            this.chbTaskListComments.Size = new System.Drawing.Size(155, 21);
             this.chbTaskListComments.TabIndex = 18;
             this.chbTaskListComments.Text = "Task List comments";
             this.chbTaskListComments.UseVisualStyleBackColor = true;
@@ -118,9 +124,10 @@ namespace FSharpVSPowerTools
             this.chbGoToMetadata.AutoSize = true;
             this.chbGoToMetadata.Checked = true;
             this.chbGoToMetadata.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbGoToMetadata.Location = new System.Drawing.Point(204, 181);
+            this.chbGoToMetadata.Location = new System.Drawing.Point(272, 223);
+            this.chbGoToMetadata.Margin = new System.Windows.Forms.Padding(4);
             this.chbGoToMetadata.Name = "chbGoToMetadata";
-            this.chbGoToMetadata.Size = new System.Drawing.Size(99, 17);
+            this.chbGoToMetadata.Size = new System.Drawing.Size(128, 21);
             this.chbGoToMetadata.TabIndex = 18;
             this.chbGoToMetadata.Text = "Go to metadata";
             this.chbGoToMetadata.UseVisualStyleBackColor = true;
@@ -130,9 +137,10 @@ namespace FSharpVSPowerTools
             this.chbUnusedReferences.AutoSize = true;
             this.chbUnusedReferences.Checked = true;
             this.chbUnusedReferences.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbUnusedReferences.Location = new System.Drawing.Point(204, 133);
+            this.chbUnusedReferences.Location = new System.Drawing.Point(272, 164);
+            this.chbUnusedReferences.Margin = new System.Windows.Forms.Padding(4);
             this.chbUnusedReferences.Name = "chbUnusedReferences";
-            this.chbUnusedReferences.Size = new System.Drawing.Size(164, 17);
+            this.chbUnusedReferences.Size = new System.Drawing.Size(217, 21);
             this.chbUnusedReferences.TabIndex = 17;
             this.chbUnusedReferences.Text = "Gray out unused declarations";
             this.chbUnusedReferences.UseVisualStyleBackColor = true;
@@ -142,9 +150,10 @@ namespace FSharpVSPowerTools
             this.chbResolveUnopenedNamespaces.AutoSize = true;
             this.chbResolveUnopenedNamespaces.Checked = true;
             this.chbResolveUnopenedNamespaces.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbResolveUnopenedNamespaces.Location = new System.Drawing.Point(204, 110);
+            this.chbResolveUnopenedNamespaces.Location = new System.Drawing.Point(272, 135);
+            this.chbResolveUnopenedNamespaces.Margin = new System.Windows.Forms.Padding(4);
             this.chbResolveUnopenedNamespaces.Name = "chbResolveUnopenedNamespaces";
-            this.chbResolveUnopenedNamespaces.Size = new System.Drawing.Size(179, 17);
+            this.chbResolveUnopenedNamespaces.Size = new System.Drawing.Size(233, 21);
             this.chbResolveUnopenedNamespaces.TabIndex = 16;
             this.chbResolveUnopenedNamespaces.Text = "Resolve unopened namespaces";
             this.chbResolveUnopenedNamespaces.UseVisualStyleBackColor = true;
@@ -154,9 +163,10 @@ namespace FSharpVSPowerTools
             this.chbUnionPatternMatchCaseGeneration.AutoSize = true;
             this.chbUnionPatternMatchCaseGeneration.Checked = true;
             this.chbUnionPatternMatchCaseGeneration.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbUnionPatternMatchCaseGeneration.Location = new System.Drawing.Point(204, 86);
+            this.chbUnionPatternMatchCaseGeneration.Location = new System.Drawing.Point(272, 106);
+            this.chbUnionPatternMatchCaseGeneration.Margin = new System.Windows.Forms.Padding(4);
             this.chbUnionPatternMatchCaseGeneration.Name = "chbUnionPatternMatchCaseGeneration";
-            this.chbUnionPatternMatchCaseGeneration.Size = new System.Drawing.Size(201, 17);
+            this.chbUnionPatternMatchCaseGeneration.Size = new System.Drawing.Size(264, 21);
             this.chbUnionPatternMatchCaseGeneration.TabIndex = 16;
             this.chbUnionPatternMatchCaseGeneration.Text = "Union pattern match case generation";
             this.chbUnionPatternMatchCaseGeneration.UseVisualStyleBackColor = true;
@@ -166,9 +176,10 @@ namespace FSharpVSPowerTools
             this.chbRecordStubGeneration.AutoSize = true;
             this.chbRecordStubGeneration.Checked = true;
             this.chbRecordStubGeneration.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbRecordStubGeneration.Location = new System.Drawing.Point(204, 63);
+            this.chbRecordStubGeneration.Location = new System.Drawing.Point(272, 78);
+            this.chbRecordStubGeneration.Margin = new System.Windows.Forms.Padding(4);
             this.chbRecordStubGeneration.Name = "chbRecordStubGeneration";
-            this.chbRecordStubGeneration.Size = new System.Drawing.Size(137, 17);
+            this.chbRecordStubGeneration.Size = new System.Drawing.Size(179, 21);
             this.chbRecordStubGeneration.TabIndex = 15;
             this.chbRecordStubGeneration.Text = "Record stub generation";
             this.chbRecordStubGeneration.UseVisualStyleBackColor = true;
@@ -178,9 +189,10 @@ namespace FSharpVSPowerTools
             this.chbFindAllReferences.AutoSize = true;
             this.chbFindAllReferences.Checked = true;
             this.chbFindAllReferences.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbFindAllReferences.Location = new System.Drawing.Point(204, 16);
+            this.chbFindAllReferences.Location = new System.Drawing.Point(272, 20);
+            this.chbFindAllReferences.Margin = new System.Windows.Forms.Padding(4);
             this.chbFindAllReferences.Name = "chbFindAllReferences";
-            this.chbFindAllReferences.Size = new System.Drawing.Size(112, 17);
+            this.chbFindAllReferences.Size = new System.Drawing.Size(147, 21);
             this.chbFindAllReferences.TabIndex = 14;
             this.chbFindAllReferences.Text = "Find all references";
             this.chbFindAllReferences.UseVisualStyleBackColor = true;
@@ -188,9 +200,10 @@ namespace FSharpVSPowerTools
             // lblInformation
             // 
             this.lblInformation.AutoSize = true;
-            this.lblInformation.Location = new System.Drawing.Point(12, 238);
+            this.lblInformation.Location = new System.Drawing.Point(14, 313);
+            this.lblInformation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblInformation.Name = "lblInformation";
-            this.lblInformation.Size = new System.Drawing.Size(139, 13);
+            this.lblInformation.Size = new System.Drawing.Size(187, 17);
             this.lblInformation.TabIndex = 13;
             this.lblInformation.Text = "*** Admin privileges required";
             // 
@@ -199,9 +212,10 @@ namespace FSharpVSPowerTools
             this.chbInterfaceImplementation.AutoSize = true;
             this.chbInterfaceImplementation.Checked = true;
             this.chbInterfaceImplementation.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbInterfaceImplementation.Location = new System.Drawing.Point(204, 39);
+            this.chbInterfaceImplementation.Location = new System.Drawing.Point(272, 48);
+            this.chbInterfaceImplementation.Margin = new System.Windows.Forms.Padding(4);
             this.chbInterfaceImplementation.Name = "chbInterfaceImplementation";
-            this.chbInterfaceImplementation.Size = new System.Drawing.Size(118, 17);
+            this.chbInterfaceImplementation.Size = new System.Drawing.Size(153, 21);
             this.chbInterfaceImplementation.TabIndex = 12;
             this.chbInterfaceImplementation.Text = "Implement interface";
             this.chbInterfaceImplementation.UseVisualStyleBackColor = true;
@@ -209,9 +223,10 @@ namespace FSharpVSPowerTools
             // chbFolderOrganization
             // 
             this.chbFolderOrganization.AutoSize = true;
-            this.chbFolderOrganization.Location = new System.Drawing.Point(15, 204);
+            this.chbFolderOrganization.Location = new System.Drawing.Point(20, 251);
+            this.chbFolderOrganization.Margin = new System.Windows.Forms.Padding(4);
             this.chbFolderOrganization.Name = "chbFolderOrganization";
-            this.chbFolderOrganization.Size = new System.Drawing.Size(115, 17);
+            this.chbFolderOrganization.Size = new System.Drawing.Size(152, 21);
             this.chbFolderOrganization.TabIndex = 12;
             this.chbFolderOrganization.Text = "Folder organization";
             this.chbFolderOrganization.UseVisualStyleBackColor = true;
@@ -221,9 +236,10 @@ namespace FSharpVSPowerTools
             this.chbSyntaxColoring.AutoSize = true;
             this.chbSyntaxColoring.Checked = true;
             this.chbSyntaxColoring.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbSyntaxColoring.Location = new System.Drawing.Point(15, 181);
+            this.chbSyntaxColoring.Location = new System.Drawing.Point(20, 223);
+            this.chbSyntaxColoring.Margin = new System.Windows.Forms.Padding(4);
             this.chbSyntaxColoring.Name = "chbSyntaxColoring";
-            this.chbSyntaxColoring.Size = new System.Drawing.Size(98, 17);
+            this.chbSyntaxColoring.Size = new System.Drawing.Size(126, 21);
             this.chbSyntaxColoring.TabIndex = 11;
             this.chbSyntaxColoring.Text = "Syntax coloring";
             this.chbSyntaxColoring.UseVisualStyleBackColor = true;
@@ -233,9 +249,10 @@ namespace FSharpVSPowerTools
             this.chbNavigateTo.AutoSize = true;
             this.chbNavigateTo.Checked = true;
             this.chbNavigateTo.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbNavigateTo.Location = new System.Drawing.Point(16, 157);
+            this.chbNavigateTo.Location = new System.Drawing.Point(21, 193);
+            this.chbNavigateTo.Margin = new System.Windows.Forms.Padding(4);
             this.chbNavigateTo.Name = "chbNavigateTo";
-            this.chbNavigateTo.Size = new System.Drawing.Size(82, 17);
+            this.chbNavigateTo.Size = new System.Drawing.Size(103, 21);
             this.chbNavigateTo.TabIndex = 10;
             this.chbNavigateTo.Text = "NavigateTo";
             this.chbNavigateTo.UseVisualStyleBackColor = true;
@@ -243,9 +260,10 @@ namespace FSharpVSPowerTools
             // chbDepthColorizer
             // 
             this.chbDepthColorizer.AutoSize = true;
-            this.chbDepthColorizer.Location = new System.Drawing.Point(16, 134);
+            this.chbDepthColorizer.Location = new System.Drawing.Point(21, 165);
+            this.chbDepthColorizer.Margin = new System.Windows.Forms.Padding(4);
             this.chbDepthColorizer.Name = "chbDepthColorizer";
-            this.chbDepthColorizer.Size = new System.Drawing.Size(166, 17);
+            this.chbDepthColorizer.Size = new System.Drawing.Size(215, 21);
             this.chbDepthColorizer.TabIndex = 9;
             this.chbDepthColorizer.Text = "Indent guides/Depth colorizer";
             this.chbDepthColorizer.UseVisualStyleBackColor = true;
@@ -255,9 +273,10 @@ namespace FSharpVSPowerTools
             this.chbRenameRefactoring.AutoSize = true;
             this.chbRenameRefactoring.Checked = true;
             this.chbRenameRefactoring.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbRenameRefactoring.Location = new System.Drawing.Point(16, 110);
+            this.chbRenameRefactoring.Location = new System.Drawing.Point(21, 135);
+            this.chbRenameRefactoring.Margin = new System.Windows.Forms.Padding(4);
             this.chbRenameRefactoring.Name = "chbRenameRefactoring";
-            this.chbRenameRefactoring.Size = new System.Drawing.Size(119, 17);
+            this.chbRenameRefactoring.Size = new System.Drawing.Size(155, 21);
             this.chbRenameRefactoring.TabIndex = 8;
             this.chbRenameRefactoring.Text = "Rename refactoring";
             this.chbRenameRefactoring.UseVisualStyleBackColor = true;
@@ -267,9 +286,10 @@ namespace FSharpVSPowerTools
             this.chbHighlightUsage.AutoSize = true;
             this.chbHighlightUsage.Checked = true;
             this.chbHighlightUsage.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbHighlightUsage.Location = new System.Drawing.Point(16, 87);
+            this.chbHighlightUsage.Location = new System.Drawing.Point(21, 107);
+            this.chbHighlightUsage.Margin = new System.Windows.Forms.Padding(4);
             this.chbHighlightUsage.Name = "chbHighlightUsage";
-            this.chbHighlightUsage.Size = new System.Drawing.Size(120, 17);
+            this.chbHighlightUsage.Size = new System.Drawing.Size(157, 21);
             this.chbHighlightUsage.TabIndex = 7;
             this.chbHighlightUsage.Text = "Highlight references";
             this.chbHighlightUsage.UseVisualStyleBackColor = true;
@@ -277,9 +297,10 @@ namespace FSharpVSPowerTools
             // chbNavBar
             // 
             this.chbNavBar.AutoSize = true;
-            this.chbNavBar.Location = new System.Drawing.Point(16, 63);
+            this.chbNavBar.Location = new System.Drawing.Point(21, 78);
+            this.chbNavBar.Margin = new System.Windows.Forms.Padding(4);
             this.chbNavBar.Name = "chbNavBar";
-            this.chbNavBar.Size = new System.Drawing.Size(110, 17);
+            this.chbNavBar.Size = new System.Drawing.Size(141, 21);
             this.chbNavBar.TabIndex = 6;
             this.chbNavBar.Text = "Navigation bar ***";
             this.chbNavBar.UseVisualStyleBackColor = true;
@@ -288,27 +309,30 @@ namespace FSharpVSPowerTools
             // 
             this.lblInfo.AutoSize = true;
             this.lblInfo.ForeColor = System.Drawing.SystemColors.HotTrack;
-            this.lblInfo.Location = new System.Drawing.Point(13, 255);
+            this.lblInfo.Location = new System.Drawing.Point(15, 334);
+            this.lblInfo.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblInfo.Name = "lblInfo";
-            this.lblInfo.Size = new System.Drawing.Size(331, 13);
+            this.lblInfo.Size = new System.Drawing.Size(444, 17);
             this.lblInfo.TabIndex = 5;
             this.lblInfo.Text = "You must restart Visual Studio in order for the changes to take effect.";
             // 
             // lblTitle
             // 
             this.lblTitle.AutoSize = true;
-            this.lblTitle.Location = new System.Drawing.Point(13, 271);
+            this.lblTitle.Location = new System.Drawing.Point(15, 354);
+            this.lblTitle.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblTitle.Name = "lblTitle";
-            this.lblTitle.Size = new System.Drawing.Size(95, 13);
+            this.lblTitle.Size = new System.Drawing.Size(128, 17);
             this.lblTitle.TabIndex = 4;
             this.lblTitle.Text = "Visit user guides at";
             // 
             // lblHome
             // 
             this.lblHome.AutoSize = true;
-            this.lblHome.Location = new System.Drawing.Point(114, 271);
+            this.lblHome.Location = new System.Drawing.Point(150, 354);
+            this.lblHome.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblHome.Name = "lblHome";
-            this.lblHome.Size = new System.Drawing.Size(254, 13);
+            this.lblHome.Size = new System.Drawing.Size(329, 17);
             this.lblHome.TabIndex = 3;
             this.lblHome.TabStop = true;
             this.lblHome.Text = "http://fsprojects.github.io/VisualFSharpPowerTools/";
@@ -319,9 +343,10 @@ namespace FSharpVSPowerTools
             this.chbFormatting.AutoSize = true;
             this.chbFormatting.Checked = true;
             this.chbFormatting.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbFormatting.Location = new System.Drawing.Point(16, 40);
+            this.chbFormatting.Location = new System.Drawing.Point(21, 49);
+            this.chbFormatting.Margin = new System.Windows.Forms.Padding(4);
             this.chbFormatting.Name = "chbFormatting";
-            this.chbFormatting.Size = new System.Drawing.Size(136, 17);
+            this.chbFormatting.Size = new System.Drawing.Size(177, 21);
             this.chbFormatting.TabIndex = 2;
             this.chbFormatting.Text = "Source code formatting";
             this.chbFormatting.UseVisualStyleBackColor = true;
@@ -331,10 +356,11 @@ namespace FSharpVSPowerTools
             this.chbXmlDoc.AutoSize = true;
             this.chbXmlDoc.Checked = true;
             this.chbXmlDoc.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbXmlDoc.Location = new System.Drawing.Point(16, 16);
+            this.chbXmlDoc.Location = new System.Drawing.Point(21, 20);
+            this.chbXmlDoc.Margin = new System.Windows.Forms.Padding(4);
             this.chbXmlDoc.Name = "chbXmlDoc";
             this.chbXmlDoc.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.chbXmlDoc.Size = new System.Drawing.Size(141, 17);
+            this.chbXmlDoc.Size = new System.Drawing.Size(184, 21);
             this.chbXmlDoc.TabIndex = 1;
             this.chbXmlDoc.Text = "Auto-generating XmlDoc";
             this.chbXmlDoc.UseVisualStyleBackColor = true;
@@ -344,20 +370,35 @@ namespace FSharpVSPowerTools
             this.chbGenerateReferences.AutoSize = true;
             this.chbGenerateReferences.Checked = true;
             this.chbGenerateReferences.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbGenerateReferences.Location = new System.Drawing.Point(204, 228);
+            this.chbGenerateReferences.Location = new System.Drawing.Point(272, 281);
+            this.chbGenerateReferences.Margin = new System.Windows.Forms.Padding(4);
             this.chbGenerateReferences.Name = "chbGenerateReferences";
-            this.chbGenerateReferences.Size = new System.Drawing.Size(157, 17);
+            this.chbGenerateReferences.Size = new System.Drawing.Size(207, 21);
             this.chbGenerateReferences.TabIndex = 20;
             this.chbGenerateReferences.Text = "Generate references for FSI";
             this.chbGenerateReferences.UseVisualStyleBackColor = true;
             // 
+            // chbCSharpTypos
+            // 
+            this.chbCSharpTypos.AutoSize = true;
+            this.chbCSharpTypos.Checked = true;
+            this.chbCSharpTypos.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chbCSharpTypos.Location = new System.Drawing.Point(272, 309);
+            this.chbCSharpTypos.Margin = new System.Windows.Forms.Padding(4);
+            this.chbCSharpTypos.Name = "chbCSharpTypos";
+            this.chbCSharpTypos.Size = new System.Drawing.Size(180, 21);
+            this.chbCSharpTypos.TabIndex = 21;
+            this.chbCSharpTypos.Text = "Correct typical C#-typos";
+            this.chbCSharpTypos.UseVisualStyleBackColor = true;
+            // 
             // GeneralOptionsControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.grbOptions);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "GeneralOptionsControl";
-            this.Size = new System.Drawing.Size(559, 310);
+            this.Size = new System.Drawing.Size(745, 396);
             this.Load += new System.EventHandler(this.GeneralOptionsControl_Load);
             this.grbOptions.ResumeLayout(false);
             this.grbOptions.PerformLayout();
@@ -391,5 +432,6 @@ namespace FSharpVSPowerTools
         private System.Windows.Forms.CheckBox chbGoToMetadata;
         private System.Windows.Forms.CheckBox chbUnusedOpens;
         private System.Windows.Forms.CheckBox chbGenerateReferences;
+        private System.Windows.Forms.CheckBox chbCSharpTypos;
     }
 }

--- a/src/FSharpVSPowerTools/GeneralOptionsControl.cs
+++ b/src/FSharpVSPowerTools/GeneralOptionsControl.cs
@@ -125,6 +125,12 @@ namespace FSharpVSPowerTools
             set { chbGenerateReferences.Checked = value; }
         }
 
+        public bool CSharpToFSharpEnabled
+        {
+            get { return chbCSharpTypos.Checked; }
+            set { chbCSharpTypos.Checked = value; }
+        }
+
         private void GeneralOptionsControl_Load(object sender, EventArgs e)
         {
             XmlDocEnabled = _optionsPage.XmlDocEnabled;

--- a/src/FSharpVSPowerTools/GeneralOptionsPage.cs
+++ b/src/FSharpVSPowerTools/GeneralOptionsPage.cs
@@ -43,6 +43,7 @@ namespace FSharpVSPowerTools
             TaskListCommentsEnabled = true;
             GoToMetadataEnabled = true;
             GenerateReferencesEnabled = true;
+            CSharpToFSharpEnabled = true;
         }
 
         private bool GetNavigationBarConfig()
@@ -166,6 +167,8 @@ namespace FSharpVSPowerTools
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool GenerateReferencesEnabled { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public bool CSharpToFSharpEnabled { get; set; }
 
         [Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         protected override IWin32Window Window
@@ -208,6 +211,7 @@ namespace FSharpVSPowerTools
                 TaskListCommentsEnabled = _optionsControl.TaskListCommentsEnabled;
                 GoToMetadataEnabled = _optionsControl.GoToMetadataEnabled;
                 GenerateReferencesEnabled = _optionsControl.GenerateReferencesEnabled;
+                CSharpToFSharpEnabled = _optionsControl.CSharpToFSharpEnabled;
             }
 
             base.OnApply(e);


### PR DESCRIPTION
Some easy common typos are replaced while you write:
var to let,
C#/ES6 lambda to F#-lambda