### PR TITLE
Fix wrong marker size in VS 2012

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,5 +14,7 @@ nuget Foq
 nuget Nuget.CommandLine
 nuget Octokit
 nuget SourceLink.SymbolStore
+nuget VSSDK.IDE.11
+nuget VSSDK.IDE.Deploy.11
 
 github fsharp/FAKE modules/Octokit/Octokit.fsx

--- a/paket.lock
+++ b/paket.lock
@@ -30,8 +30,11 @@ NUGET
     Octokit (0.12.0)
       Microsoft.Net.Http
     SourceLink.SymbolStore (0.5.0)
+    VSSDK.IDE.11 (11.0.4)
+    VSSDK.IDE.Deploy.11 (11.0.4)
+      VSSDK.IDE.11 (>= 11.0.4 < 12.0.0)
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (52ee2053781c7106766d2b23686344f70dc11483)
+    modules/Octokit/Octokit.fsx (98d8f2e57e8f9972703d4237dd62f8e13d6b8d7d)
       Octokit

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -278,4 +278,6 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Import Project="..\..\packages\VSSDK.IDE.Deploy.11\build\VSSDK.IDE.Deploy.11.props" Condition="Exists('..\..\packages\VSSDK.IDE.Deploy.11\build\VSSDK.IDE.Deploy.11.props')" Label="Paket" />
+  <Import Project="..\..\packages\VSSDK.IDE.Deploy.11\build\VSSDK.IDE.Deploy.11.targets" Condition="Exists('..\..\packages\VSSDK.IDE.Deploy.11\build\VSSDK.IDE.Deploy.11.targets')" Label="Paket" />
 </Project>

--- a/src/FSharpVSPowerTools/paket.references
+++ b/src/FSharpVSPowerTools/paket.references
@@ -1,2 +1,4 @@
 Fantomas
 FSharp.Compiler.Service
+VSSDK.IDE.11
+VSSDK.IDE.Deploy.11


### PR DESCRIPTION
Close #1026.

This PR also adds `VSSDK.IDE.Deploy.11` NuGet package. The purpose is to develop and debug in VS 2013 but deploy in VS 2012. Originally I always keep a separate branch for VS 2012 for debugging, but it's painful to keep it compilable when code changes.

Reference https://github.com/tunnelvisionlabs/vsxdeps/pull/23