### PR TITLE
NavigateToSource now supports bitbucket urls

### DIFF
--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -376,6 +376,20 @@ module String =
     let split options (separator: string[]) (value: string) = 
         match value with null -> null | x -> x.Split(separator, options)
 
+    let (|StartsWith|_|) value x =
+        if String.IsNullOrWhiteSpace(x) then
+            None
+        elif x.StartsWith(value) then
+            Some x
+        else None
+
+    let (|Contains|_|) value x =
+        if String.IsNullOrWhiteSpace(x) then
+            None
+        elif x.StartsWith(value) then
+            Some x
+        else None
+     
 [<AutoOpen; CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
 module Pervasive =
     open System.Diagnostics

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -376,18 +376,18 @@ module String =
     let split options (separator: string[]) (value: string) = 
         match value with null -> null | x -> x.Split(separator, options)
 
-    let (|StartsWith|_|) value x =
-        if String.IsNullOrWhiteSpace(x) then
+    let (|StartsWith|_|) pattern value =
+        if String.IsNullOrWhiteSpace(value) then
             None
-        elif x.StartsWith(value) then
-            Some x
+        elif value.StartsWith(pattern) then
+            Some value
         else None
 
-    let (|Contains|_|) value x =
-        if String.IsNullOrWhiteSpace(x) then
+    let (|Contains|_|) pattern value =
+        if String.IsNullOrWhiteSpace(value) then
             None
-        elif x.StartsWith(value) then
-            Some x
+        elif value.Contains(pattern) then
+            Some value
         else None
      
 [<AutoOpen; CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -334,21 +334,21 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                             replace m.Value (sprintf "blob/%s" m.Value) url
                         | _ -> url
                     let browserUrl =
-
-                        let url = 
-                            url 
+                        let formattedGithubUrl =  
+                            sprintf "%s#L%d" 
+                             (url 
                              |> replace "raw.githubusercontent" "github" 
                              |> replace "raw.github" "github"
-                             |> replace "/raw/" "/src/"  // bitbucket doesn't have a raw subdomain, instead we replace it
-                             |> replaceBlob m
+                             |> replaceBlob m)
+                             r.StartLine
 
-                        let lineAnchor = 
-                            match url with
-                            | github when github.StartsWith("https://github.com") -> sprintf "#L%d" r.StartLine
-                            | bitbucket when bitbucket.StartsWith("https://bitbucket.org") -> sprintf "#cl-%d" r.StartLine
-                            | _ -> ""
-                        
-                        sprintf "%s%s" url lineAnchor
+                        match url with
+                        | githubUserContent when githubUserContent.StartsWith("https://raw.githubusercontent.com") -> formattedGithubUrl
+                        | githubRaw when githubRaw.StartsWith("https://raw.github.com") -> formattedGithubUrl
+                        | github when github.StartsWith("https://github.com") -> formattedGithubUrl
+                        | bitbucket when bitbucket.StartsWith("https://bitbucket.org") -> 
+                            sprintf "%s#cl-%d" (url |> replace "/raw/" "/src/") r.StartLine
+                        | other -> other
 
                     if fireNavigationEvent then
                         currentUrl <- Some url

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -339,7 +339,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                             url 
                              |> replace "raw.githubusercontent" "github" 
                              |> replace "raw.github" "github"
-                             |> replace "/raw/" "/"  // bitbucket doesn't have a raw subdomain, instead we strip it from the url
+                             |> replace "/raw/" "/src/"  // bitbucket doesn't have a raw subdomain, instead we replace it
                              |> replaceBlob m
 
                         let lineAnchor = 

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -349,6 +349,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                         | String.StartsWith "https://bitbucket.org" _-> 
                             sprintf "%s#cl-%d" (url |> replace "/raw/" "/src/") r.StartLine
                         | String.Contains ".codebasehq.com" _-> sprintf "%s#L%d" (url |> replace "/raw/" "/blob/") r.StartLine
+                        | String.StartsWith "https://gitlab.com" _-> sprintf "%s#L%d" (url |> replace "/raw/" "/blob/") r.StartLine
                         | other -> other
 
                     if fireNavigationEvent then

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -343,11 +343,12 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                              r.StartLine
 
                         match url with
-                        | githubUserContent when githubUserContent.StartsWith("https://raw.githubusercontent.com") -> formattedGithubUrl
-                        | githubRaw when githubRaw.StartsWith("https://raw.github.com") -> formattedGithubUrl
-                        | github when github.StartsWith("https://github.com") -> formattedGithubUrl
-                        | bitbucket when bitbucket.StartsWith("https://bitbucket.org") -> 
+                        | String.StartsWith "https://raw.githubusercontent.com" _-> formattedGithubUrl
+                        | String.StartsWith "https://raw.github.com" _-> formattedGithubUrl
+                        | String.StartsWith "https://github.com" _-> formattedGithubUrl
+                        | String.StartsWith "https://bitbucket.org" _-> 
                             sprintf "%s#cl-%d" (url |> replace "/raw/" "/src/") r.StartLine
+                        | String.Contains ".codebasehq.com" _-> sprintf "%s#L%d" (url |> replace "/raw/" "/blob/") r.StartLine
                         | other -> other
 
                     if fireNavigationEvent then


### PR DESCRIPTION
This should allow support for bitbucket urls when navigating to source. Bitbucket doesn't have a "raw" subdomain and the link anchor is different to github.

Haven't managed to get this installed locally but I'll give it a try when the appveyor ci builds this branch (hopefully).