### PR TITLE
Revert "use AllowStaleResults.MatchingSource everywhere"

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -537,7 +537,7 @@ type LanguageService (?fileSystem: IFileSystem) =
 
     member x.GetAllEntitiesInProjectAndReferencedAssemblies (projectOptions: FSharpProjectOptions, fileName, source, ?withCache) =
         async {
-            let! checkResults = x.ParseAndCheckFileInProject (projectOptions, fileName, source, AllowStaleResults.MatchingSource)
+            let! checkResults = x.ParseAndCheckFileInProject (projectOptions, fileName, source, AllowStaleResults.No)
             return 
                 Some [ match checkResults.GetPartialAssemblySignature() with
                        | Some signature -> 
@@ -567,7 +567,7 @@ type LanguageService (?fileSystem: IFileSystem) =
 
     member x.GetIdentTooltip (line, colAtEndOfNames, lineStr, names, project: FSharpProjectOptions, file, source) =
         async {
-            let! checkResults = x.ParseAndCheckFileInProject (project, file, source, AllowStaleResults.MatchingSource)
+            let! checkResults = x.ParseAndCheckFileInProject (project, file, source, AllowStaleResults.No)
             return! checkResults.GetIdentTooltip (line, colAtEndOfNames, lineStr, names)
         }
 

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -136,7 +136,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
             let! symbolUses = 
                 vsLanguageService.GetAllUsesOfAllSymbolsInSourceString(
                     signature, filePath, signatureProject, 
-                    AllowStaleResults.MatchingSource, checkForUnusedOpens=false, profiler=Profiler())
+                    AllowStaleResults.No, checkForUnusedOpens=false, profiler=Profiler())
 
             /// Try to reconstruct fully qualified name for the purpose of matching symbols
             let rec tryGetFullyQualifiedName (symbol: FSharpSymbol) = 

--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -57,7 +57,7 @@ type HighlightUsageTagger(textDocument: ITextDocument,
         async {
             if currentRequest = requestedPoint then
                 try
-                    let! res = vsLanguageService.GetFSharpSymbolUse (newWord, symbol, fileName, projectProvider, AllowStaleResults.MatchingSource)
+                    let! res = vsLanguageService.GetFSharpSymbolUse (newWord, symbol, fileName, projectProvider, AllowStaleResults.No)
                     match res with
                     | Some (_, checkResults) ->
                         let! results = vsLanguageService.FindUsagesInFile (newWord, symbol, checkResults)

--- a/src/FSharpVSPowerTools.Logic/ResolveUnopenedNamespaceTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/ResolveUnopenedNamespaceTagger.fs
@@ -62,7 +62,7 @@ type ResolveUnopenedNamespaceSmartTagger
                         if not (point.InSpan newWord) then return! None
                         else
                             let! res = 
-                                vsLanguageService.GetFSharpSymbolUse(newWord, sym, doc.FullName, project, AllowStaleResults.MatchingSource) |> liftAsync
+                                vsLanguageService.GetFSharpSymbolUse(newWord, sym, doc.FullName, project, AllowStaleResults.No) |> liftAsync
                             
                             match res with
                             | Some _ -> return! None

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -160,7 +160,7 @@ type VSLanguageService
     member __.ParseAndCheckFileInProject (currentFile: string, source, projectProvider: IProjectProvider) =
         async {
             let! opts = projectProvider.GetProjectCheckerOptions instance
-            return! instance.ParseAndCheckFileInProject(opts, currentFile, source, AllowStaleResults.MatchingSource) 
+            return! instance.ParseAndCheckFileInProject(opts, currentFile, source, AllowStaleResults.No) 
         }
 
     member __.ProcessNavigableItemsInProject(openDocuments, projectProvider: IProjectProvider, processNavigableItems, ct) =


### PR DESCRIPTION
Colorization is buggy as hell. I think all these troubles are not worth the small (if any) performance boost. 