### PR TITLE
Operator coloring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ paket-files
 *.xml
 
 release.cmd
+_NCrunch_*

--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -121,11 +121,13 @@ type AllowStaleResults =
     | No
 
 type WordSpan = 
-    { Line: int
+    { SymbolKind: SymbolKind
+      Line: int
       StartCol: int
       EndCol: int }
-    static member FromRange (r: Range.range) = 
-        { Line = r.StartLine
+    static member FromRange kind (r: Range.range) = 
+        { SymbolKind = kind
+          Line = r.StartLine
           StartCol = r.StartColumn 
           EndCol = r.EndColumn }
     member x.ToRange() = x.Line, x.StartCol, x.Line, x.EndCol

--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -136,8 +136,10 @@ type WordSpan =
 type LexerBase() = 
     abstract GetSymbolFromTokensAtLocation: FSharpTokenInfo list * line: int * rightCol: int -> Symbol option
     abstract TokenizeLine: line: int -> FSharpTokenInfo list
+    abstract LineCount: int
     member x.GetSymbolAtLocation (line: int, col: int) =
            x.GetSymbolFromTokensAtLocation (x.TokenizeLine line, line, col)
+    member x.TokenizeAll() = [|0..x.LineCount-1|] |> Array.map x.TokenizeLine
 
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 

--- a/src/FSharpVSPowerTools.Core/Lexer.fs
+++ b/src/FSharpVSPowerTools.Core/Lexer.fs
@@ -31,6 +31,8 @@ type internal DraftToken =
         { Kind = kind; Token = token; RightColumn = token.LeftColumn + token.FullMatchedLength - 1 }
 
 module Lexer =
+    open Microsoft.FSharp.Compiler
+
     /// Get the array of all lex states in current source
     let internal getLexStates defines (source: string) =
         [|
@@ -88,9 +90,9 @@ module Lexer =
         let isOperator t = t.ColorClass = FSharpTokenColorKind.Operator
     
         let (|GenericTypeParameterPrefix|StaticallyResolvedTypeParameterPrefix|Other|) token =
-            match token.TokenName with
-            | "QUOTE" -> GenericTypeParameterPrefix
-            | "INFIX_AT_HAT_OP" ->
+            match Parser.tokenTagToTokenId token.Tag with
+            | Parser.TOKEN_QUOTE -> GenericTypeParameterPrefix
+            | Parser.TOKEN_INFIX_AT_HAT_OP ->
                  // The lexer return INFIX_AT_HAT_OP token for both "^" and "@" symbols.
                  // We have to check the char itself to distingush one from another.
                  if token.FullMatchedLength = 1 && lineStr.[token.LeftColumn] = '^' then 

--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -152,7 +152,8 @@ module private OperatorCategorizer =
                         match Parser.tokenTagToTokenId t.Tag with 
                         | Parser.TOKEN_EQUALS 
                         | Parser.TOKEN_COLON_GREATER
-                        | Parser.TOKEN_COLON_QMARK_GREATER -> 
+                        | Parser.TOKEN_COLON_QMARK_GREATER 
+                        | Parser.TOKEN_COLON_QMARK -> 
                             Some (t.LeftColumn, t.RightColumn + 1)
                         | _ -> None)
                     // pick tokens which are not overlapped with any symbols

--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -155,8 +155,8 @@ module private OperatorCategorizer =
                         match spansByLine |> Map.tryFind (line + 1) with
                         | Some spans -> 
                             spans |> Seq.exists (fun s -> 
-                                (lCol < s.StartCol - 1 || lCol > s.EndCol - 1)
-                                && (rCol < s.StartCol - 1  || rCol > s.EndCol - 1))
+                                (lCol < s.StartCol && rCol < s.StartCol) || 
+                                (lCol > s.EndCol && rCol > s.EndCol))
                         | None -> true)
                     |> List.map (fun (lCol, rCol) ->
                         { Category = Category.Operator

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -52,6 +52,13 @@ module Array =
         |> snd 
         |> List.toArray
 
+    let foldi (folder : 'State -> int -> 'T -> 'State) (state : 'State) (array : 'T[]) =
+        let mutable state = state
+        let len = array.Length
+        for i = 0 to len - 1 do
+            state <- folder state i array.[i]
+        state
+
 [<RequireQualifiedAccess>]
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Option =

--- a/src/FSharpVSPowerTools.Logic/Constants.fs
+++ b/src/FSharpVSPowerTools.Logic/Constants.fs
@@ -36,6 +36,7 @@ let [<Literal>] fsharpModule = "FSharp.Module"
 let [<Literal>] fsharpUnused = "FSharp.Unused"
 let [<Literal>] fsharpPrintf = "FSharp.Printf"
 let [<Literal>] fsharpEscaped = "FSharp.Escaped"
+let [<Literal>] fsharpOperator = "FSharp.Operator"
 
 let [<Literal>] depthAdornmentLayerName = "FSharpDepthFullLineAdornment"
 

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -64,6 +64,7 @@ type SyntaxConstructClassifier
         | Category.Unused -> Some Constants.fsharpUnused
         | Category.Printf -> Some Constants.fsharpPrintf
         | Category.Escaped -> Some Constants.fsharpEscaped
+        | Category.Operator -> Some Constants.fsharpOperator
         | _ -> None
         |> Option.map classificationRegistry.GetClassificationType
 

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -227,16 +227,20 @@ type VSLanguageService
         }
 
     member __.CreateLexer (snapshot, args) =
+        let lineStart, _, lineEnd, _ = SnapshotSpan(snapshot, 0, snapshot.Length).ToRange()
+        
         let getLineStr line =
-            let lineStart,_,_,_ = SnapshotSpan(snapshot, 0, snapshot.Length).ToRange()
             let lineNumber = line - lineStart
             snapshot.GetLineFromLineNumber(lineNumber).GetText() 
+        
         let source = snapshot.GetText()
+        
         { new LexerBase() with
             member __.GetSymbolFromTokensAtLocation (tokens, line, rightCol) =
                 Lexer.getSymbolFromTokens tokens line rightCol (getLineStr line) SymbolLookupKind.ByRightColumn
             member __.TokenizeLine line =
-                Lexer.tokenizeLine source args line (getLineStr line) (buildQueryLexState snapshot.TextBuffer) }
+                Lexer.tokenizeLine source args line (getLineStr line) (buildQueryLexState snapshot.TextBuffer)
+            member __.LineCount = lineEnd + 1 }
 
     member x.GetAllUsesOfAllSymbolsInFile (snapshot: ITextSnapshot, currentFile: string, project: IProjectProvider, stale,
                                             checkForUnusedOpens: bool, profiler: Profiler) = 

--- a/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
@@ -28,6 +28,7 @@ namespace FSharpVSPowerTools
         public const string FSharpUnused = Constants.fsharpUnused;
         public const string FSharpPrintf = Constants.fsharpPrintf;
         public const string FSharpEscaped = Constants.fsharpEscaped;
+        public const string FSharpOperator = Constants.fsharpOperator;
 
         [Export]
         [Name(FSharpReferenceType)]
@@ -78,6 +79,11 @@ namespace FSharpVSPowerTools
         [Name(FSharpEscaped)]
         [BaseDefinition("identifier")]
         internal static ClassificationTypeDefinition FSharpEscapedClassificationType = null;
+
+        [Export]
+        [Name(FSharpOperator)]
+        [BaseDefinition("identifier")]
+        internal static ClassificationTypeDefinition FSharpOperatorClassificationType = null;
     }
 
     public class FontColor
@@ -114,7 +120,8 @@ namespace FSharpVSPowerTools
                 { ClassificationTypes.FSharpModule, new FontColor(Color.FromRgb(43, 145, 175)) },
                 { ClassificationTypes.FSharpUnused, new FontColor(Color.FromRgb(157, 157, 157)) },
                 { ClassificationTypes.FSharpPrintf, new FontColor(Color.FromRgb(43, 145, 175)) },
-                { ClassificationTypes.FSharpEscaped, new FontColor(Color.FromRgb(255, 0, 128)) }
+                { ClassificationTypes.FSharpEscaped, new FontColor(Color.FromRgb(255, 0, 128)) },
+                { ClassificationTypes.FSharpOperator, new FontColor(Colors.Black) }
             };
 
             themeColors.Add(VisualStudioTheme.Blue, lightAndBlueColors);
@@ -133,7 +140,8 @@ namespace FSharpVSPowerTools
                 { ClassificationTypes.FSharpModule, new FontColor(Color.FromRgb(78, 201, 176)) },
                 { ClassificationTypes.FSharpUnused, new FontColor(Color.FromRgb(155, 155, 155)) },
                 { ClassificationTypes.FSharpPrintf, new FontColor(Color.FromRgb(78, 220, 176)) },
-                { ClassificationTypes.FSharpEscaped, new FontColor(Color.FromRgb(190, 0, 94)) }
+                { ClassificationTypes.FSharpEscaped, new FontColor(Color.FromRgb(190, 0, 94)) },
+                { ClassificationTypes.FSharpOperator, new FontColor(Color.FromRgb(220, 220, 220)) }
             };
 
             themeColors.Add(VisualStudioTheme.Dark, darkColors);
