### PR TITLE
Enable formatting tests again

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -3,8 +3,8 @@ NUGET
   specs:
     Expression.Blend.Sdk (1.0.2)
     FAKE (4.0.3)
-    Fantomas (1.10.0)
-      FSharp.Compiler.Service (>= 1.4.0.1)
+    Fantomas (1.11.0)
+      FSharp.Compiler.Service (>= 1.4.0.5)
     Foq (1.7.1)
     FsCheck (2.0.5)
       FSharp.Core (>= 3.1.2.5)

--- a/tests/FSharpVSPowerTools.Tests/FormattingCommandTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/FormattingCommandTests.fs
@@ -27,7 +27,7 @@ module FormattingCommandTests =
     let helper = FormattingCommandHelper()
     let fileName = getTempFileName ".fs"
 
-    [<Test; RequiresSTA; Ignore "Fantomas does not play well with FCS 1.4.0.4">]
+    [<Test; RequiresSTA>]
     let ``should be able to format document``() =
         let content = """
 type Type
@@ -59,7 +59,7 @@ type Type =
         | TyCon(s, ts) -> s
 """
 
-    [<Test; RequiresSTA; Ignore "Fantomas does not play well with FCS 1.4.0.4">]
+    [<Test; RequiresSTA>]
     let ``should be able to format selection``() =
         let content = """
 let rangeTest testValue mid size =


### PR DESCRIPTION
Update Fantomas to v1.11.0.
Fix https://github.com/fsprojects/VisualFSharpPowerTools/issues/366.