### PR TITLE
ProjectItem.FileNames use 1 based indexing

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FolderMenuCommands.fs
+++ b/src/FSharpVSPowerTools.Logic/FolderMenuCommands.fs
@@ -198,7 +198,7 @@ type FolderMenuCommands(dte: DTE2, mcs: OleMenuCommandService, shell: IVsUIShell
         | true, Some destination ->
             for item in info.Items do
                 Debug.Assert(item.FileCount = 1s, "Item should be unique.")
-                let filePath = item.FileNames(0s)
+                let filePath = item.FileNames(1s) //1 based indexing
                 let buildAction = item.TryGetProperty("ItemType")
                 let newItem = destination.AddFromFileCopy(filePath)
                 // The new item may lose ItemType; we try to recover it.
@@ -225,12 +225,13 @@ type FolderMenuCommands(dte: DTE2, mcs: OleMenuCommandService, shell: IVsUIShell
             | _ -> info.Project.ProjectItems
         let folder = items.AddFolder name
         Debug.Assert(folder.FileCount = 1s, "Item should be unique.")
-        if Directory.Exists(folder.FileNames(0s)) then
+        let folderFilename = folder.FileNames(1s) //1 based indexing
+        if Directory.Exists(folderFilename) then
             // We tolerate that folder might already exist
             Logging.messageBoxInfo Resource.validationExistingFolderOnDisk
         else
             try
-                Directory.CreateDirectory(folder.FileNames(0s)) |> ignore
+                Directory.CreateDirectory(folderFilename) |> ignore
             with _ ->
                 Logging.messageBoxError Resource.validationCannotCreateFolder
                 // Can't create folder, remove folder item for consistency

--- a/src/FSharpVSPowerTools.Logic/FolderMenuCommands.fs
+++ b/src/FSharpVSPowerTools.Logic/FolderMenuCommands.fs
@@ -197,8 +197,7 @@ type FolderMenuCommands(dte: DTE2, mcs: OleMenuCommandService, shell: IVsUIShell
         match folderExists, destination with
         | true, Some destination ->
             for item in info.Items do
-                Debug.Assert(item.FileCount = 1s, "Item should be unique.")
-                let filePath = item.FileNames(1s) //1 based indexing
+                let filePath = VSUtils.filePath item
                 let buildAction = item.TryGetProperty("ItemType")
                 let newItem = destination.AddFromFileCopy(filePath)
                 // The new item may lose ItemType; we try to recover it.
@@ -224,8 +223,7 @@ type FolderMenuCommands(dte: DTE2, mcs: OleMenuCommandService, shell: IVsUIShell
             | [ item ] -> item.ProjectItems
             | _ -> info.Project.ProjectItems
         let folder = items.AddFolder name
-        Debug.Assert(folder.FileCount = 1s, "Item should be unique.")
-        let folderFilename = folder.FileNames(1s) //1 based indexing
+        let folderFilename = VSUtils.filePath folder
         if Directory.Exists(folderFilename) then
             // We tolerate that folder might already exist
             Logging.messageBoxInfo Resource.validationExistingFolderOnDisk

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -50,6 +50,10 @@ let isPhysicalFile (item: EnvDTE.ProjectItem) =
 let isPhysicalFileOrFolder (item: EnvDTE.ProjectItem) =
     item <> null && isPhysicalFileOrFolderKind item.Kind
 
+let filePath (item: EnvDTE.ProjectItem) =
+    Debug.Assert(item.FileCount = 1s, "Item should be unique.")
+    item.FileNames(1s) //1 based indexing
+
 let inline private isTypeParameter (prefix: char) (s: string) =
     match s.Length with
     | 0 | 1 -> false


### PR DESCRIPTION
0 based index works for compatibility with c#, but raise a Debug.Assert dialog on visualfsharp

ref [MSDN](https://msdn.microsoft.com/en-us/library/envdte.projectitem.filenames.aspx):
> index
Type: System.Int16
Required. The index of file names from 1 to FileCount for the project item.