@@ -387,6 +395,23 @@ namespace FSharpVSPowerTools
              {
                  this.DisplayName = "F# Escaped Characters";
                  var colors = colorManager.GetDefaultColors(ClassificationTypes.FSharpEscaped);
+                 this.ForegroundColor = colors.Foreground;
+                 this.BackgroundColor = colors.Background;
+             }
+        }
+
+        [Export(typeof(EditorFormatDefinition))]
+        [ClassificationType(ClassificationTypeNames = ClassificationTypes.FSharpOperator)]
+        [Name(ClassificationTypes.FSharpOperator)]
+        [UserVisible(true)]
+        [Order(After = Priority.Low, Before = Priority.Default)]
+        internal sealed class FSharpOperatorFormat : ClassificationFormatDefinition
+        {
+             [ImportingConstructor]
+             public FSharpOperatorFormat(ClassificationColorManager colorManager)
+             {
+                 this.DisplayName = "F# Operators";
+                 var colors = colorManager.GetDefaultColors(ClassificationTypes.FSharpOperator);
                  this.ForegroundColor = colors.Foreground;
                  this.BackgroundColor = colors.Background;
              }

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -26,6 +26,8 @@ let sourceFiles = [| fileName |]
 let framework = FSharpTargetFramework.NET_4_5
 let languageService = LanguageService()
 
+type private Cat = Category
+
 let opts source = 
     let opts = 
         languageService.GetCheckerOptions (fileName, projectFileName, source, sourceFiles, LanguageServiceTestHelper.args, [||], framework) 
@@ -44,7 +46,8 @@ let (=>) source (expected: (int * ((Category * int * int) list)) list) =
                 Lexer.getSymbol source line col lineStr SymbolLookupKind.ByRightColumn LanguageServiceTestHelper.args Lexer.queryLexState
             member __.TokenizeLine line =
                 let lineStr = sourceLines.[line]
-                Lexer.tokenizeLine source LanguageServiceTestHelper.args line lineStr Lexer.queryLexState }
+                Lexer.tokenizeLine source LanguageServiceTestHelper.args line lineStr Lexer.queryLexState 
+            member __.LineCount = sourceLines.Length }
 
     let symbolsUses = 
         async {
@@ -97,7 +100,7 @@ let (=>) source (expected: (int * ((Category * int * int) list)) list) =
                 spans
                 |> Seq.choose (fun span ->
                     match span.Category with 
-                    | Category.Other -> None
+                    | Cat.Other -> None
                     | _ -> Some (span.Category, span.WordSpan.StartCol, span.WordSpan.EndCol))
                 |> Seq.sortBy (fun (_, startCol, _) -> startCol)
                 |> Seq.toList
@@ -110,8 +113,10 @@ let (=>) source (expected: (int * ((Category * int * int) list)) list) =
         |> List.sortBy (fun (line, _) -> line)
     
     try actual |> Collection.assertEquiv expected
-    with _ -> 
+    with e -> 
         debug "AST: %A" (checkResults.GetUntypedAst())
+        for x in actual do
+            debug "Actual: %A" x
         reraise()
 
 [<Test>]
@@ -119,39 +124,42 @@ let ``module value``() =
     """
 let moduleValue = 1
 """
-    => [2, []]
+    => [2, [Cat.Operator, 16, 17]]
 
 [<Test>]
 let ``module function``() = 
     """
 let moduleFunction x = x + 1
 """
-    => [ 2, [ Category.Function, 4, 18; Category.Operator, 25, 26 ]]
+    => [ 2, [ Cat.Function, 4, 18; Cat.Operator, 21, 22; Cat.Operator, 25, 26 ]]
 
 [<Test>]
 let ``module higher order function``() = 
     """
 let higherOrderFunction func x = (func x) - 1
 """
-   => [ 2, [ Category.Function, 24, 28; Category.Function, 34, 38; Category.Function, 4, 23; Category.Operator, 42, 43 ]]
+   => [ 2, [ Cat.Function, 24, 28; Cat.Function, 34, 38; Cat.Function, 4, 23; Cat.Operator, 31, 32; Cat.Operator, 42, 43 ]]
 
 [<Test>]
 let ``class let value``() = 
     """
 type Class() =
     let value = 1
-    member x.M = value
+    member __.M = value
 """
-    => [ 3, []]
+    => [ 2, [ Cat.ReferenceType, 5, 10; Cat.Operator, 13, 14 ]
+         3, [ Cat.Operator, 14, 15 ]
+         4, [ Cat.Operator, 16, 17 ]]
 
 [<Test>]
 let ``class let function``() = 
     """
 type Class() =
     let classLetFunction x = x
-    member x.M = classLetFunction 1
+    member __.M = classLetFunction 1
 """
-    => [ 3, [ Category.Function, 8, 24 ]]
+    => [ 3, [ Cat.Function, 8, 24; Cat.Operator, 27, 28 ]
+         4, [ Cat.Function, 18, 34; Cat.Operator, 16, 17 ]]
 
 [<Test>]
 let ``class method``() = 
@@ -159,7 +167,7 @@ let ``class method``() =
 type Class() =
     member __.Method _ = ()
 """
-   => [ 3, [ Category.Function, 14, 20 ]]
+   => [ 3, [ Cat.Function, 14, 20; Cat.Operator, 23, 24 ]]
 
 [<Test>]
 let ``class property``() = 
@@ -167,7 +175,7 @@ let ``class property``() =
 type Class() =
     member __.Prop = ()
 """
-   => [ 3, []]
+   => [ 3, [ Cat.Operator, 19, 20]]
 
 [<Test>]
 let ``static method``() = 
@@ -175,7 +183,7 @@ let ``static method``() =
 type Class() =
     static member Method _ = ()
 """
-    => [3, [ Category.Function, 18, 24 ]]
+    => [3, [ Cat.Function, 18, 24; Cat.Operator, 27, 28 ]]
 
 [<Test>]
 let ``static property``() = 
@@ -183,7 +191,7 @@ let ``static property``() =
 type Class() =
     static member StaticProperty = 1
 """
-    => [ 3, []]
+    => [ 3, [ Cat.Operator, 33, 34 ]]
 
 [<Test>]
 let ``event``() = 
@@ -192,8 +200,8 @@ type Class() =
     let event = Event<_>()
     member __.Event = event.Publish
 """
-    => [ 3, [ Category.ReferenceType, 16, 21 ]
-         4, []]
+    => [ 3, [  Cat.Operator, 14, 15; Cat.ReferenceType, 16, 21 ]
+         4, [ Cat.Operator, 20, 21 ]]
 
 [<Test>]
 let ``static event``() = 
@@ -202,8 +210,8 @@ type Class() =
     static let staticEvent = Event<_>()
     static member StaticEvent = staticEvent.Publish
 """
-    => [ 3, [ Category.ReferenceType, 29, 34 ]
-         4, []]
+    => [ 3, [  Cat.Operator, 27, 28; Cat.ReferenceType, 29, 34 ]
+         4, [ Cat.Operator, 30, 31 ]]
           
 [<Test>]
 let ``class constructor``() = 
@@ -211,8 +219,8 @@ let ``class constructor``() =
 type Class() =
     new (_: int) = new Class()
 """
-    => [ 2, [ Category.ReferenceType, 5, 10 ]
-         3, [ Category.ValueType, 12, 15; Category.ReferenceType, 23, 28 ]]
+    => [ 2, [ Cat.ReferenceType, 5, 10; Cat.Operator, 13, 14 ]
+         3, [ Cat.ValueType, 12, 15; Cat.Operator, 17, 18; Cat.ReferenceType, 23, 28 ]]
 
 [<Test>]
 let ``generic class constructor``() = 
@@ -220,8 +228,8 @@ let ``generic class constructor``() =
 type Class<'a>() = class end
     let _ = new Class<_>()
 """
-    => [ 2, [ Category.ReferenceType, 5, 10 ]
-         3, [ Category.ReferenceType, 16, 21 ]]
+    => [ 2, [ Cat.ReferenceType, 5, 10; Cat.Operator, 17, 18 ]
+         3, [ Cat.Operator, 10, 11; Cat.ReferenceType, 16, 21 ]]
 
 [<Test>]
 let ``interface implemented in a class``() = 
@@ -230,8 +238,8 @@ type Class() =
     interface System.IDisposable with
         member __.Dispose() = ()
 """
-    => [ 3, [ Category.ReferenceType, 21, 32 ]
-         4, [ Category.Function, 18, 25 ]]
+    => [ 3, [ Cat.ReferenceType, 21, 32 ]
+         4, [ Cat.Function, 18, 25; Cat.Operator, 28, 29 ]]
 
 [<Test>]
 let ``property with explicit accessors``() = 
@@ -242,15 +250,15 @@ type Class() =
                 and set(_: int) = ()
 """
     => [ 3, [] 
-         4, []
-         5, [ Category.ValueType, 27, 30 ]]
+         4, [ Cat.Operator, 27, 28 ]
+         5, [ Cat.ValueType, 27, 30; Cat.Operator, 32, 33 ]]
 
 [<Test>]
 let ``fully qualified CLI type constructor``() = 
     """
 let dateTime = new System.Net.WebClient()
 """
-    => [ 2, [ Category.ReferenceType, 30, 39 ]]
+    => [ 2, [  Cat.Operator, 13, 14; Cat.ReferenceType, 30, 39 ]]
 
 [<Test>]
 let ``fully qualified F# type constructor``() = 
@@ -261,14 +269,14 @@ module M1 =
 
 let m1m2Type = M1.M2.Type()
 """
-    => [ 6, [ Category.Module, 18, 20; Category.Module, 15, 17; Category.ReferenceType, 21, 25 ]]
+    => [ 6, [  Cat.Operator, 13, 14; Cat.Module, 18, 20; Cat.Module, 15, 17; Cat.ReferenceType, 21, 25 ]]
 
 [<Test>]
 let ``generic class declaration``() = 
     """
 type GenericClass<'T>() = class end
 """
-    => [ 2, [ Category.ReferenceType, 5, 17 ]]
+    => [ 2, [ Cat.ReferenceType, 5, 17; Cat.Operator, 24, 25 ]]
 
 [<Test>]
 let ``generic class instantiation``() = 
@@ -281,9 +289,9 @@ let genericClassOfInt = GenericClass<int>()
 let genericClassOfUserFSharpType = GenericClass<M1.M2.Type>()
 let genericClassOfCLIType = GenericClass<System.DateTime>()
 """
-    => [ 6, [ Category.ReferenceType, 24, 36; Category.ValueType, 37, 40 ]
-         7, [ Category.ReferenceType, 35, 47; Category.Module, 51, 53; Category.Module, 48, 50; Category.ReferenceType, 54, 58 ]
-         8, [ Category.ReferenceType, 28, 40; Category.ValueType, 48, 56 ]]
+    => [ 6, [ Cat.Operator, 22, 23; Cat.ReferenceType, 24, 36; Cat.ValueType, 37, 40 ]
+         7, [ Cat.Operator, 33, 34; Cat.ReferenceType, 35, 47; Cat.Module, 51, 53; Cat.Module, 48, 50; Cat.ReferenceType, 54, 58 ]
+         8, [ Cat.Operator, 26, 27; Cat.ReferenceType, 28, 40; Cat.ValueType, 48, 56 ]]
 
 [<Test>]
 let ``record``() = 
@@ -293,9 +301,10 @@ module M1 =
         type Type() = class end
 type Record = { IntField: int; UserTypeField: M1.M2.Type }
 """
-    => [ 5, [ Category.ReferenceType, 5, 11
-              Category.ValueType, 26, 29
-              Category.Module, 49, 51; Category.Module, 46, 48; Category.ReferenceType, 52, 56 ]]
+    => [ 5, [ Cat.ReferenceType, 5, 11
+              Cat.Operator, 12, 13
+              Cat.ValueType, 26, 29
+              Cat.Module, 49, 51; Cat.Module, 46, 48; Cat.ReferenceType, 52, 56 ]]
 
 [<Test>]
 let ``value type``() = 
@@ -308,13 +317,13 @@ type UserValueTypeAbbriviation = UserValueType
 let userValueType = UserValueType()
 let userValueTypeAbbriviation: UserValueTypeAbbriviation = UserValueTypeAbbriviation()
 """
-    => [ 2, [ Category.ValueType, 27, 30 ]
-         3, [ Category.ValueType, 22, 27 ]
-         4, [ Category.ValueType, 34, 42 ]
-         5, [ Category.ValueType, 5, 18 ]
-         6, [ Category.ValueType, 5, 30; Category.ValueType, 33, 46 ]
-         7, [ Category.ValueType, 20, 33 ] 
-         8, [ Category.ValueType, 31, 56; Category.ValueType, 59, 84 ]]
+    => [ 2, [ Cat.ValueType, 27, 30; Cat.Operator, 31, 32 ]
+         3, [ Cat.ValueType, 22, 27; Cat.Operator, 28, 29 ]
+         4, [ Cat.ValueType, 34, 42; Cat.Operator, 25, 26 ]
+         5, [ Cat.ValueType, 5, 18; Cat.Operator, 19, 20 ]
+         6, [ Cat.ValueType, 5, 30; Cat.Operator, 31, 32; Cat.ValueType, 33, 46 ]
+         7, [ Cat.Operator, 18, 19; Cat.ValueType, 20, 33 ] 
+         8, [ Cat.ValueType, 31, 56; Cat.Operator, 57, 58; Cat.ValueType, 59, 84 ]]
 
 [<Test>]
 let ``DU case of function``() =
@@ -323,23 +332,23 @@ type DUWithFunction = FuncCase of (unit -> unit)
 let (FuncCase funcCase) = FuncCase (fun() -> ())
 match FuncCase (fun() -> ()) with FuncCase func -> func()
 """
-    => [ 2, [ Category.ReferenceType, 5, 19; Category.PatternCase, 22, 30; Category.ReferenceType, 35, 39; Category.ReferenceType, 43, 47 ]
-         3, [ Category.PatternCase, 5, 13; Category.Function, 14, 22; Category.PatternCase, 26, 34 ]
-         4, [ Category.PatternCase, 6, 14; Category.PatternCase, 34, 42; Category.Function, 43, 47; Category.Function, 51, 55 ]]
+    => [ 2, [ Cat.ReferenceType, 5, 19; Cat.Operator, 20, 21; Cat.PatternCase, 22, 30; Cat.ReferenceType, 35, 39; Cat.ReferenceType, 43, 47 ]
+         3, [ Cat.PatternCase, 5, 13; Cat.Function, 14, 22; Cat.Operator, 24, 25; Cat.PatternCase, 26, 34 ]
+         4, [ Cat.PatternCase, 6, 14; Cat.PatternCase, 34, 42; Cat.Function, 43, 47; Cat.Function, 51, 55 ]]
 
 [<Test>]
 let ``double quoted function without spaces``() = 
     """
 let ``double_quoted_function_without_spaces`` () = ()
 """
-    => [ 2, [ Category.Function, 4, 45 ]]
+    => [ 2, [ Cat.Function, 4, 45; Cat.Operator, 49, 50 ]]
 
 [<Test>]
 let ``double quoted function with spaces``() = 
     """
 let ``double quoted function with spaces`` () = ()
 """
-    => [ 2, [ Category.Function, 4, 42 ]]
+    => [ 2, [ Cat.Function, 4, 42; Cat.Operator, 46, 47 ]]
 
 [<Test>]
 let ``fully qualified attribute``() = 
@@ -347,14 +356,14 @@ let ``fully qualified attribute``() =
 [<System.Diagnostics.DebuggerDisplay "name">]
 type TypeWithAttribute() = class end
 """
