### PR TITLE
Fix inconsistent coloring during editing

### DIFF
--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -188,7 +188,8 @@ type SyntaxConstructClassifier
                     |> Map.ofArray
                                
                 fastState.Swap (function
-                    | FastStage.Data data -> FastStage.Data { data with Spans = spans; SingleSymbolsProjects = [] }
+                    | FastStage.Data data -> 
+                        FastStage.Data { data with Snapshot = snapshot; Spans = spans; SingleSymbolsProjects = [] }
                     | state -> state)
                     |> ignore
                 

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -355,12 +355,12 @@ type SyntaxConstructClassifier
                 | _ -> ()))
         else None
         
-    let getClassificationSpans (snapshotSpan: SnapshotSpan) =
+    let getClassificationSpans (targetSnapshotSpan: SnapshotSpan) =
         match fastState.Value with
         | FastStage.Data { FastStageData.Snapshot = snapshot; Spans = spans }
         | FastStage.Updating (Some { FastStageData.Snapshot = snapshot; Spans = spans }, _) ->
-            let spanStartLine = snapshotSpan.Start.GetContainingLine().LineNumber + 1
-            let spanEndLine = snapshotSpan.End.GetContainingLine().LineNumber + 1
+            let spanStartLine = targetSnapshotSpan.Start.GetContainingLine().LineNumber + 1
+            let spanEndLine = targetSnapshotSpan.End.GetContainingLine().LineNumber + 1
             let spans =
                 spans
                 // Locations are sorted, so we can safely filter them efficiently
@@ -372,8 +372,8 @@ type SyntaxConstructClassifier
                         let origSnapshot = columnSpan.Snapshot |> Option.getOrElse snapshot
                         let! span = fromRange origSnapshot (columnSpan.WordSpan.ToRange())
                         let span = 
-                            if snapshotSpan.Snapshot <> snapshot then
-                                span.TranslateTo(snapshotSpan.Snapshot, SpanTrackingMode.EdgeExclusive)  
+                            if targetSnapshotSpan.Snapshot <> span.Snapshot then
+                                span.TranslateTo(targetSnapshotSpan.Snapshot, SpanTrackingMode.EdgeExclusive)  
                             else span
                         // Translate the span to the new snapshot
                         return clType, span 

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -263,6 +263,7 @@ type SyntaxConstructClassifier
 
                     let spans = pf.Time "getCategoriesAndLocations" <| fun _ ->
                         getCategoriesAndLocations (allSymbolsUses, checkResults, lexer, getTextLineOneBased, [], None)
+                        |> Array.map (fun span -> { span with Snapshot = Some snapshot })
                         |> Array.sortBy (fun { WordSpan = { Line = line }} -> line)
 
                     let spans = 


### PR DESCRIPTION
The idea that we used to get current fresh snapshot inside `triggerClassificationChanged`, then tried to translate calculated spans to it. Now the very same snapshot on which the spans are calculated is explicitly passed to `triggerClassificationChanged`, so almost no translation is needed (for previously calculated Unused spans only) and it seems to fix the annoying inconsistent colorization during editing. 

Please, use it in your daily work and keep an eye on any colorization glitches. 