### PR TITLE
Implement assembly resolution for FsiReferenceCommand

### DIFF
--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -390,7 +390,7 @@ module Pervasive =
         | null -> None
         | :? 'T as a -> Some a
         | _ -> 
-            fail "Cannot cast %O to %O" (o.GetType()) typeof<'T>.Name
+            debug "Cannot cast %O to %O" (o.GetType()) typeof<'T>.Name
             None
 
     /// Load times used to reset type checking properly on script/project load/unload. It just has to be unique for each project load/reload.

--- a/src/FSharpVSPowerTools/PowerToolsCommandsPackage.cs
+++ b/src/FSharpVSPowerTools/PowerToolsCommandsPackage.cs
@@ -106,11 +106,10 @@ namespace FSharpVSPowerTools
         private void SetupReferenceMenu()
         {
             var mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
-            var shell = GetService(typeof(SVsUIShell)) as IVsUIShell;
-
+            
             if (mcs != null)
             {
-                fsiReferenceMenu = new FsiReferenceCommand(DTE.Value, mcs, shell);
+                fsiReferenceMenu = new FsiReferenceCommand(DTE.Value, mcs);
                 fsiReferenceMenu.SetupCommands();
             }
         }


### PR DESCRIPTION
It turns out that we can use assembly resolution from F# Project System to ensure that assembly ordering is resolved correctly by default. We still keep the revised ordering if users decide to change it.

It isn't obvious to me until this conversation https://github.com/fsprojects/Paket/issues/677.