-    => [ 2, [ Category.ReferenceType, 21, 36 ]]
+    => [ 2, [ Cat.ReferenceType, 21, 36 ]]
 
 [<Test>]
 let ``async type``() = 
     """
 let asyncRunSync = Async.RunSynchronously
 """
-    => [ 2, [ Category.Function, 4, 16; Category.ReferenceType, 19, 24; Category.Function, 25, 41 ]]
+    => [ 2, [ Cat.Function, 4, 16; Cat.Operator, 17, 18; Cat.ReferenceType, 19, 24; Cat.Function, 25, 41 ]]
 
 [<Test>]
 let ``standard computation expression name``() = 
@@ -365,8 +374,8 @@ seq {
 } |> ignore
 """
     => [ 2, []
-         3, [ Category.Function, 8, 12 ]
-         4, [ Category.Function, 10, 14 ]]
+         3, [ Cat.Function, 8, 12; Cat.Operator, 15, 16 ]
+         4, [ Cat.Function, 10, 14 ]]
 
 [<Test>]
 let ``used let bindings in computation expression should not be marked as unused``() = 
@@ -377,8 +386,8 @@ seq {
 } |> ignore
 """
     => [ 2, []
-         3, [ Category.Function, 8, 12 ]
-         4, [ Category.Function, 10, 14 ]]
+         3, [ Cat.Function, 8, 12; Cat.Operator, 15, 16 ]
+         4, [ Cat.Function, 10, 14 ]]
 
 [<Test>]
 let ``user defined computation expression name``() = 
@@ -390,35 +399,35 @@ type CustomBuilder() =
 let customComputationExpression = CustomBuilder()
 let _ = customComputationExpression { add "str" }
 """
-    => [ 7, []]
+    => [ 7, [ Cat.Operator, 6, 7 ]]
 
 [<Test>]
 let ``method chain``() =
     """
 let _ = System.Environment.MachineName.ToLower()
 """
-    => [ 2, [ Category.ReferenceType, 15, 26; Category.Function, 39, 46 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.ReferenceType, 15, 26; Cat.Function, 39, 46 ]]
     
 [<Test>]
 let ``complex method chain``() =
     """
 let _ = System.Guid.NewGuid().ToString("N").Substring(1)
 """
-    => [ 2, [ Category.ValueType, 15, 19; Category.Function, 20, 27; Category.Function, 30, 38; Category.Function, 44, 53 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.ValueType, 15, 19; Cat.Function, 20, 27; Cat.Function, 30, 38; Cat.Function, 44, 53 ]]
 
 [<Test>]
 let ``generic type with ignored type parameter``() = 
     """
 let _ = list<_>.Empty
 """
-    => [ 2, [ Category.ReferenceType, 8, 12 ]]
+    => [ 2, [ Cat.ReferenceType, 8, 12 ]]
 
 [<Test>]
 let ``F# namespace``() = 
     """
 let _ = Microsoft.FSharp.Collections.List<int>.Empty
 """
-    => [ 2, [ Category.ReferenceType, 37, 41; Category.ValueType, 42, 45 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.ReferenceType, 37, 41; Cat.ValueType, 42, 45 ]]
        
 [<Test>]
 let ``double quoted member``() = 
@@ -427,7 +436,7 @@ type System.String with
     member __.``Long func``() = "x"
 let _ = "x".``Long func``().Substring(3)
 """
-    => [ 4, [ Category.Function, 12, 25; Category.Function, 28, 37 ]]
+    => [ 4, [ Cat.Function, 12, 25; Cat.Function, 28, 37 ]]
 
 [<Test; Ignore "WIP">]
 let ``indexer``() = 
@@ -445,7 +454,7 @@ let ``mutable value``() =
     """
 let mutable mutableValue = 1
 """
-    => [ 2,  [ Category.MutableVar, 12, 24 ]]
+    => [ 2,  [ Cat.MutableVar, 12, 24; Cat.Operator, 25, 26 ]]
 
 [<Test>]
 let ``mutable field``() =
@@ -458,9 +467,9 @@ type MutableClass() =
 let func() =
     let mutable mutableLocalVar = 1 in mutableLocalVar
 """
-    => [ 3, [ Category.MutableVar, 14, 26; Category.ValueType, 28, 31 ]
-         5, [ Category.MutableVar, 16, 28 ]
-         8, [ Category.MutableVar, 16, 31; Category.MutableVar, 39, 54 ]]
+    => [ 3, [ Cat.MutableVar, 14, 26; Cat.ValueType, 28, 31 ]
+         5, [ Cat.MutableVar, 16, 28; Cat.Operator, 29, 30 ]
+         8, [ Cat.MutableVar, 16, 31; Cat.Operator, 32, 33; Cat.MutableVar, 39, 54 ]]
 
 [<Test>]
 let ``reference value``() = 
@@ -468,9 +477,9 @@ let ``reference value``() =
 let refValue = ref 1
 refValue := !refValue + 1
 """ 
-    => [ 2, [ Category.MutableVar, 4, 12; Category.Function, 15, 18 ]
-         3, [ Category.MutableVar, 0, 8; Category.Operator, 9, 11; Category.Operator, 12, 13; Category.MutableVar, 13, 21
-              Category.Operator, 22, 23 ]]
+    => [ 2, [ Cat.MutableVar, 4, 12; Cat.Operator, 13, 14; Cat.Function, 15, 18 ]
+         3, [ Cat.MutableVar, 0, 8; Cat.Operator, 9, 11; Cat.Operator, 12, 13; Cat.MutableVar, 13, 21
+              Cat.Operator, 22, 23 ]]
 
 [<Test>]
 let ``reference field``() = 
@@ -481,16 +490,16 @@ type ClassWithRefValue() =
 type RecordWithRefValue = 
     { Field: int ref }
 """
-    => [ 3, [ Category.Function, 19, 22; Category.MutableVar, 8, 16 ]
-         4, [ Category.Operator, 12, 13; Category.MutableVar, 13, 21 ]
-         6, [ Category.MutableVar, 6, 11; Category.ValueType, 13, 16; Category.ReferenceType, 17, 20 ]]
+    => [ 3, [ Cat.Operator, 17, 18; Cat.Function, 19, 22; Cat.MutableVar, 8, 16 ]
+         4, [ Cat.Operator, 10, 11; Cat.Operator, 12, 13; Cat.MutableVar, 13, 21 ]
+         6, [ Cat.MutableVar, 6, 11; Cat.ValueType, 13, 16; Cat.ReferenceType, 17, 20 ]]
 
 [<Test>]
 let ``single line quotation``() = 
     """
 let _ = <@ 1 = 1 @>
 """
-    => [ 2, [ Category.Quotation, 8, 19; Category.Operator, 13, 14 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Quotation, 8, 19; Cat.Operator, 13, 14 ]]
 
 [<Test>]
 let ``multi line quotation``() = 
@@ -498,8 +507,8 @@ let ``multi line quotation``() =
 let _ = <@ 1 = 1
            && 2 = 2 @>
 """
-    => [ 2, [ Category.Quotation, 8, 16; Category.Operator, 13, 14 ]
-         3, [ Category.Operator, 11, 13; Category.Quotation, 11, 22; Category.Operator, 16, 17 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Quotation, 8, 16; Cat.Operator, 13, 14 ]
+         3, [ Cat.Operator, 11, 13; Cat.Quotation, 11, 22; Cat.Operator, 16, 17 ]]
 
 [<Test>]
 let ``quotation as function argument``() = 
@@ -515,11 +524,11 @@ let _ =
 let qf1 (n, e1) = ()
 let _ = qf1 (1, <@ 1 @>)
 """
-    => [ 2, [ Category.Function, 8, 10; Category.Quotation, 11, 22; Category.Operator, 16, 17 ]
-         4, [ Category.Function, 8, 9; Category.Quotation, 10, 21; Category.Operator, 15, 16; Category.Operator, 27, 28; 
-              Category.Quotation, 22, 33 ]
-         9, [ Category.Quotation, 6, 16 ]
-         11, [ Category.Function, 8, 11; Category.Quotation, 16, 23 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Function, 8, 10; Cat.Quotation, 11, 22; Cat.Operator, 16, 17 ]
+         4, [ Cat.Operator, 6, 7; Cat.Function, 8, 9; Cat.Quotation, 10, 21; Cat.Operator, 15, 16;
+              Cat.Quotation, 22, 33; Cat.Operator, 27, 28 ]
+         9, [ Cat.Quotation, 6, 16 ]
+         11, [ Cat.Operator, 6, 7; Cat.Function, 8, 11; Cat.Quotation, 16, 23 ]]
 
 [<Test>]
 let ``quotation in type``() = 
@@ -529,16 +538,16 @@ type TypeWithQuotations() =
     member __.F() = <@ 1 = 1 @>
     member __.P = <@ 1 + 1 @>
 """
-    => [ 3, [ Category.Quotation, 12, 23; Category.Operator, 17, 18 ]
-         4, [ Category.Function, 14, 15; Category.Quotation, 20, 31; Category.Operator, 25, 26 ]
-         5, [ Category.Quotation, 18, 29; Category.Operator, 23, 24 ]]
+    => [ 3, [ Cat.Operator, 10, 11; Cat.Quotation, 12, 23; Cat.Operator, 17, 18 ]
+         4, [ Cat.Function, 14, 15; Cat.Operator, 18, 19; Cat.Quotation, 20, 31; Cat.Operator, 25, 26 ]
+         5, [ Cat.Operator, 16, 17; Cat.Quotation, 18, 29; Cat.Operator, 23, 24 ]]
 
 [<Test>]
 let ``untyped quotation``() = 
     """
 let _ = <@@ 1 @@>
 """
-    => [ 2, [ Category.Quotation, 8, 17 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Quotation, 8, 17 ]]
 
 [<Test>]
 let ``complicated quotation layout``() = 
@@ -548,16 +557,16 @@ let _  = f <@ 1
               + 2
               + 3 @> <@@ 1 @@>
 """
-    => [ 3, [ Category.Function, 9, 10; Category.Quotation, 11, 15 ]
-         4, [ Category.Operator, 14, 15; Category.Quotation, 14, 17 ]
-         5, [ Category.Operator, 14, 15; Category.Quotation, 14, 20; Category.Quotation, 21, 30 ]]
+    => [ 3, [ Cat.Function, 9, 10; Cat.Quotation, 11, 15 ]
+         4, [ Cat.Operator, 14, 15; Cat.Quotation, 14, 17 ]
+         5, [ Cat.Operator, 14, 15; Cat.Quotation, 14, 20; Cat.Quotation, 21, 30 ]]
 
 [<Test>]
 let ``quotation in lambda``() = 
     """
 let _ = fun() -> <@ 1 @>
 """
-    => [ 2, [ Category.Quotation, 17, 24 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Quotation, 17, 24 ]]
 
 [<Test>]
 let ``quotation in record``() = 
@@ -565,21 +574,21 @@ let ``quotation in record``() =
 type RecordWithQuotation = { Field: Microsoft.FSharp.Quotations.Expr<int> }
 let _ = { Field = <@ 1 @> }
 """
