### PR TITLE
decrease FSharpChecker's internal cache to 50 projects

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -158,7 +158,7 @@ type LanguageService (?fileSystem: IFileSystem) =
   // when its view of the prior-typechecking-state of the start of a file has changed, for example
   // when the background typechecker has "caught up" after some other file has been changed, 
   // and its time to re-typecheck the current file.
-  let checkerInstance = FSharpChecker.Create (projectCacheSize = 200, keepAllBackgroundResolutions = false)
+  let checkerInstance = FSharpChecker.Create (projectCacheSize = 50, keepAllBackgroundResolutions = false)
 
   let checkerAsync (f: FSharpChecker -> Async<'a>) = 
     let ctx = System.Threading.SynchronizationContext.Current


### PR DESCRIPTION
With old value `200` when I found all refs of a symbol used in ~90 projects, VS occupied > 2GB of RAM  and became unusable due to continuous GCing. 

With the cache of size `50` subsequent launches of "Find all refs" are as slow as the very first one, but VS private set stays at ~1.6GB, which is acceptable. 