### PR TITLE
Skip object identifiers when checking for unused symbols

### DIFF
--- a/src/FSharpVSPowerTools.Core/TypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/TypedAstUtils.fs
@@ -302,6 +302,8 @@ module UnusedDeclarations =
             | Entity ((Record | UnionType | Interface | FSharpModule), _, _) -> None
             // FCS returns inconsistent results for override members; we're going to skip these symbols.
             | MemberFunctionOrValue func when func.IsOverrideOrExplicitInterfaceImplementation -> None
+            // Ignore object identifiers i.e. 'this' since graying them out could be annoying. 
+            | MemberFunctionOrValue func when func.IsMemberThisValue -> None
             // Usage of DU case parameters does not give any meaningful feedback; we never gray them out.
             | Parameter -> None
             | _ ->

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -3,8 +3,8 @@
 #r "../../packages/NUnit/lib/nunit.framework.dll"
 #load "../../src/FSharpVSPowerTools.Core/Utils.fs"
       "../../src/FSharpVSPowerTools.Core/CompilerLocationUtils.fs"
-      "../../src/FSharpVSPowerTools.Core/TypedAstUtils.fs"
       "../../src/FSharpVSPowerTools.Core/UntypedAstUtils.fs"
+      "../../src/FSharpVSPowerTools.Core/TypedAstUtils.fs"
       "../../src/FSharpVSPowerTools.Core/Lexer.fs"
       "../../src/FSharpVSPowerTools.Core/AssemblyContentProvider.fs"
       "../../src/FSharpVSPowerTools.Core/LanguageService.fs"
@@ -179,6 +179,14 @@ type Class() =
     member __.Prop = ()
 """
    => [ 3, [ Cat.Operator, 19, 20]]
+
+[<Test>]
+let ``ignore object identifiers``() = 
+ """
+type Class() =
+    member x.Prop = ()
+"""
+   => [ 3, [ Cat.Operator, 18, 19 ]]
 
 [<Test>]
 let ``static method``() = 
@@ -878,7 +886,7 @@ let ``unused self binding``() =
 type PublicClass() =
     member this.PublicMethod _ = ()
 """ 
-    => [ 3, [ Cat.Unused, 11, 15; Cat.Function, 16, 28; Cat.Operator, 31, 32 ]]
+    => [ 3, [ Cat.Function, 16, 28; Cat.Operator, 31, 32 ]]
 
 [<Test>]
 let ``used self binding``() =


### PR DESCRIPTION
UserVoice request: http://vfpt.uservoice.com/forums/247560-general/suggestions/8793808-do-not-mark-orange-in-the-right-bar-unused-self-re

Graying out object identifiers could be annoying. Since it has little practical value, we skip it while checking for unused references.