-    => [ 3, [ Category.Quotation, 18, 25 ]]
+    => [ 3, [ Cat.Operator, 6, 7; Cat.Operator, 16, 17; Cat.Quotation, 18, 25 ]]
 
 [<Test>]
 let ``quotation in list expression``() = 
     """
 let _ = [ <@ 1 @> ]
 """
-    => [ 2, [ Category.Quotation, 10, 17 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Quotation, 10, 17 ]]
 
 [<Test>]
 let ``quotation in seq for expression``() = 
     """
 let _ = seq { for i in [1..10] -> <@ i @> }
 """
-    => [ 2, [ Category.Quotation, 34, 41 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Quotation, 34, 41 ]]
 
 [<Test>]
 let ``quotation as a result of function``() = 
@@ -587,7 +596,7 @@ let ``quotation as a result of function``() =
 let qf() : Microsoft.FSharp.Quotations.Expr<int> =
     <@ 1 @>
 """
-    => [ 3, [ Category.Quotation, 4, 11 ]]
+    => [ 3, [ Cat.Quotation, 4, 11 ]]
 
 [<Test>]
 let ``quotation as default constructor arguments``() = 
@@ -595,7 +604,7 @@ let ``quotation as default constructor arguments``() =
 type ClassWithQuotationInConstructor(expr) = class end
 let _ = ClassWithQuotationInConstructor(<@ 1 @>)
 """
-    => [ 3, [ Category.ReferenceType, 8, 39; Category.Quotation, 40, 47 ]]
+    => [ 3, [ Cat.ReferenceType, 8, 39; Cat.Quotation, 40, 47 ]]
 
 [<Test>]
 let ``quotation as initialization of auto property``() = 
@@ -603,7 +612,7 @@ let ``quotation as initialization of auto property``() =
 type ClassWithWritableProperty() =
     member val Prop = <@@ 1 @@> with get, set
 """
-    => [ 3, [ Category.MutableVar, 15, 19; Category.Quotation, 22, 31 ]]
+    => [ 3, [ Cat.MutableVar, 15, 19; Cat.Operator, 20, 21; Cat.Quotation, 22, 31 ]]
 
 [<Test>]
 let ``quotation in property setter``() = 
@@ -613,7 +622,7 @@ type ClassWithWritableProperty() =
 let clWithWritableProperty = ClassWithWritableProperty()
 clWithWritableProperty.Prop <- <@@ 2 @@>
 """
-    => [ 5, [ Category.Quotation, 31, 40 ]]
+    => [ 5, [ Cat.Quotation, 31, 40 ]]
 
 [<Test>]
 let ``quotation in nested module``() = 
@@ -621,7 +630,7 @@ let ``quotation in nested module``() =
 module NestedModule =
     let _ = <@ 1 @>
 """
-    => [ 3, [ Category.Quotation, 12, 19 ]]
+    => [ 3, [ Cat.Operator, 10, 11; Cat.Quotation, 12, 19 ]]
 
 [<Test>]
 let ``quotation inside computation expression``() =
@@ -646,15 +655,15 @@ let _ =
             return! ret <@ 1 @>
     }
 """
-    => [ 6, [ Category.Quotation, 16, 23 ]
-         7, [ Category.Function, 11, 17; Category.Quotation, 18, 25 ]
-         8, [ Category.Function, 17, 20; Category.Quotation, 21, 28 ]
-         10, [ Category.Function, 20, 23; Category.Quotation, 24, 31 ]
-         12, [ Category.Function, 20, 23; Category.Quotation, 24, 31 ]
-         13, [ Category.Function, 12, 19; Category.Quotation, 20, 28 ]
-         14, [ Category.Quotation, 14, 21 ]
-         17, [ Category.Quotation, 19, 26 ]
-         19, [ Category.Function, 20, 23; Category.Quotation, 24, 31 ]]
+    => [ 6, [ Cat.Operator, 14, 15; Cat.Quotation, 16, 23 ]
+         7, [ Cat.Function, 11, 17; Cat.Quotation, 18, 25 ]
+         8, [ Cat.Operator, 15, 16; Cat.Function, 17, 20; Cat.Quotation, 21, 28 ]
+         10, [ Cat.Function, 20, 23; Cat.Quotation, 24, 31 ]
+         12, [ Cat.Function, 20, 23; Cat.Quotation, 24, 31 ]
+         13, [ Cat.Function, 12, 19; Cat.Quotation, 20, 28 ]
+         14, [ Cat.Quotation, 14, 21 ]
+         17, [ Cat.Quotation, 19, 26 ]
+         19, [ Cat.Function, 20, 23; Cat.Quotation, 24, 31 ]]
 
 [<Test>]
 let ``quotation in try / with / finally blocks``() =
@@ -672,12 +681,12 @@ async {
     return ()
 }
 """
-    => [3, [ Category.Quotation, 8, 15]
-        4, [ Category.Quotation, 14, 21]
-        5, [ Category.Function, 8, 14; Category.Quotation, 15, 22]
-        9, [ Category.Quotation, 12, 19]
-        10, [ Category.Quotation, 18, 25]
-        11, [ Category.Function, 12, 18; Category.Quotation, 19, 26]
+    => [3, [ Cat.Quotation, 8, 15]
+        4, [ Cat.Quotation, 14, 21]
+        5, [ Cat.Function, 8, 14; Cat.Quotation, 15, 22]
+        9, [ Cat.Quotation, 12, 19]
+        10, [ Cat.Quotation, 18, 25]
+        11, [ Cat.Function, 12, 18; Cat.Quotation, 19, 26]
        ]
 
 [<Test>]
@@ -686,8 +695,8 @@ let ``tuple alias``() =
 type Tuple = int * string
 let tupleFunc (x: Tuple) : Tuple = x
 """
-    => [ 2, [ Category.ReferenceType, 5, 10; Category.ValueType, 13, 16; Category.ReferenceType, 19, 25 ]    
-         3, [ Category.Function, 4, 13; Category.ReferenceType, 18, 23; Category.ReferenceType, 27, 32 ]]
+    => [ 2, [ Cat.ReferenceType, 5, 10; Cat.Operator, 11, 12; Cat.ValueType, 13, 16; Cat.ReferenceType, 19, 25 ]    
+         3, [ Cat.Function, 4, 13; Cat.ReferenceType, 18, 23; Cat.ReferenceType, 27, 32; Cat.Operator, 33, 34 ]]
 
 [<Test>]
 let ``multiline method chain``() = 
@@ -697,8 +706,8 @@ let _ =
         .Substring(1)
         .Trim().Remove(1)
 """
-    => [ 4, [ Category.Function, 9, 18 ]
-         5, [ Category.Function, 9, 13; Category.Function, 16, 22 ]]
+    => [ 4, [ Cat.Function, 9, 18 ]
+         5, [ Cat.Function, 9, 13; Cat.Function, 16, 22 ]]
 
 [<Test>]
 let ``module``() = 
@@ -708,34 +717,36 @@ module Module2 =
     module Module3 =
         let x = ()
 """
-    => [ 2, [ Category.Module, 7, 14 ]
-         3, [ Category.Module, 7, 14 ]
-         4, [ Category.Module, 11, 18 ]]
+    => [ 2, [ Cat.Module, 7, 14 ]
+         3, [ Cat.Module, 7, 14; Cat.Operator, 15, 16 ]
+         4, [ Cat.Module, 11, 18; Cat.Operator, 19, 20 ]]
 
 [<Test>]
 let ``static CLR class``() = 
     """
 let _ = System.Linq.Enumerable.Range(0, 1)
 """
-    => [ 2, [ Category.ReferenceType, 20, 30; Category.Function, 31, 36 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.ReferenceType, 20, 30; Cat.Function, 31, 36 ]]
 
 [<Test>]
 let ``F# external modules``() = 
     """
 let _ = [1] |> Seq.sort |> Seq.toList |> List.rev
 """
-    => [ 2, [ Category.Operator, 12, 14; Category.Module, 15, 18; Category.Function, 19, 23
-              Category.Operator, 24, 26; Category.Module, 27, 30; Category.Function, 31, 37
-              Category.Operator, 38, 40; Category.Module, 41, 45; Category.Function, 46, 49 ]]
+    => [ 2, [ Cat.Operator, 6, 7;
+              Cat.Operator, 12, 14; Cat.Module, 15, 18; Cat.Function, 19, 23
+              Cat.Operator, 24, 26; Cat.Module, 27, 30; Cat.Function, 31, 37
+              Cat.Operator, 38, 40; Cat.Module, 41, 45; Cat.Function, 46, 49 ]]
 
 [<Test>]
 let ``byref argument``() = 
     """
 let ``func with byref arg`` (_: byref<int>) = ()
 """
-    => [ 2, [ Category.Function, 4, 27
-              Category.ReferenceType, 32, 37
-              Category.ValueType, 38, 41 ]]
+    => [ 2, [ Cat.Function, 4, 27
+              Cat.ReferenceType, 32, 37
+              Cat.ValueType, 38, 41
+              Cat.Operator, 44, 45 ]]
 
 [<Test>]
 let ``unit of measure``() =
@@ -746,9 +757,9 @@ let _: int<ms> =
 type RecordWithUnitOfMeasure =
     { Field1: int<ms> }
 """
-    => [ 3, [ Category.ValueType, 7, 10; Category.ReferenceType, 11, 13 ]
-         4, [ Category.ReferenceType, 6, 8 ]
-         6, [ Category.ValueType, 14, 17; Category.ReferenceType, 18, 20 ]]
+    => [ 3, [ Cat.ValueType, 7, 10; Cat.ReferenceType, 11, 13; Cat.Operator, 15, 16 ]
+         4, [ Cat.ReferenceType, 6, 8 ]
+         6, [ Cat.ValueType, 14, 17; Cat.ReferenceType, 18, 20 ]]
 
 [<Test>]
 let ``standard and custom numeric literals``() = 
@@ -758,8 +769,8 @@ module NumericLiteralZ =
     let FromInt32 (i: int) = i
 let _ = 77Z
 """
-    => [ 2, []    
-         5, []]
+    => [ 2, [ Cat.Operator, 6, 7 ]    
+         5, [ Cat.Operator, 6, 7 ]]
 
 [<Test>]
 let ``anonymous generic parameters``() =
