### PR TITLE
Improve Unused Declaration Margin

### DIFF
--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -284,6 +284,8 @@ type ForegroundThreadGuard private() =
 
 [<RequireQualifiedAccess>]
 module ViewChange =    
+    open Microsoft.VisualStudio.Text.Tagging
+
     let layoutEvent (view: ITextView) = 
         view.LayoutChanged |> Event.choose (fun e -> if e.NewSnapshot <> e.OldSnapshot then Some() else None)
     
@@ -296,8 +298,8 @@ module ViewChange =
     let bufferEvent (buffer: ITextBuffer) = 
         buffer.ChangedLowPriority |> Event.map (fun _ -> ())
 
-    let classificationEvent (classifier: IClassifier) = 
-        classifier.ClassificationChanged |> Event.map (fun _ -> ())
+    let tagsChanged (tagAggregator: ITagAggregator<_>) = 
+        tagAggregator.TagsChanged |> Event.map (fun _ -> ())
 
 type DocumentEventListener (events: IEvent<unit> list, delayMillis: uint16, update: unit -> unit) =
     // Start an async loop on the UI thread that will execute the update action after the delay

--- a/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
@@ -422,10 +422,9 @@ namespace FSharpVSPowerTools
     [Export(typeof(ITaggerProvider))]
     [TagType(typeof(UnusedDeclarationTag))]
     [Export(typeof(IClassifierProvider))]
-    [Export(typeof(IWpfTextViewConnectionListener))]
     [ContentType("F#")]
     [TextViewRole(PredefinedTextViewRoles.Document)]
-    public class SyntaxConstructClassifierProvider : IClassifierProvider, IWpfTextViewConnectionListener, IDisposable
+    public class SyntaxConstructClassifierProvider : ITaggerProvider, IClassifierProvider, IDisposable
     { 
         [Import]
         internal IClassificationTypeRegistryService classificationRegistry = null;
@@ -483,26 +482,6 @@ namespace FSharpVSPowerTools
         public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
         {
             return GetClassifier(buffer) as ITagger<T>;
-        }
-
-        public void SubjectBuffersConnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)
-        {
-        }
-
-        public void SubjectBuffersDisconnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)
-        {
-            if (reason != ConnectionReason.TextViewLifetime) return;
-
-            IDisposable classifier;
-            foreach (ITextBuffer buffer in subjectBuffers)
-            {
-                if (buffer.Properties.TryGetProperty(serviceType, out classifier))
-                {
-                    bool success = buffer.Properties.RemoveProperty(serviceType);
-                    Debug.Assert(success, "Should be able to remove classifier from the buffer");
-                    classifier.Dispose();
-                }
-            }
         }
 
         public void Dispose()

--- a/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/SyntaxConstructClassifierProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
+using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.Win32;
 using System;
@@ -418,6 +419,8 @@ namespace FSharpVSPowerTools
         }
     }
 
+    [Export(typeof(ITaggerProvider))]
+    [TagType(typeof(UnusedDeclarationTag))]
     [Export(typeof(IClassifierProvider))]
     [Export(typeof(IWpfTextViewConnectionListener))]
     [ContentType("F#")]
@@ -475,6 +478,11 @@ namespace FSharpVSPowerTools
             }
 
             return null;
+        }
+
+        public ITagger<T> CreateTagger<T>(ITextBuffer buffer) where T : ITag
+        {
+            return GetClassifier(buffer) as ITagger<T>;
         }
 
         public void SubjectBuffersConnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)

--- a/src/FSharpVSPowerTools/UnusedDeclarationMarginProvider.cs
+++ b/src/FSharpVSPowerTools/UnusedDeclarationMarginProvider.cs
@@ -9,6 +9,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FSharpVSPowerTools.SyntaxColoring;
 
 namespace FSharpVSPowerTools
 {
@@ -21,7 +22,7 @@ namespace FSharpVSPowerTools
     public class UnusedDeclarationMarginProvider : IWpfTextViewMarginProvider
     {
         [Import]
-        internal IClassifierAggregatorService classifierAggregatorService = null;
+        internal IViewTagAggregatorFactoryService viewTagAggregatorFactoryService = null;
 
         [Import(typeof(SVsServiceProvider))]
         internal IServiceProvider serviceProvider = null;
@@ -32,8 +33,8 @@ namespace FSharpVSPowerTools
             if (generalOptions == null || !(generalOptions.UnusedReferencesEnabled || generalOptions.UnusedOpensEnabled)) return null;
 
  	        var textView = wpfTextViewHost.TextView;
-            return new UnusedDeclarationMargin(textView, marginContainer,
-                           classifierAggregatorService.GetClassifier(textView.TextBuffer));
+            var tagAggregator = viewTagAggregatorFactoryService.CreateTagAggregator<UnusedDeclarationTag>(textView);
+            return new UnusedDeclarationMargin(textView, marginContainer, tagAggregator);
         }
     }
 }


### PR DESCRIPTION
Read unused declaration tags through a separate channel. It seems to work; I'm not sure about performance though.