### PR TITLE
Set VSIX dependency on Visual F# Tools

### DIFF
--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="1.9.4" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="1.11.2" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A collection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>
@@ -13,12 +13,12 @@
     <Tags>fsharp, f#, power tools, editing, formatting, navigation, highlighting, refactoring</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="11.0" />
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0,13.0)" />
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[13.0,15.0)" />
   </Installation>
   <Dependencies>
-  </Dependencies>
+    <Dependency d:Source="Installed" Id="FSharp.Editor" DisplayName="Microsoft Visual FSharp Editor Extensions" Version="[12.0,15.0)" d:InstallSource="Download" Location="http://www.microsoft.com/en-us/download/details.aspx?id=48179" />
+    </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
This is an attempt to prevent #1048.

Drop support for VS 2012 since it's not possible to set dependency on VS 2012.

I will create a `vs2012` branch and have an archived vsix on AppVeyor for anyone who stucks with VS2012.