@@ -773,20 +784,20 @@ module AnonymousGenericParameters =
     let i () : Map<'a, 'b> = new Map<'a, 'b>([])
     let j () : System.Collections.Generic.List<_> = new System.Collections.Generic.List<_>()
 """
-    => [ 3, [ Category.Function, 8, 10; Category.ReferenceType, 16, 19; Category.ReferenceType, 34, 37 ]
-         4, [ Category.Function, 8, 11; Category.ReferenceType, 16, 19; Category.ReferenceType, 34, 37 ] 
-         5, [ Category.Function, 8, 9; Category.ReferenceType, 15, 18; Category.ReferenceType, 33, 36 ]
-         6, [ Category.Function, 8, 10; Category.ReferenceType, 15, 18; Category.ReferenceType, 33, 36 ] 
-         7, [ Category.Function, 8, 9; Category.ReferenceType, 15, 18; Category.ReferenceType, 33, 36 ]
-         8, [ Category.Function, 8, 9; Category.ReferenceType, 15, 18; Category.ReferenceType, 33, 36 ]
-         9, [ Category.Function, 8, 9; Category.ReferenceType, 42, 46; Category.ReferenceType, 83, 87 ]]
+    => [ 3, [ Cat.Function, 8, 10; Cat.ReferenceType, 16, 19; Cat.Operator, 28, 29; Cat.ReferenceType, 34, 37 ]
+         4, [ Cat.Function, 8, 11; Cat.ReferenceType, 16, 19; Cat.Operator, 28, 29; Cat.ReferenceType, 34, 37 ] 
+         5, [ Cat.Function, 8, 9; Cat.ReferenceType, 15, 18; Cat.Operator, 27, 28; Cat.ReferenceType, 33, 36 ]
+         6, [ Cat.Function, 8, 10; Cat.ReferenceType, 15, 18; Cat.Operator, 27, 28; Cat.ReferenceType, 33, 36 ] 
+         7, [ Cat.Function, 8, 9; Cat.ReferenceType, 15, 18; Cat.Operator, 27, 28; Cat.ReferenceType, 33, 36 ]
+         8, [ Cat.Function, 8, 9; Cat.ReferenceType, 15, 18; Cat.Operator, 27, 28; Cat.ReferenceType, 33, 36 ]
+         9, [ Cat.Function, 8, 9; Cat.ReferenceType, 42, 46; Cat.Operator, 50, 51; Cat.ReferenceType, 83, 87 ]]
 
 [<Test>]
 let ``array alias``() =
     """
 type ArrayAlias = byte[]
 """
-    => [ 2, [ Category.ReferenceType, 5, 15; Category.ValueType, 18, 22 ]]
+    => [ 2, [ Cat.ReferenceType, 5, 15; Cat.Operator, 16, 17; Cat.ValueType, 18, 22 ]]
 
 [<Test; Ignore "Lexer cannot recognize (|P|_|) as an Ident at position of the last bar">]
 let ``active pattern``() =
@@ -794,8 +805,8 @@ let ``active pattern``() =
 let (|ActivePattern|_|) x = Some x
 let _ = (|ActivePattern|_|) 1
 """
-    => [ 2, [ Category.PatternCase, 6, 19; Category.PatternCase, 28, 32 ]
-         3, [ Category.Function, 8, 27 ]]
+    => [ 2, [ Cat.PatternCase, 6, 19; Cat.PatternCase, 28, 32 ]
+         3, [ Cat.Function, 8, 27 ]]
 
 [<Test>]
 let ``non public module``() =
@@ -803,7 +814,7 @@ let ``non public module``() =
 module private PrivateModule =
     let x = ()
 """
-    => [ 2, [ Category.Module, 15, 28 ]]
+    => [ 2, [ Cat.Module, 15, 28; Cat.Operator, 29, 30 ]]
 
 [<Test>]
 let ``unused non public module function and value``() =
@@ -812,15 +823,15 @@ module private PrivateModule =
     let func _ = ()
     let value = ()
 """
-    => [ 3, [ Category.Unused, 8, 12 ]  
-         4, [ Category.Unused, 8, 13 ]]
+    => [ 3, [ Cat.Unused, 8, 12; Cat.Operator, 15, 16 ]  
+         4, [ Cat.Unused, 8, 13; Cat.Operator, 14, 15 ]]
 
 [<Test>]
 let ``unused default constructor of non public class``() =
     """
 type private PrivateClass() = class end
 """
-    => [ 2, [ Category.Unused, 13, 25 ]]
+    => [ 2, [ Cat.Unused, 13, 25; Cat.Operator, 28, 29 ]]
 
 [<Test>]
 let ``unused non public class let binding``() =
@@ -830,8 +841,8 @@ type PublicClass() =
     let letFunc _ = ()
     member __.P = ()
 """
-    => [ 3, [ Category.Unused, 8, 16] 
-         4, [ Category.Unused, 8, 15]]
+    => [ 3, [ Cat.Unused, 8, 16; Cat.Operator, 17, 18 ] 
+         4, [ Cat.Unused, 8, 15; Cat.Operator, 18, 19 ]]
 
 [<Test>]
 let ``unused non public class member``() =
@@ -840,8 +851,8 @@ type PublicClass() =
     member private __.Prop = ()
     member private __.Method _ = ()
 """
-    => [ 3, [ Category.Unused, 22, 26] 
-         4, [ Category.Unused, 22, 28]]
+    => [ 3, [ Cat.Unused, 22, 26; Cat.Operator, 27, 28 ] 
+         4, [ Cat.Unused, 22, 28; Cat.Operator, 31, 32 ]]
 
 [<Test>]
 let ``unused self binding``() =
@@ -849,7 +860,7 @@ let ``unused self binding``() =
 type PublicClass() =
     member this.PublicMethod _ = ()
 """ 
-    => [ 3, [ Category.Unused, 11, 15; Category.Function, 16, 28 ]]
+    => [ 3, [ Cat.Unused, 11, 15; Cat.Function, 16, 28; Cat.Operator, 31, 32 ]]
 
 [<Test>]
 let ``used self binding``() =
@@ -857,7 +868,7 @@ let ``used self binding``() =
 type PublicClass() =
     member this.Method2 _ = this
 """
-    => [ 3, [ Category.Function, 16, 23 ]]
+    => [ 3, [ Cat.Function, 16, 23; Cat.Operator, 26, 27 ]]
 
 [<Test>]
 let ``unused function / member argument``() =
@@ -866,8 +877,8 @@ type PublicClass() =
     member __.Method1 (arg1: int, arg2) = arg2
 let func arg1 arg2 = arg2
 """
-    => [ 3, [ Category.Function, 14, 21; Category.Unused, 23, 27; Category.ValueType, 29, 32 ]
-         4, [ Category.Function, 4, 8; Category.Unused, 9, 13 ]]
+    => [ 3, [ Cat.Function, 14, 21; Cat.Unused, 23, 27; Cat.ValueType, 29, 32; Cat.Operator, 40, 41 ]
+         4, [ Cat.Function, 4, 8; Cat.Unused, 9, 13; Cat.Operator, 19, 20 ]]
 
 [<Test>]
 let ``unused function / member local binding``() =
@@ -880,8 +891,8 @@ let func x =
     let local = 1
     x
 """
-    => [ 4, [ Category.Unused, 12, 17 ]
-         7, [ Category.Unused, 8, 13 ]]
+    => [ 4, [ Cat.Unused, 12, 17; Cat.Operator, 18, 19 ]
+         7, [ Cat.Unused, 8, 13; Cat.Operator, 14, 15 ]]
 
 [<Test>]
 let ``unused DU field names are not marked as unused even though they are not used anywhere``() =
@@ -889,10 +900,11 @@ let ``unused DU field names are not marked as unused even though they are not us
 type DU = Case of field1: int * field2: string
 let _ = Case (1, "")
 """
-    => [ 2, [ Category.ReferenceType, 5, 7
-              Category.PatternCase, 10, 14
-              Category.ValueType, 26, 29
-              Category.ReferenceType, 40, 46 ]]
+    => [ 2, [ Cat.ReferenceType, 5, 7
+              Cat.Operator, 8, 9
+              Cat.PatternCase, 10, 14
+              Cat.ValueType, 26, 29
+              Cat.ReferenceType, 40, 46 ]]
 
 [<Test>]
 let ``unused open declaration in top level module``() =
@@ -903,7 +915,7 @@ open System.IO
 let _ = DateTime.Now
 """
     => [ 3, []
-         4, [ Category.Unused, 5, 14 ]]
+         4, [ Cat.Unused, 5, 14 ]]
          
 [<Test>]
 let ``unused open declaration in namespace``() =
@@ -915,7 +927,7 @@ module Nested =
     let _ = DateTime.Now
 """
     => [ 3, []
-         4, [ Category.Unused, 5, 14 ]]
+         4, [ Cat.Unused, 5, 14 ]]
          
 [<Test>]
 let ``unused open declaration in nested module``() =
@@ -927,7 +939,7 @@ module Nested =
     let _ = DateTime.Now
 """
     => [ 4, []
-         5, [ Category.Unused, 9, 18 ]]
+         5, [ Cat.Unused, 9, 18 ]]
 
 [<Test>] 
 let ``unused open declaration due to partially qualified symbol``() =
@@ -938,7 +950,7 @@ open System.IO
 let _ = IO.File.Create ""
 """
     => [ 3, []
-         4, [ Category.Unused, 5, 14 ]]
+         4, [ Cat.Unused, 5, 14 ]]
 
 [<Test>]
 let ``unused parent open declaration due to partially qualified symbol``() =
@@ -948,7 +960,7 @@ open System
 open System.IO
 let _ = File.Create ""
 """
