### PR TITLE
Support generating XmlDoc of let bindings to anonymous functions

### DIFF
--- a/FSharpVSPowerTools.v14.sln
+++ b/FSharpVSPowerTools.v14.sln
@@ -58,7 +58,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test samples", "test samples", "{CDFE262B-BF3B-4B13-B3E6-859CC2A82F0D}"
 	ProjectSection(SolutionItems) = preProject
 		tests\FSharpVSPowerTools.Core.Tests\Coloring.fs = tests\FSharpVSPowerTools.Core.Tests\Coloring.fs
+		tests\FSharpVSPowerTools.Core.Tests\DepthColorizerSampleFile.fs = tests\FSharpVSPowerTools.Core.Tests\DepthColorizerSampleFile.fs
 		tests\FSharpVSPowerTools.Core.Tests\InterfaceSampleFile.fs = tests\FSharpVSPowerTools.Core.Tests\InterfaceSampleFile.fs
+		tests\FSharpVSPowerTools.Core.Tests\SampleFile.fs = tests\FSharpVSPowerTools.Core.Tests\SampleFile.fs
 		tests\FSharpVSPowerTools.Core.Tests\Tutorial.fs = tests\FSharpVSPowerTools.Core.Tests\Tutorial.fs
 	EndProjectSection
 EndProject

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,8 @@
 * Implement FSharpLint integration ([#1034](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1034))
 * Support relevant FSharp.Core.dll based on VS versions ([#1065](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1065))
 * Show Lightbulb instead of SmartTag on VS 2015 ([#1069](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1069))
+* Faster closing of VS solutions ([#1076](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1076))
+* Support lightweight interface implementation ([#1091](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1091))
 
 #### 2.0.0 - July 26 2015
 * Optimize dialog layouts for high DPI ([#1024](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1024))

--- a/src/FSharpVSPowerTools.Core/XmlDocParser.fs
+++ b/src/FSharpVSPowerTools.Core/XmlDocParser.fs
@@ -64,9 +64,20 @@ module internal XmlDocParsing =
                 let indent = indentOf line
                 [ for SynBinding.Binding(_, _, _, _, _, _, synValData, synPat, _, _, _, _) in synBindingList do
                       match synValData with
-                      | SynValData(_memberFlagsOpt, SynValInfo(args, _), _) when args.Length > 0 -> 
-                          let paramNames = digNamesFrom synPat
-                          yield! paramNames
+                      | SynValData(_memberFlagsOpt, SynValInfo(args, _), _) when not (List.isEmpty args) -> 
+                          let parameters =
+                              args 
+                              |> List.collect (
+                                    List.collect (fun (SynArgInfo(_, _, ident)) -> 
+                                        match ident with 
+                                        | Some ident -> [ident.idText]
+                                        | None -> []))
+                          match parameters with
+                          | [] ->
+                              let paramNames = digNamesFrom synPat
+                              yield! paramNames
+                          | _ :: _ ->
+                             yield! parameters
                       | _ -> () ]
                 |> fun paramNames -> [ XmlDocable(line,indent,paramNames) ]
             | SynModuleDecl.Types(synTypeDefnList, _) -> (synTypeDefnList |> List.collect getXmlDocablesSynTypeDefn)

--- a/src/FSharpVSPowerTools/UI/GeneralOptionsControl.Designer.cs
+++ b/src/FSharpVSPowerTools/UI/GeneralOptionsControl.Designer.cs
@@ -467,9 +467,9 @@ namespace FSharpVSPowerTools
             this.chbLinter.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbLinter.Name = "chbLinter";
             this.chbLinter.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbLinter.Size = new System.Drawing.Size(62, 17);
+            this.chbLinter.Size = new System.Drawing.Size(139, 17);
             this.chbLinter.TabIndex = 23;
-            this.chbLinter.Text = "Linter";
+            this.chbLinter.Text = "FSharpLint integration";
             this.chbLinter.UseVisualStyleBackColor = true;
             // 
             // lblInformation

--- a/tests/FSharpVSPowerTools.Core.Tests/SampleFile.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SampleFile.fs
@@ -91,3 +91,9 @@ type TypeWithXmlDocComment() =
     member x.X = ()
     /// member
     member x.Y = ()
+
+let f = 0
+
+let func : int -> int -> int list =
+    fun x y ->
+        List.append [x] [y]

--- a/tests/FSharpVSPowerTools.Core.Tests/XmlDocTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/XmlDocTests.fs
@@ -1,6 +1,6 @@
 ﻿#if INTERACTIVE
 #r "../../bin/FSharp.Compiler.Service.dll"
-#r "../../bin/FSharpVSPowerTools.Core.dll"
+#load "../../src/FSharpVSPowerTools.Core/XmlDocParser.fs"
 #r "../../packages/NUnit/lib/nunit.framework.dll"
 #load "TestHelpers.fs"
 #else
@@ -45,6 +45,10 @@ let ``should create XML Doc for members``() =
     Set.contains (XmlDocable(27, 4, [])) output |> assertEqual true
     Set.contains (XmlDocable(33, 4, ["x"; "y"])) output |> assertEqual true
     Set.contains (XmlDocable(91, 4, [])) output |> assertEqual true
+
+[<Test>]
+let ``should create XML Doc for let bindings of anonymous functions``() =
+    Set.contains (XmlDocable(97, 0, [ "x"; "y"])) output |> assertEqual true
 
 [<Test>]
 let ``should not create XML Doc for members which already have non-empty XML Docs``() =


### PR DESCRIPTION
Close #1085.

We support this use case because the information is available from F# untyped ASTs.