### PR TITLE
disable already rendered folder validation

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FolderMenuCommands.fs
+++ b/src/FSharpVSPowerTools.Logic/FolderMenuCommands.fs
@@ -315,15 +315,28 @@ type FolderMenuCommands(dte: DTE2, mcs: OleMenuCommandService, shell: IVsUIShell
             match action with
             | Action.NameAction a -> 
                 let folderNames = getFolderNamesFromProject info.Project
+                let uniqueFolderName =
+                    match VisualStudioVersion.fromDTEVersion dte.Version with
+                    | VisualStudioVersion.VS2012
+                    | VisualStudioVersion.VS2013 ->
+                        true
+                    | VisualStudioVersion.VS2015 -> 
+                        false
+                    | v ->
+                        Logging.logWarning "Unknown Visual Studio version detected while adding/renaming folder: %O" v
+                        true
+
                 let resources = 
                     match a with
                     | NameAction.New ->
                         { WindowTitle = Resource.newFolderDialogTitle
                           OriginalName = ""
+                          CheckUniqueFolderNames = uniqueFolderName
                           FolderNames = folderNames }
                     | NameAction.Rename -> 
                         { WindowTitle = Resource.renameFolderDialogTitle
                           OriginalName = info.Items.Head.Name
+                          CheckUniqueFolderNames = uniqueFolderName
                           FolderNames = folderNames }
                 askForFolderName resources |> Option.iter (performNameAction info a)
             | Action.VerticalMoveAction a -> performVerticalMove info a

--- a/src/FSharpVSPowerTools.Logic/FolderNameDialog.fs
+++ b/src/FSharpVSPowerTools.Logic/FolderNameDialog.fs
@@ -11,6 +11,7 @@ type NewFolderNameDialog = FsXaml.XAML<"FolderNameDialog.xaml">
 type NewFolderNameDialogResources = 
     { WindowTitle: string
       FolderNames: Set<string>
+      CheckUniqueFolderNames: bool
       OriginalName: string }
 
 type NewFolderNameDialogModel(resources: NewFolderNameDialogResources) as self = 
@@ -30,7 +31,7 @@ type NewFolderNameDialogModel(resources: NewFolderNameDialogResources) as self =
         validate "Name"
         >> notNullOrWhitespace
         >> fixErrorsWithMessage Resource.validatingEmptyName
-        >> custom validateExists
+        >> (if resources.CheckUniqueFolderNames then (custom validateExists) else id)
         >> custom validateFolderName
         >> result
     


### PR DESCRIPTION
i fixed this error with Microsoft/visualfsharp@7e2a0db2517dcee28986324f61b3348493a30800 and is merged in Visual F# 4.0

how can i check VisualF# extension version ( to leave this check for VisualF# < 4.0 )?

![already_rendered_same_name](https://cloud.githubusercontent.com/assets/147243/7700645/7228a0a6-fe20-11e4-97b2-ecee4486883b.gif)