-    => [ 3, [ Category.Unused, 5, 11 ]
+    => [ 3, [ Cat.Unused, 5, 11 ]
          4, []]
 
 [<Test>]
@@ -960,7 +972,7 @@ module Nested =
     open System.IO
     let _ = File.Create ""
 """
-    => [ 3, [ Category.Unused, 5, 14 ]
+    => [ 3, [ Cat.Unused, 5, 14 ]
          5, []]
 
 [<Test>]
@@ -981,7 +993,7 @@ let ``multiple open declaration in the same line``() =
     """
 open System.IO; let _ = File.Create "";; open System.IO
 """
-    => [ 2, [ Category.ReferenceType, 24, 28; Category.Function, 29, 35; Category.Unused, 46, 55 ]]
+    => [ 2, [ Cat.ReferenceType, 24, 28; Cat.Function, 29, 35; Cat.Unused, 46, 55 ]]
 
 [<Test>]
 let ``open a nested module inside another one is not unused``() =
@@ -1042,7 +1054,7 @@ open NormalModule.AutoOpenModule1.NestedNormalModule.AutoOpenModule2
 open NormalModule.AutoOpenModule1.NestedNormalModule
 let _ = Class()
 """
-    => [ 12, [ Category.Unused, 5, 68 ]
+    => [ 12, [ Cat.Unused, 5, 68 ]
          13, []]
     
 [<Test>]
@@ -1074,7 +1086,7 @@ module Module =
 open Module
 let _ = "a long string".Trim()
 """
-    => [ 5, [ Category.Unused, 5, 11 ]]
+    => [ 5, [ Cat.Unused, 5, 11 ]]
 
 [<Test>]
 let ``open declaration is not marked as unused if an extension method is used``() =
@@ -1099,7 +1111,7 @@ module Module =
 open Module
 let x = Class()
 """
-    => [ 6, [ Category.Unused, 5, 11 ]]
+    => [ 6, [ Cat.Unused, 5, 11 ]]
 
 [<Test>]
 let ``open declaration is not marked as unused if a type from it used in a constructor signarute``() =
@@ -1119,7 +1131,7 @@ module M =
 open M
 type Site (x: int -> unit) = class end
 """
-    => [ 4, [ Category.Unused, 5, 6 ] ]
+    => [ 4, [ Cat.Unused, 5, 6 ] ]
 
 [<Test>]
 let ``static extension method applied to a type results that both namespaces /where the type is declared and where the extension is declared/ is not marked as unudes``() =
@@ -1153,7 +1165,7 @@ module M =
     open System
     let _ = dt.Hour
 """
-    => [4, [ Category.Unused, 9, 15 ]]
+    => [4, [ Cat.Unused, 9, 15 ]]
 
 [<Test>]
 let ``either of two open declarations are not marked as unused if symbols from both of them are used``() =
@@ -1189,7 +1201,7 @@ module M =
 open M
 let _ = M.func 1
 """
-    => [4, [Category.Unused, 5, 6 ]]
+    => [4, [Cat.Unused, 5, 6 ]]
 
 [<Test>]
 let ``open module is not marked as unused if a symbol defined in it is used in OCaml-style type annotation``() =
@@ -1267,7 +1279,7 @@ module M =
     open InternalModuleWithSuffix
     let _ = InternalModuleWithSuffix.func1()
 """
-    => [ 6, [Category.Unused, 9, 33 ]]
+    => [ 6, [Cat.Unused, 9, 33 ]]
     
 [<Test>]
 let ``redundant opening a module is marks as unused``() =
@@ -1278,7 +1290,7 @@ module M =
     open InternalModuleWithSuffix
     let _ = InternalModuleWithSuffix.func1()
 """
-    => [ 5, [Category.Unused, 9, 33 ]]
+    => [ 5, [Cat.Unused, 9, 33 ]]
 
 [<Test>]
 let ``usage of an unqualified union case makes opening module in which it's defined not maked as unused``() =
@@ -1406,7 +1418,7 @@ module Module =
     open ``global``.Namesp
     let _ = System.String("")
 """
-    => [ 3, [Category.Unused, 9, 26]]
+    => [ 3, [Cat.Unused, 9, 26]]
 
 [<Test>]
 let ``record fields should be taken into account``() = 
@@ -1442,7 +1454,7 @@ type IClass() =
 
 let f (x: IClass) = (x :> IInterface).Property
 """
-    => [ 7, []]
+    => [ 7, [ Cat.Operator, 27, 28 ]]
 
 [<Test>]
 let ``active pattern cases should be taken into account``() =
@@ -1472,7 +1484,7 @@ module M =
 open M
 let _ = 1
 """
-    => [ 4, [ Category.Unused, 5, 6 ]]
+    => [ 4, [ Cat.Unused, 5, 6 ]]
     
 [<Test>]
 let ``printf formatters in bindings``() =
@@ -1481,9 +1493,9 @@ let _ = printfn ""
 let _ = printfn "%s %s"
 do printfn "%6d %%  % 06d" 1 2
 """
-    => [ 2, [ Category.Function, 8, 15 ]
-         3, [ Category.Function, 8, 15; Category.Printf, 17, 19; Category.Printf, 20, 22 ]
-         4, [ Category.Function, 3, 10; Category.Printf, 12, 15; Category.Printf, 20, 25 ]]
+    => [ 2, [ Cat.Function, 8, 15 ]
+         3, [ Cat.Function, 8, 15; Cat.Printf, 17, 19; Cat.Printf, 20, 22 ]
+         4, [ Cat.Function, 3, 10; Cat.Printf, 12, 15; Cat.Printf, 20, 25 ]]
 
 [<Test>]
 let ``printf formatters in try / with / finally``() =
@@ -1497,10 +1509,10 @@ try
 with _ ->
     failwithf "foo %d bar" 0
 """
-    =>  [ 3, [ Category.Function, 12, 19; Category.Printf, 25, 27 ]
-          5, [ Category.Function, 8, 15; Category.Printf, 21, 23 ]
-          7, [ Category.Function, 8, 14; Category.Printf, 20, 22 ]
-          9, [ Category.Function, 4, 13; Category.Printf, 19, 21 ]]
+    =>  [ 3, [ Cat.Function, 12, 19; Cat.Printf, 25, 27 ]
+          5, [ Cat.Function, 8, 15; Cat.Printf, 21, 23 ]
+          7, [ Cat.Function, 8, 14; Cat.Printf, 20, 22 ]
+          9, [ Cat.Function, 4, 13; Cat.Printf, 19, 21 ]]
 
 [<Test>]
 let ``printf formatters in record / DU members``() =
@@ -1518,10 +1530,10 @@ type DU = DU
         override __.ToString() = 
             sprintf "%d" 1
 """
-    => [ 5, [ Category.Function, 12, 19; Category.Printf, 21, 23 ]
-         7, [ Category.Function, 12, 19; Category.Printf, 21, 23 ]
-         11, [ Category.Function, 12, 19; Category.Printf, 21, 23 ]
-         13, [ Category.Function, 12, 19; Category.Printf, 21, 23 ]]
+    => [ 5, [ Cat.Function, 12, 19; Cat.Printf, 21, 23 ]
+         7, [ Cat.Function, 12, 19; Cat.Printf, 21, 23 ]
+         11, [ Cat.Function, 12, 19; Cat.Printf, 21, 23 ]
+         13, [ Cat.Function, 12, 19; Cat.Printf, 21, 23 ]]
 
 [<Test>]
 let ``printf formatters in extention members``() =
@@ -1530,19 +1542,19 @@ type System.Object with
     member __.M1 = 
         sprintf "%A" 
 """
-    => [ 4, [ Category.Function, 8, 15; Category.Printf, 17, 19 ]]
+    => [ 4, [ Cat.Function, 8, 15; Cat.Printf, 17, 19 ]]
 
 [<Test>]
 let ``printf formatters in escaped string``() =
     """
 let _ = sprintf @"%A"
 """
-    => [ 2, [ Category.Function, 8, 15; Category.Printf, 18, 20 ]]
+    => [ 2, [ Cat.Function, 8, 15; Cat.Printf, 18, 20 ]]
 
 [<Test>]
 let ``printf formatters in triple-quoted string``() =
     "let _ = sprintf \"\"\"%A\"\"\""
-    => [ 1, [ Category.Function, 8, 15; Category.Printf, 19, 21 ]]
+    => [ 1, [ Cat.Function, 8, 15; Cat.Printf, 19, 21 ]]
 
 [<Test>]
 let ``multiline printf formatters``() =
@@ -1551,9 +1563,9 @@ let _ = printfn "foo %s %d
                  %A bar
 %i"
 """
-    => [ 2, [ Category.Function, 8, 15; Category.Printf, 21, 23; Category.Printf, 24, 26 ] 
-         3, [ Category.Printf, 17, 19 ]
-         4, [ Category.Printf, 0, 2 ] ]
+    => [ 2, [ Cat.Function, 8, 15; Cat.Printf, 21, 23; Cat.Printf, 24, 26 ] 
+         3, [ Cat.Printf, 17, 19 ]
+         4, [ Cat.Printf, 0, 2 ] ]
 
 [<Test>]
 let ``printf formatters in for expressions``() =
@@ -1566,10 +1578,10 @@ for _ in (sprintf "%d" 1).ToCharArray() do
 |> ignore
 
     """
-    => [ 2, [ Category.Function, 10, 17; Category.Printf, 19, 21; Category.Function, 26, 37 ]
-         3, [ Category.Function, 4, 11; Category.Printf, 13, 15]
-         5, [ Category.Function, 12, 19; Category.Printf, 21, 23; Category.Function, 28, 39 ]
-         6, [ Category.Function, 10, 17; Category.Printf, 19, 21]
+    => [ 2, [ Cat.Function, 10, 17; Cat.Printf, 19, 21; Cat.Function, 26, 37 ]
+         3, [ Cat.Function, 4, 11; Cat.Printf, 13, 15]
+         5, [ Cat.Function, 12, 19; Cat.Printf, 21, 23; Cat.Function, 28, 39 ]
+         6, [ Cat.Function, 10, 17; Cat.Printf, 19, 21]
     ]
 
 [<Test>]
@@ -1577,7 +1589,7 @@ let ``printf formatters in quoted expressions``() =
     """
 let _ = <@ sprintf "%A" @>
 """
-    => [ 2, [Category.Function, 11, 18; Category.Printf, 20, 22; Category.Quotation, 8, 26 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Function, 11, 18; Cat.Printf, 20, 22; Cat.Quotation, 8, 26 ]]
 
 [<Test>]
 let ``printf formatters if printf function is namespace qualified``() =
@@ -1586,15 +1598,15 @@ let _ = Microsoft.FSharp.Core.Printf.printf "%A" 0
 open Microsoft.FSharp.Core
 let _ = Printf.printf "%A" 0
 """
-    => [ 2, [ Category.Module, 30, 36; Category.Function, 37, 43; Category.Printf, 45, 47 ]
-         4, [ Category.Module, 8, 14; Category.Function, 15, 21; Category.Printf, 23, 25 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Module, 30, 36; Cat.Function, 37, 43; Cat.Printf, 45, 47 ]
+         4, [ Cat.Operator, 6, 7; Cat.Module, 8, 14; Cat.Function, 15, 21; Cat.Printf, 23, 25 ]]
 
 [<Test>]
 let ``printf formatters are not colorized in plane strings``() =
     """
 let _ = sprintf "foo", "%A"
 """
-    => [ 2, [Category.Function, 8, 15 ]]
+    => [ 2, [Cat.Function, 8, 15 ]]
 
 [<Test>]
 let ``fprintf formatters``() =
@@ -1603,9 +1615,9 @@ let _ = fprintf null "%A" 0
 let _ = Microsoft.FSharp.Core.Printf.fprintf null "%A" 0
 let _ = fprintfn null "%A" 0
 """
-    => [ 2, [Category.Function, 8, 15; Category.Printf, 22, 24 ]
-         3, [Category.Module, 30, 36; Category.Function, 37, 44; Category.Printf, 51, 53 ]
-         4, [Category.Function, 8, 16; Category.Printf, 23, 25 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Function, 8, 15; Cat.Printf, 22, 24 ]
+         3, [ Cat.Operator, 6, 7; Cat.Module, 30, 36; Cat.Function, 37, 44; Cat.Printf, 51, 53 ]
+         4, [ Cat.Operator, 6, 7; Cat.Function, 8, 16; Cat.Printf, 23, 25 ]]
 
 [<Test>]
 let ``kprintf and bprintf formatters``() =
@@ -1613,15 +1625,15 @@ let ``kprintf and bprintf formatters``() =
 let _ = Printf.kprintf (fun _ -> ()) "%A" 1
 let _ = Printf.bprintf null "%A" 1
 """
-    => [ 2, [Category.Module, 8, 14; Category.Function, 15, 22; Category.Printf, 38, 40]
-         3, [Category.Module, 8, 14; Category.Function, 15, 22; Category.Printf, 29, 31]]
+    => [ 2, [Cat.Module, 8, 14; Cat.Function, 15, 22; Cat.Printf, 38, 40]
+         3, [Cat.Module, 8, 14; Cat.Function, 15, 22; Cat.Printf, 29, 31]]
 
 [<Test>]
 let ``wildcards in printf formatters``() =
     """
 let _ = sprintf "%*d" 1
 """
-    => [ 2, [Category.Function, 8, 15; Category.Printf, 17, 20 ]]
+    => [ 2, [Cat.Function, 8, 15; Cat.Printf, 17, 20 ]]
 
 [<Test>]
 let ``float printf formatters``() =
@@ -1629,38 +1641,39 @@ let ``float printf formatters``() =
 let _ = sprintf "%7.1f" 1.0
 let _ = sprintf "%-8.1e+567" 1.0
 """
-    => [ 2, [Category.Function, 8, 15; Category.Printf, 17, 22]
-         3, [Category.Function, 8, 15; Category.Printf, 17, 23]]
+    => [ 2, [Cat.Function, 8, 15; Cat.Printf, 17, 22]
+         3, [Cat.Function, 8, 15; Cat.Printf, 17, 23]]
 
 [<Test>]
 let ``malformed printf formatters``() =
     """
 let _ = sprintf "%.7f %7.1A %7.f %--8.1f"
 """
-    => [ 2, [Category.Function, 8, 15]]
+    => [ 2, [Cat.Function, 8, 15]]
 
 [<Test>]
 let ``all escaped symbols in string``() =
     """    
 let _ = "\n\r \t\b foo \\ \" \' \u08FF \U0102AABB \u012 \U01234"
 """
-    => [ 2, [ Category.Escaped, 9, 11
-              Category.Escaped, 11, 13
-              Category.Escaped, 14, 16
-              Category.Escaped, 16, 18
-              Category.Escaped, 23, 25
-              Category.Escaped, 26, 28
-              Category.Escaped, 29, 31
-              Category.Escaped, 32, 38
-              Category.Escaped, 39, 49 ]]
+    => [ 2, [ Cat.Operator, 6, 7
+              Cat.Escaped, 9, 11
+              Cat.Escaped, 11, 13
+              Cat.Escaped, 14, 16
+              Cat.Escaped, 16, 18
+              Cat.Escaped, 23, 25
+              Cat.Escaped, 26, 28
+              Cat.Escaped, 29, 31
+              Cat.Escaped, 32, 38
+              Cat.Escaped, 39, 49 ]]
 
 [<Test>]
 let ``escaped symbols in multiline string``() =
     """
 let _ = "\n
 \r" """
-    => [ 2, [ Category.Escaped, 9, 11 ]
-         3, [ Category.Escaped, 0, 2 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Escaped, 9, 11 ]
+         3, [ Cat.Escaped, 0, 2 ]]
 
 [<Test>]
 let ``escaped symbols in complex multiline string``() =
@@ -1670,19 +1683,19 @@ let _ = "foo \n bar \r baz
  \r f \t\b \\ 
 \n"
 """
-    => [ 2, [ Category.Escaped, 13, 15; Category.Escaped, 20, 22 ]
-         3, [ Category.Escaped, 0, 2 ]
-         4, [ Category.Escaped, 1, 3; Category.Escaped, 6, 8; Category.Escaped, 8, 10; Category.Escaped, 11, 13 ]
-         5, [ Category.Escaped, 0, 2 ]]
+    => [ 2, [ Cat.Operator, 6, 7; Cat.Escaped, 13, 15; Cat.Escaped, 20, 22 ]
+         3, [ Cat.Escaped, 0, 2 ]
+         4, [ Cat.Escaped, 1, 3; Cat.Escaped, 6, 8; Cat.Escaped, 8, 10; Cat.Escaped, 11, 13 ]
+         5, [ Cat.Escaped, 0, 2 ]]
 
 [<Test>]
 let ``escaped symbols in method chains``() =
     """
 let _ = "a\r\n".Replace("\r\n", "\n").Split('\r')
 """
-    => [ 2, [ Category.Escaped, 10, 12; Category.Escaped, 12, 14; Category.Function, 16, 23
-              Category.Escaped, 25, 27; Category.Escaped, 27, 29
-              Category.Escaped, 33, 35; Category.Function, 38, 43 ]]
+    => [ 2, [ Cat.Escaped, 10, 12; Cat.Escaped, 12, 14; Cat.Function, 16, 23
+              Cat.Escaped, 25, 27; Cat.Escaped, 27, 29
+              Cat.Escaped, 33, 35; Cat.Function, 38, 43 ]]
 
 [<Test>]
 let ``operators based on SymbolUse``() =
@@ -1692,14 +1705,14 @@ let _ = 1 = 2
 let (>>=) _x _y = ()
 let _ = 1 >>= 2
 """
-    => [ 2, [ Category.Operator, 10, 11 ]
-         3, [ Category.Operator, 10, 11 ]
-         4, [ Category.Operator, 5, 8 ]
-         5, [ Category.Operator, 10, 13 ]] 
+    => [ 2, [ Cat.Operator, 10, 11; Cat.Operator, 6, 7 ]
+         3, [ Cat.Operator, 10, 11; Cat.Operator, 6, 7 ]
+         4, [ Cat.Operator, 5, 8; Cat.Operator, 16, 17 ]
+         5, [ Cat.Operator, 10, 13; Cat.Operator, 6, 7 ]] 
          
 [<Test>]
 let ``operators based on Lexer``() =
     """
-let f x = 1
+let _ = 1
 """
-    => [ 2, [ Category.Operator, 6, 7 ]] 
+    => [ 2, [ Cat.Operator, 6, 7 ]] 

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -1699,7 +1699,7 @@ let _ = "a\r\n".Replace("\r\n", "\n").Split('\r')
               Cat.Escaped, 33, 35; Cat.Function, 38, 43 ]]
 
 [<Test>]
-let ``operators based on SymbolUse``() =
+let ``operators``() =
     """
 let _ = 1 + 2
 let _ = 1 = 2
@@ -1712,7 +1712,7 @@ let _ = 1 >>= fun _ -> 2
          5, [ Cat.Operator, 10, 13; Cat.Operator, 6, 7 ]] 
 
 [<Test>]
-let ``operators based on Lexer``() =
+let ``lexer-based operator is hidden by symbol-based one``() =
     """
 let _ = 1
 let a = [||]
@@ -1720,4 +1720,13 @@ let (>>=) _x _y = ()
 a.[0] >>= fun _ -> ()
 """
     => [ 2, [ Cat.Operator, 6, 7 ]
-         5, [ Cat.Operator, 1, 2; Cat.Operator, 6, 9 ]] 
+         5, [ Cat.Operator, 1, 2; Cat.Function, 1, 2; Cat.Operator, 6, 9 ]]
+
+[<Test>]
+let ``cast operators``() =
+    """
+let _ = System.DateTime.Now :> obj
+let _ = System.DateTime.Now :?> obj
+"""
+    => [ 2, [ Cat.Operator, 6, 7; Cat.ValueType, 15, 23; Cat.Operator, 28, 30; Cat.ReferenceType, 31, 34 ] 
+         3, [ Cat.Operator, 6, 7; Cat.ValueType, 15, 23; Cat.Operator, 28, 31; Cat.ReferenceType, 32, 35 ] ]

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -1705,11 +1705,13 @@ let _ = 1 + 2
 let _ = 1 = 2
 let (>>=) _x _y = ()
 let _ = 1 >>= fun _ -> 2
+let _ = match obj() with | :? exn -> () | _ -> ()
 """
     => [ 2, [ Cat.Operator, 10, 11; Cat.Operator, 6, 7 ]
          3, [ Cat.Operator, 10, 11; Cat.Operator, 6, 7 ]
          4, [ Cat.Operator, 5, 8; Cat.Operator, 16, 17 ]
-         5, [ Cat.Operator, 10, 13; Cat.Operator, 6, 7 ]] 
+         5, [ Cat.Operator, 10, 13; Cat.Operator, 6, 7 ] 
+         6, [ Cat.Operator, 6, 7; Cat.ReferenceType, 14, 17; Cat.Operator, 27, 29; Cat.ReferenceType, 30, 33 ]] 
 
 [<Test>]
 let ``lexer-based operator is hidden by symbol-based one``() =

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -1685,7 +1685,7 @@ let _ = "a\r\n".Replace("\r\n", "\n").Split('\r')
               Category.Escaped, 33, 35; Category.Function, 38, 43 ]]
 
 [<Test>]
