### PR TITLE
Handle theme changes in QuickInfo margin

### DIFF
--- a/src/FSharpVSPowerTools.Logic/Constants.fs
+++ b/src/FSharpVSPowerTools.Logic/Constants.fs
@@ -55,4 +55,4 @@ let [<Literal>] cmdidPreviousHighlightedReference = 2401u
 let [<Literal>] cmdidGenerateReferencesForFsi = 0x100u
 let [<Literal>] guidAddReferenceInFSICmdSetString = "8c9a49dd-2d34-4d18-905b-c557692980be"
 let guidGenerateReferencesForFsiCmdSet = Guid(guidAddReferenceInFSICmdSetString)
-let [<Literal>] QuickInfoMargin = "vfpt.quickinfo.margin";
+let [<Literal>] QuickInfoMargin = "vfpt.quickinfo.margin"

--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -82,6 +82,9 @@
     <Compile Include="VSUtils.fs">
       <Link>Common/VSUtils.fs</Link>
     </Compile>
+    <Compile Include="VSColors.fs">
+      <Link>Common/VSColors.fs</Link>
+    </Compile>
     <Compile Include="VisualStudioVersion.fs">
       <Link>Common/VisualStudioVersion.fs</Link>
     </Compile>

--- a/src/FSharpVSPowerTools.Logic/QuickInfoMargin.xaml
+++ b/src/FSharpVSPowerTools.Logic/QuickInfoMargin.xaml
@@ -4,14 +4,24 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:sys="clr-namespace:System;assembly=mscorlib" 
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.11.0" 
-             xmlns:pt="clr-namespace:FSharpVSPowerTools.QuickInfo"
+             xmlns:local="clr-namespace:FSharpVSPowerTools.Common;assembly=FSharpVSPowerTools.Logic"
              mc:Ignorable="d" 
              Height="24"
              d:DesignHeight="25" d:DesignWidth="600">
     <TextBox x:Name="tbQuickInfo" 
         IsEnabled="True" 
         IsReadOnly="True" 
-        Text="{Binding QuickInfo, Mode=OneWay}" 
-        Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" />
+        Text="{Binding QuickInfo, Mode=OneWay}" />
+    <UserControl.Resources>
+        <ResourceDictionary 
+              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+              xmlns:fsxaml="http://github.com/fsprojects/FsXaml">
+            <Style TargetType="{x:Type TextBox}">
+                <Setter Property="Background" Value="{DynamicResource {x:Static local:VSColors.CommandShelfBackgroundGradientBrushKey}}" />
+                <Setter Property="Foreground" Value="{DynamicResource {x:Static local:VSColors.CommandBarTextActiveBrushKey}}" />
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
 </UserControl>
 

--- a/src/FSharpVSPowerTools.Logic/QuickInfoMargin.xaml
+++ b/src/FSharpVSPowerTools.Logic/QuickInfoMargin.xaml
@@ -18,6 +18,7 @@
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
               xmlns:fsxaml="http://github.com/fsprojects/FsXaml">
             <Style TargetType="{x:Type TextBox}">
+                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static local:VSColors.CommandShelfBackgroundGradientBrushKey}}" />
                 <Setter Property="Background" Value="{DynamicResource {x:Static local:VSColors.CommandShelfBackgroundGradientBrushKey}}" />
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static local:VSColors.CommandBarTextActiveBrushKey}}" />
             </Style>

--- a/src/FSharpVSPowerTools.Logic/VSColors.fs
+++ b/src/FSharpVSPowerTools.Logic/VSColors.fs
@@ -1,0 +1,29 @@
+﻿namespace FSharpVSPowerTools.Common
+
+open System
+open System.Reflection
+open Microsoft.VisualStudio.Shell
+open FSharpVSPowerTools
+
+// A port from https://github.com/tomasr/viasfora/blob/master/Viasfora/Util/VsColors.cs
+
+type VSColors () =
+    static let colorTypeOpt =
+        try
+            let vsShellAssembly = Assembly.Load("Microsoft.VisualStudio.Shell.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
+            vsShellAssembly
+            |> Option.ofNull
+            |> Option.map (fun assembly ->
+                assembly.GetType("Microsoft.VisualStudio.PlatformUI.EnvironmentColors"))
+        with _ ->
+            None
+
+    static let tryGetOrElse (key: string) (alternate: obj) = 
+        colorTypeOpt
+        |> Option.map (fun colorType ->
+            let prop = colorType.GetProperty(key)
+            prop.GetValue(null, null))
+        |> Option.getOrElse alternate
+
+    static member CommandShelfBackgroundGradientBrushKey = tryGetOrElse "CommandShelfBackgroundGradientBrushKey" VsBrushes.CommandBarGradientBeginKey
+    static member CommandBarTextActiveBrushKey = tryGetOrElse "CommandBarTextActiveBrushKey" VsBrushes.CommandBarTextActiveKey

--- a/src/FSharpVSPowerTools/QuickInfoMarginProvider.cs
+++ b/src/FSharpVSPowerTools/QuickInfoMarginProvider.cs
@@ -1,6 +1,5 @@
 ﻿using FSharpVSPowerTools;
 using FSharpVSPowerTools.ProjectSystem;
-using FSharpVSPowerTools.QuickInfo;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -8,10 +7,10 @@ using Microsoft.VisualStudio.Utilities;
 using System;
 using System.ComponentModel.Composition;
 
-namespace Winterdom.Viasfora.Margins
+namespace FSharpVSPowerTools.QuickInfo
 {
     [Export(typeof(IWpfTextViewMarginProvider))]
-    [Name(FSharpVSPowerTools.Constants.QuickInfoMargin)]
+    [Name(Constants.QuickInfoMargin)]
     [Order(After = PredefinedMarginNames.HorizontalScrollBar)]
     [MarginContainer(PredefinedMarginNames.Bottom)]
     [ContentType("F#")]

--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="1.8.2" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="1.8.3" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A collection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>


### PR DESCRIPTION
Fix #989.

Note to self: one needs to specify the assembly name so that associated types can be found.