### PR TITLE
Remove '=' suffix on signatures of types	in QuickInfo margin

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
 #### 1.10.0 - Unreleased
+* Optimize dialog layouts for high DPI ([#1024](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1024))
+* Fix wrong size of unused markers in VS 2012 ([#1027](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1027))
 
 #### 1.9.0 - June 21 2015
 * Implement QuickInfo margin ([#973](https://github.com/fsprojects/VisualFSharpPowerTools/issues/973))

--- a/src/FSharpVSPowerTools.Logic/QuickInfoMargin.fs
+++ b/src/FSharpVSPowerTools.Logic/QuickInfoMargin.fs
@@ -61,7 +61,14 @@ type QuickInfoMargin (textDocument: ITextDocument,
                 tooltip 
                 |> String.split StringSplitOptions.RemoveEmptyEntries [|"\r\n"; "\r"; "\n"|] 
                 |> Array.toList 
-                |> List.tryHead))
+                |> List.tryHead
+                |> Option.map (fun str ->
+                    if str.StartsWith("type ", StringComparison.Ordinal) then
+                        let index = str.LastIndexOf("=", StringComparison.Ordinal)
+                        if index > 0 then
+                            str.[0..index-1]
+                        else str
+                    else str)))
             |> Option.getOrElse ""
 
     let flattenLines (x: string) =

--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="1.9.1" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="1.9.2" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A collection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>


### PR DESCRIPTION
I find the `=` suffix in signatures e.g. `type A = ` very annoying, so I remove it.