-let operators() =
+let ``operators based on SymbolUse``() =
     """
 let _ = 1 + 2
 let _ = 1 = 2
@@ -1695,4 +1695,11 @@ let _ = 1 >>= 2
     => [ 2, [ Category.Operator, 10, 11 ]
          3, [ Category.Operator, 10, 11 ]
          4, [ Category.Operator, 5, 8 ]
-         5, [ Category.Operator, 10, 13 ]]
+         5, [ Category.Operator, 10, 13 ]] 
+         
+[<Test>]
+let ``operators based on Lexer``() =
+    """
+let f x = 1
+"""
+    => [ 2, [ Category.Operator, 6, 7 ]] 

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -1704,16 +1704,20 @@ let ``operators based on SymbolUse``() =
 let _ = 1 + 2
 let _ = 1 = 2
 let (>>=) _x _y = ()
-let _ = 1 >>= 2
+let _ = 1 >>= fun _ -> 2
 """
     => [ 2, [ Cat.Operator, 10, 11; Cat.Operator, 6, 7 ]
          3, [ Cat.Operator, 10, 11; Cat.Operator, 6, 7 ]
          4, [ Cat.Operator, 5, 8; Cat.Operator, 16, 17 ]
          5, [ Cat.Operator, 10, 13; Cat.Operator, 6, 7 ]] 
-         
+
 [<Test>]
 let ``operators based on Lexer``() =
     """
 let _ = 1
+let a = [||]
+let (>>=) _x _y = ()
+a.[0] >>= fun _ -> ()
 """
-    => [ 2, [ Cat.Operator, 6, 7 ]] 
+    => [ 2, [ Cat.Operator, 6, 7 ]
+         5, [ Cat.Operator, 1, 2; Cat.Operator, 6, 9 ]] 

--- a/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
@@ -128,8 +128,8 @@ let internal f() = ()
             helper.ClassificationSpansOf(buffer, classifier)
             |> Seq.toList
             |> assertEqual
-                [ { Classification = "FSharp.Function"
-                    Span = (4, 14) => (4, 14) } ]
+                [ { Classification = "FSharp.Function"; Span = (4, 14) => (4, 14) }
+                  { Classification = "FSharp.Operator"; Span = (4, 18) => (4, 18) } ]
 
         // second event is raised when all spans, including Unused are ready
         testEvent classifier.ClassificationChanged "Timed out before classification changed" timeout <| fun _ ->

--- a/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
@@ -85,26 +85,26 @@ module Module1 =
         helper.SetUpProjectAndCurrentDocument(VirtualProjectProvider(buffer, fileName), fileName)
         let classifier = helper.GetClassifier(buffer)
         testEvent classifier.ClassificationChanged "Timed out before classification changed" timeout <| fun _ ->
-            helper.ClassificationSpansOf(buffer, classifier)
-            |> Seq.toList
-            |> assertEqual
-                [ { Classification = "FSharp.Function"; Span = (2, 5) => (2, 18) }
-                  { Classification = "FSharp.Operator"; Span = (2, 26) => (2, 26) }
-                  { Classification = "FSharp.Operator"; Span = (2, 22) => (2, 22) }
-                  { Classification = "FSharp.Operator"; Span = (3, 23) => (3, 23) }
-                  { Classification = "FSharp.ReferenceType"; Span = (3, 25) => (3, 35) }
-                  { Classification = "FSharp.ValueType"; Span = (3, 37) => (3, 39) } 
-                  { Classification = "FSharp.MutableVar"; Span = (4, 13) => (4, 24) }
-                  { Classification = "FSharp.Operator"; Span = (4, 26) => (4, 26) }
-                  { Classification = "FSharp.PatternCase"; Span = (5, 7) => (5, 19) }
-                  { Classification = "FSharp.Operator"; Span = (5, 27) => (5, 27) } 
-                  { Classification = "FSharp.PatternCase"; Span = (5, 29) => (5, 32) }
-                  { Classification = "FSharp.Operator"; Span = (6, 7) => (6, 7) }
-                  { Classification = "FSharp.Quotation"; Span = (6, 9) => (6, 19) } 
-                  { Classification = "FSharp.Operator"; Span = (6, 14) => (6, 14) }
-                  { Classification = "FSharp.Module"; Span = (7, 8) => (7, 14) } 
-                  { Classification = "FSharp.Operator"; Span = (7, 16) => (7, 16) }
-                  { Classification = "FSharp.Operator"; Span = (8, 11) => (8, 11) }] 
+        let actual = helper.ClassificationSpansOf(buffer, classifier) |> Seq.toList
+        let expected =
+            [ { Classification = "FSharp.Function"; Span = (2, 5) => (2, 18) }
+              { Classification = "FSharp.Operator"; Span = (2, 22) => (2, 22) }
+              { Classification = "FSharp.Operator"; Span = (2, 26) => (2, 26) }
+              { Classification = "FSharp.Operator"; Span = (3, 23) => (3, 23) }
+              { Classification = "FSharp.ReferenceType"; Span = (3, 25) => (3, 35) }
+              { Classification = "FSharp.ValueType"; Span = (3, 37) => (3, 39) } 
+              { Classification = "FSharp.MutableVar"; Span = (4, 13) => (4, 24) }
+              { Classification = "FSharp.Operator"; Span = (4, 26) => (4, 26) }
+              { Classification = "FSharp.PatternCase"; Span = (5, 7) => (5, 19) }
+              { Classification = "FSharp.Operator"; Span = (5, 27) => (5, 27) } 
+              { Classification = "FSharp.PatternCase"; Span = (5, 29) => (5, 32) }
+              { Classification = "FSharp.Operator"; Span = (6, 7) => (6, 7) }
+              { Classification = "FSharp.Quotation"; Span = (6, 9) => (6, 19) } 
+              { Classification = "FSharp.Operator"; Span = (6, 14) => (6, 14) }
+              { Classification = "FSharp.Module"; Span = (7, 8) => (7, 14) } 
+              { Classification = "FSharp.Operator"; Span = (7, 16) => (7, 16) }
+              { Classification = "FSharp.Operator"; Span = (8, 11) => (8, 11) }] 
+        CollectionAssert.AreEquivalent(expected, actual)
 
     [<Test>]
     let ``should be able to get classification spans for unused items``() = 
@@ -130,12 +130,12 @@ let internal f() = ()
 
         // second event is raised when all spans, including Unused are ready
         testEvent classifier.ClassificationChanged "Timed out before classification changed" timeout <| fun _ ->
-            helper.ClassificationSpansOf(buffer, classifier)
-            |> Seq.toList
-            |> assertEqual
+            let actual = helper.ClassificationSpansOf(buffer, classifier) |> Seq.toList
+            let expected =
                 [ { Classification = "FSharp.Unused"; Span = (2, 6) => (2, 11) };
                   { Classification = "FSharp.Unused"; Span = (3, 6) => (3, 31) };
                   { Classification = "FSharp.Unused"; Span = (4, 14) => (4, 14) } ]
+            CollectionAssert.AreEquivalent(expected, actual)
         File.Delete(fileName)
         
 
@@ -156,9 +156,8 @@ let _ = XmlProvider< "<root><value>\"1\"</value></root>">.GetSample() |> ignore
         helper.SetUpProjectAndCurrentDocument(ExternalProjectProvider(projectFileName), fileName)
         let classifier = helper.GetClassifier(buffer)
         testEvent classifier.ClassificationChanged "Timed out before classification changed" timeout <| fun _ -> 
-            helper.ClassificationSpansOf(buffer, classifier)
-            |> Seq.toList
-            |> assertEqual 
+            let actual = helper.ClassificationSpansOf(buffer, classifier) |> Seq.toList
+            let expected = 
                 [ { Classification = "FSharp.Module"; Span = (2, 8, 2, 24) }
                   
                   { Classification = "FSharp.ReferenceType"; Span = (4, 6, 4, 12) }
@@ -186,3 +185,4 @@ let _ = XmlProvider< "<root><value>\"1\"</value></root>">.GetSample() |> ignore
                   { Classification = "FSharp.Function"; Span = (7, 59, 7, 67) }
                   { Classification = "FSharp.Operator"; Span = (7, 71, 7, 72) } 
                   { Classification = "FSharp.Function"; Span = (7, 74, 7, 79) } ]
+            CollectionAssert.AreEquivalent(expected, actual)

--- a/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
@@ -90,14 +90,21 @@ module Module1 =
             |> assertEqual
                 [ { Classification = "FSharp.Function"; Span = (2, 5) => (2, 18) }
                   { Classification = "FSharp.Operator"; Span = (2, 26) => (2, 26) }
+                  { Classification = "FSharp.Operator"; Span = (2, 22) => (2, 22) }
+                  { Classification = "FSharp.Operator"; Span = (3, 23) => (3, 23) }
                   { Classification = "FSharp.ReferenceType"; Span = (3, 25) => (3, 35) }
                   { Classification = "FSharp.ValueType"; Span = (3, 37) => (3, 39) } 
                   { Classification = "FSharp.MutableVar"; Span = (4, 13) => (4, 24) }
-                  { Classification = "FSharp.PatternCase"; Span = (5, 7) => (5, 19) } 
+                  { Classification = "FSharp.Operator"; Span = (4, 26) => (4, 26) }
+                  { Classification = "FSharp.PatternCase"; Span = (5, 7) => (5, 19) }
+                  { Classification = "FSharp.Operator"; Span = (5, 27) => (5, 27) } 
                   { Classification = "FSharp.PatternCase"; Span = (5, 29) => (5, 32) }
+                  { Classification = "FSharp.Operator"; Span = (6, 7) => (6, 7) }
                   { Classification = "FSharp.Quotation"; Span = (6, 9) => (6, 19) } 
                   { Classification = "FSharp.Operator"; Span = (6, 14) => (6, 14) }
-                  { Classification = "FSharp.Module"; Span = (7, 8) => (7, 14) } ] 
+                  { Classification = "FSharp.Module"; Span = (7, 8) => (7, 14) } 
+                  { Classification = "FSharp.Operator"; Span = (7, 16) => (7, 16) }
+                  { Classification = "FSharp.Operator"; Span = (8, 11) => (8, 11) }] 
 
     [<Test>]
     let ``should be able to get classification spans for unused items``() = 
@@ -155,20 +162,24 @@ let _ = XmlProvider< "<root><value>\"1\"</value></root>">.GetSample() |> ignore
                 [ { Classification = "FSharp.Module"; Span = (2, 8, 2, 24) }
                   
                   { Classification = "FSharp.ReferenceType"; Span = (4, 6, 4, 12) }
+                  { Classification = "FSharp.Operator"; Span = (4, 14) => (4, 14) }
                   { Classification = "FSharp.ReferenceType"; Span = (4, 16, 4, 26) }
                   { Classification = "FSharp.Escaped"; Span = (4, 43, 4, 44) }
                   { Classification = "FSharp.Escaped"; Span = (4, 46, 4, 47) }
                   { Classification = "FSharp.Escaped"; Span = (4, 63, 4, 64) }
                   { Classification = "FSharp.Escaped"; Span = (4, 66, 4, 67) }
                   
+                  { Classification = "FSharp.Operator"; Span = (5, 7) => (5, 7) }
                   { Classification = "FSharp.ReferenceType"; Span = (5, 9, 5, 15) }
                   { Classification = "FSharp.Function"; Span = (5, 17, 5, 25) }
 
+                  { Classification = "FSharp.Operator"; Span = (6, 7) => (6, 7) }
                   { Classification = "FSharp.ReferenceType"; Span = (6, 9, 6, 19) }
                   { Classification = "FSharp.Escaped"; Span = (6, 36, 6, 37) }
                   { Classification = "FSharp.Escaped"; Span = (6, 39, 6, 40) } 
                   { Classification = "FSharp.Function"; Span = (6, 59, 6, 67) }
 
+                  { Classification = "FSharp.Operator"; Span = (7, 7) => (7, 7) }
                   { Classification = "FSharp.ReferenceType"; Span = (7, 9, 7, 19) }
                   { Classification = "FSharp.Escaped"; Span = (7, 36, 7, 37) }
                   { Classification = "FSharp.Escaped"; Span = (7, 39, 7, 40) } 

--- a/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
@@ -88,13 +88,15 @@ module Module1 =
             helper.ClassificationSpansOf(buffer, classifier)
             |> Seq.toList
             |> assertEqual
-                [ { Classification = "FSharp.Function"; Span = (2, 5) => (2, 18) };
-                  { Classification = "FSharp.ReferenceType"; Span = (3, 25) => (3, 35) };
-                  { Classification = "FSharp.ValueType"; Span = (3, 37) => (3, 39) }; 
-                  { Classification = "FSharp.MutableVar"; Span = (4, 13) => (4, 24) };
-                  { Classification = "FSharp.PatternCase"; Span = (5, 7) => (5, 19) }; 
-                  { Classification = "FSharp.PatternCase"; Span = (5, 29) => (5, 32) };
-                  { Classification = "FSharp.Quotation"; Span = (6, 9) => (6, 19) }; 
+                [ { Classification = "FSharp.Function"; Span = (2, 5) => (2, 18) }
+                  { Classification = "FSharp.Operator"; Span = (2, 26) => (2, 26) }
+                  { Classification = "FSharp.ReferenceType"; Span = (3, 25) => (3, 35) }
+                  { Classification = "FSharp.ValueType"; Span = (3, 37) => (3, 39) } 
+                  { Classification = "FSharp.MutableVar"; Span = (4, 13) => (4, 24) }
+                  { Classification = "FSharp.PatternCase"; Span = (5, 7) => (5, 19) } 
+                  { Classification = "FSharp.PatternCase"; Span = (5, 29) => (5, 32) }
+                  { Classification = "FSharp.Quotation"; Span = (6, 9) => (6, 19) } 
+                  { Classification = "FSharp.Operator"; Span = (6, 14) => (6, 14) }
                   { Classification = "FSharp.Module"; Span = (7, 8) => (7, 14) } ] 
 
     [<Test>]
@@ -171,4 +173,5 @@ let _ = XmlProvider< "<root><value>\"1\"</value></root>">.GetSample() |> ignore
                   { Classification = "FSharp.Escaped"; Span = (7, 36, 7, 37) }
                   { Classification = "FSharp.Escaped"; Span = (7, 39, 7, 40) } 
                   { Classification = "FSharp.Function"; Span = (7, 59, 7, 67) }
-                  { Classification = "FSharp.Function"; Span = (7, 74, 7, 79) }]
+                  { Classification = "FSharp.Operator"; Span = (7, 71, 7, 72) } 
+                  { Classification = "FSharp.Function"; Span = (7, 74, 7, 79) } ]

--- a/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
@@ -62,13 +62,16 @@ module SyntaxConstructClassifierTests =
         DocumentEventListener.SkipTimerDelay <- true
 
     [<Test>]
-    let ``should not return anything if the code doesn't contain semantic symbol``() = 
+    let ``should return a syngle operator symbol if the code doesn't contain any other symbols``() = 
         let content = "let x = 0"
         let buffer = createMockTextBuffer content fileName
         helper.SetUpProjectAndCurrentDocument(VirtualProjectProvider(buffer, fileName), fileName)
         let classifier = helper.GetClassifier(buffer)
         testEvent classifier.ClassificationChanged "Timed out before classification changed" timeout
-            (fun () -> helper.ClassificationSpansOf(buffer, classifier) |> Seq.isEmpty |> assertTrue)
+            (fun () -> 
+            helper.ClassificationSpansOf(buffer, classifier) 
+            |> Seq.toList
+            |> assertEqual [ { Classification = "FSharp.Operator"; Span = (1, 7) => (1, 7) } ])
 
     [<Test>]
     let ``should be able to get classification spans for main categories``() = 
@@ -132,9 +135,10 @@ let internal f() = ()
         testEvent classifier.ClassificationChanged "Timed out before classification changed" timeout <| fun _ ->
             let actual = helper.ClassificationSpansOf(buffer, classifier) |> Seq.toList
             let expected =
-                [ { Classification = "FSharp.Unused"; Span = (2, 6) => (2, 11) };
-                  { Classification = "FSharp.Unused"; Span = (3, 6) => (3, 31) };
-                  { Classification = "FSharp.Unused"; Span = (4, 14) => (4, 14) } ]
+                [ { Classification = "FSharp.Unused"; Span = (2, 6) => (2, 11) }
+                  { Classification = "FSharp.Unused"; Span = (3, 6) => (3, 31) }
+                  { Classification = "FSharp.Unused"; Span = (4, 14) => (4, 14) }
+                  {Classification = "FSharp.Operator"; Span = (4, 18) => (4, 18) } ]
             CollectionAssert.AreEquivalent(expected, actual)
         File.Delete(fileName)
         


### PR DESCRIPTION
Examples:
![image](https://cloud.githubusercontent.com/assets/873919/6331340/a1205274-bb8f-11e4-87c5-12e8a4c3a839.png)
![image](https://cloud.githubusercontent.com/assets/873919/6331359/b3c7c9e8-bb8f-11e4-9f96-6fe30ee9755c.png)
![image](https://cloud.githubusercontent.com/assets/873919/6331387/dd07658e-bb8f-11e4-95ed-90016f4e0cd9.png)
![image](https://cloud.githubusercontent.com/assets/873919/6331466/569a9c72-bb90-11e4-80fb-25ecb5998305.png)
![image](https://cloud.githubusercontent.com/assets/873919/6331523/b47f3410-bb90-11e4-8c22-1abff1e9c4ce.png)
![image](https://cloud.githubusercontent.com/assets/873919/6331552/e4bcf1b2-bb90-11e4-96f5-c5e85bb546d1.png)

Limitations:
* it does not colorize `=` in value definition like `let x = 1`
* it does not colorize `:>`, `:?>`, `->`, `<-` (and maybe some other build-in operators)

Default color for Operator category is the same as for plane ident.