### PR TITLE
"Go To Definition" to handle #load directives

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -52,7 +52,7 @@ let msBuildVersionToTry = ["12.0";"14.0"]
 
 let maybeVersion =
     msBuildVersionToTry
-    |> Seq.map (fun v -> ProgramFilesX86 @@ (sprintf @"\MSbuild\%s\Bin\MSbuild.exe"))
+    |> Seq.map (fun v -> ProgramFilesX86 @@ (sprintf @"\MSbuild\%s\Bin\MSbuild.exe" v))
     |> Seq.tryFind File.Exists
     
 match maybeVersion with

--- a/build.fsx
+++ b/build.fsx
@@ -47,9 +47,6 @@ let gitHome = "https://github.com/" + gitOwner
 let gitName = "VisualFSharpPowerTools"
 let cloneUrl = "git@github.com:fsprojects/VisualFSharpPowerTools.git"
 
-// Ensure to use MSBuild 12 for the main solution if it exists, otherwise use version 14
-let msBuildVersionToTry = ["12.0";"14.0"]
-
 // Default to MSBuild 12 if present
 let msBuildPath = (ProgramFilesX86 @@ @"\MSBuild\12.0\Bin\MSBuild.exe")
 if File.Exists msBuildPath then

--- a/build.fsx
+++ b/build.fsx
@@ -50,14 +50,10 @@ let cloneUrl = "git@github.com:fsprojects/VisualFSharpPowerTools.git"
 // Ensure to use MSBuild 12 for the main solution if it exists, otherwise use version 14
 let msBuildVersionToTry = ["12.0";"14.0"]
 
-let maybeVersion =
-    msBuildVersionToTry
-    |> Seq.map (fun v -> ProgramFilesX86 @@ (sprintf @"\MSbuild\%s\Bin\MSbuild.exe" v))
-    |> Seq.tryFind File.Exists
-    
-match maybeVersion with
-| None -> failwithf "couldn't find MSBuild"
-| Some msBuildPath -> setEnvironVar "MSBuild" msBuildPath
+// Default to MSBuild 12 if present
+let msBuildPath = (ProgramFilesX86 @@ @"\MSBuild\12.0\Bin\MSBuild.exe")
+if File.Exists msBuildPath then
+    setEnvironVar "MSBuild" msBuildPath
 
 // Read additional information from the release notes document
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__

--- a/build.fsx
+++ b/build.fsx
@@ -47,8 +47,17 @@ let gitHome = "https://github.com/" + gitOwner
 let gitName = "VisualFSharpPowerTools"
 let cloneUrl = "git@github.com:fsprojects/VisualFSharpPowerTools.git"
 
-// Ensure to use MSBuild 12 for the main solution
-setEnvironVar "MSBuild" (ProgramFilesX86 @@ @"\MSBuild\12.0\Bin\MSBuild.exe")
+// Ensure to use MSBuild 12 for the main solution if it exists, otherwise use version 14
+let msBuildVersionToTry = ["12.0";"14.0"]
+
+let maybeVersion =
+    msBuildVersionToTry
+    |> Seq.map (fun v -> ProgramFilesX86 @@ (sprintf @"\MSbuild\%s\Bin\MSbuild.exe"))
+    |> Seq.tryFind File.Exists
+    
+match maybeVersion with
+| None -> failwithf "couldn't find MSBuild"
+| Some msBuildPath -> setEnvironVar "MSBuild" msBuildPath
 
 // Read additional information from the release notes document
 Environment.CurrentDirectory <- __SOURCE_DIRECTORY__

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,7 @@
 source http://nuget.org/api/v2
 
 nuget FAKE
+nuget FSharp.Management
 nuget NUnit.Runners
 nuget FSharp.Core 3.1.2.5
 nuget FSharp.Formatting

--- a/paket.lock
+++ b/paket.lock
@@ -13,6 +13,7 @@ NUGET
     FSharp.Formatting (2.10.0)
       FSharp.Compiler.Service (>= 0.0.87)
       FSharpVSPowerTools.Core (1.8.0)
+    FSharp.Management (0.3.0)
     FSharp.ViewModule.Core (0.9.9.1)
     FSharpLint.Core (0.0.6)
       FSharp.Compiler.Service (>= 1.4.0.1)

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -749,16 +749,14 @@ module HashDirectiveInfo =
     /// returns the Some (complete file name of a resolved #load directive at position) or None
     let getHashLoadDirectiveResolvedPathAtPosition (pos: pos) (ast: ParsedInput) : string option =
         let l = pos.Line
-        let directive =
-            getIncludeAndLoadDirectives ast
-            |> Array.tryFind (function
-                | Load(ExistingFile _, range)
-                  // check the line is within the range
-                  // (doesn't work when there are multiple files given to a single #load directive)
-                  when range.StartLine <= l && range.EndLine >= l
-                    -> true
-                | _ -> false
-            )
-        match directive with
-        | Some ( Load( ExistingFile f, _) ) -> Some f
-        | _ -> None
+
+        getIncludeAndLoadDirectives ast
+        |> Array.tryPick (
+            function
+            | Load(ExistingFile f, range) 
+                // check the line is within the range
+                // (doesn't work when there are multiple files given to a single #load directive)
+                when range.StartLine <= l && range.EndLine >= l
+                    -> Some f
+            | _     -> None
+        )

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -748,8 +748,6 @@ module HashDirectiveInfo =
 
     /// returns the Some (complete file name of a resolved #load directive at position) or None
     let getHashLoadDirectiveResolvedPathAtPosition (pos: pos) (ast: ParsedInput) : string option =
-        let l = pos.Line
-
         getIncludeAndLoadDirectives ast
         |> Array.tryPick (
             function

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -756,7 +756,7 @@ module HashDirectiveInfo =
             | Load(ExistingFile f, range) 
                 // check the line is within the range
                 // (doesn't work when there are multiple files given to a single #load directive)
-                when range.StartLine <= l && range.EndLine >= l
+                when rangeContainsPos range pos
                     -> Some f
             | _     -> None
         )

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -686,9 +686,9 @@ module HashDirectiveInfo =
         let isPathRooted = Path.IsPathRooted
         let getDirectoryOfFile = Path.GetFullPathSafe >> Path.GetDirectoryName
         let getRootedDirectory = Path.GetFullPathSafe
-        let makeRootedDirectoryIfNecessary directory =
+        let makeRootedDirectoryIfNecessary baseDirectory directory =
             if not (isPathRooted directory) then
-                getRootedDirectory directory
+                getRootedDirectory (baseDirectory </> directory)
             else
                 directory
 
@@ -700,8 +700,8 @@ module HashDirectiveInfo =
                 for decl in declarations do
                     match decl with
                     | SynModuleDecl.HashDirective(ParsedHashDirective("I",[directory],range),_) ->
-                        let directory = makeRootedDirectoryIfNecessary directory
-
+                        let directory = makeRootedDirectoryIfNecessary (getDirectoryOfFile file) directory
+                        
                         if directoryExists directory then
                             let includeDirective = ResolvedDirectory(directory)
                             pushInclude includeDirective

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -51,10 +51,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
             let filepath = textDocument.FilePath
             let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
             let! doc = dte.GetCurrentDocument(filepath)
-            let! project = maybe {
-                let! project = projectFactory.CreateForDocument view.TextBuffer doc
-                return project
-            }
+            let! project = projectFactory.CreateForDocument view.TextBuffer doc
             return (filepath, project, doc)
         }
 

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -46,13 +46,24 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
     let urlChanged = if fireNavigationEvent then Some (Event<UrlChangeEventArgs>()) else None
     let mutable currentUrl = None
 
+    let getCurrentFilePathProjectAndDoc () =
+        maybe {
+            let filepath = textDocument.FilePath
+            let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+            let! doc = dte.GetCurrentDocument(filepath)
+            let! project = maybe {
+                let! project = projectFactory.CreateForDocument view.TextBuffer doc
+                return project
+            }
+            return (filepath, project, doc)
+        }
+
     let getDocumentState () =
         async {
-            let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+            
             let projectItems = maybe {
+                let! _, project, doc = getCurrentFilePathProjectAndDoc()
                 let! caretPos = view.TextBuffer.GetSnapshotPoint view.Caret.Position
-                let! doc = dte.GetCurrentDocument(textDocument.FilePath)
-                let! project = projectFactory.CreateForDocument view.TextBuffer doc
                 let! span, symbol = vsLanguageService.GetSymbol(caretPos, project)
                 return doc.FullName, project, span, symbol }
 
@@ -421,10 +432,21 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                 match symbolResult with
                 | Some (_, _, _, _, FSharpFindDeclResult.DeclFound _) 
                 | None ->
-                    // Run the operation on UI thread since continueCommandChain may access UI components.
-                    do! Async.SwitchToContext uiContext
-                    // Declaration location might exist so let Visual F# Tools handle it. 
-                    return continueCommandChain()
+                    // no FSharpSymbol found, here we look at #load directive
+                    let directive = maybe {
+                        let! filepath, project, _ = getCurrentFilePathProjectAndDoc()
+                        let! directive = Async.RunSynchronously <| vsLanguageService.GetLoadDirectiveFileNameAtCursor(filepath, view, project)
+                        return directive
+                    }
+                    match directive with
+                    | Some fileToOpen ->
+                        // directive found, navigate to the file at first line
+                        serviceProvider.NavigateTo(fileToOpen, 0, 0, 0, 0)
+                    | None ->
+                        // Run the operation on UI thread since continueCommandChain may access UI components.
+                        do! Async.SwitchToContext uiContext
+                        // Declaration location might exist so let Visual F# Tools handle it. 
+                        return continueCommandChain()
                 | Some (project, parseTree, span, fsSymbolUse, FSharpFindDeclResult.DeclNotFound _) ->
                     match navigationPreference with
                     | NavigationPreference.Metadata ->

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -430,11 +430,11 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                 | Some (_, _, _, _, FSharpFindDeclResult.DeclFound _) 
                 | None ->
                     // no FSharpSymbol found, here we look at #load directive
-                    let directive = maybe {
-                        let! filepath, project, _ = getCurrentFilePathProjectAndDoc()
-                        let! directive = Async.RunSynchronously <| vsLanguageService.GetLoadDirectiveFileNameAtCursor(filepath, view, project)
-                        return directive
-                    }
+                    let! directive = 
+                        asyncMaybe {
+                            let! filepath, project, _ = getCurrentFilePathProjectAndDoc()
+                            return! vsLanguageService.GetLoadDirectiveFileNameAtCursor(filepath, view, project)
+                        }
                     match directive with
                     | Some fileToOpen ->
                         // directive found, navigate to the file at first line

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -314,6 +314,18 @@ type VSLanguageService
                 return None
         }
 
+    member __.GetLoadDirectiveFileNameAtCursor (fileName, view: Microsoft.VisualStudio.Text.Editor.ITextView, project) =
+        async {
+            let source = view.TextBuffer.CurrentSnapshot.GetText()
+            let! parseResult = __.ParseFileInProject(fileName, source, project)
+            return maybe {
+                let! pos = view.posAtCaretPosition()
+                let! ast = parseResult.ParseTree
+                let! result = UntypedAstUtils.HashDirectiveInfo.getHashLoadDirectiveResolvedPathAtPosition pos ast
+                return result
+            }
+        }
+
     member __.GetOpenDeclarationTooltip (line, colAtEndOfNames, lineStr, names, project: IProjectProvider, file, source) =
         async {
             let! opts = project.GetProjectCheckerOptions instance

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -319,7 +319,7 @@ type VSLanguageService
             let source = view.TextBuffer.CurrentSnapshot.GetText()
             let! parseResult = __.ParseFileInProject(fileName, source, project)
             return maybe {
-                let! pos = view.posAtCaretPosition()
+                let! pos = view.PosAtCaretPosition()
                 let! ast = parseResult.ParseTree
                 let! result = UntypedAstUtils.HashDirectiveInfo.getHashLoadDirectiveResolvedPathAtPosition pos ast
                 return result

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -88,6 +88,8 @@ type ITextBuffer with
         event.Trigger(sender, SnapshotSpanEventArgs(span))
 
 type ITextView with
+    /// Return a simple zero-based (line, column) tuple from 
+    /// actual caret position in this ITextView
     member x.GetCaretPosition () =
         maybe {
           let! point = x.TextBuffer.GetSnapshotPoint x.Caret.Position
@@ -95,7 +97,11 @@ type ITextView with
           let col = point.Position - point.GetContainingLine().Start.Position
           return (line, col)
         }
-    member x.posAtCaretPosition () =
+
+    /// Return Microsoft.FSharp.Compiler.Range.pos from actual 
+    /// caret position in this ITextView taking care of off by 
+    /// 1 indexing between VS and FCS
+    member x.PosAtCaretPosition () =
         maybe {
           let! line, col = x.GetCaretPosition()
           return Microsoft.FSharp.Compiler.Range.mkPos (line+1) (col+1)

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -87,6 +87,20 @@ type ITextBuffer with
         let span = SnapshotSpan(x.CurrentSnapshot, 0, x.CurrentSnapshot.Length)
         event.Trigger(sender, SnapshotSpanEventArgs(span))
 
+type ITextView with
+    member x.GetCaretPosition () =
+        maybe {
+          let! point = x.TextBuffer.GetSnapshotPoint x.Caret.Position
+          let line = point.Snapshot.GetLineNumberFromPosition point.Position
+          let col = point.Position - point.GetContainingLine().Start.Position
+          return (line, col)
+        }
+    member x.posAtCaretPosition () =
+        maybe {
+          let! line, col = x.GetCaretPosition()
+          return Microsoft.FSharp.Compiler.Range.mkPos (line+1) (col+1)
+        }
+
 open System.Runtime.InteropServices
 open Microsoft.VisualStudio
 open Microsoft.VisualStudio.Editor

--- a/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
@@ -69,10 +69,14 @@
     <Compile Include="RecordStubGeneratorTests.fs" />
     <Compile Include="UnionPatternMatchCaseGeneratorTests.fs" />
     <Compile Include="GoToDefinitionTests.fs" />
+    <Compile Include="GoToDefinitionTests.LoadDirective.fs" />
     <Compile Include="UnopenedNamespacesResolverTests.fs" />
     <Compile Include="TaskListCommentExtractorTests.fs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Management">
+      <HintPath>..\..\packages\FSharp.Management\lib\net40\FSharp.Management.dll</HintPath>
+    </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
@@ -220,6 +220,37 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
+      <ItemGroup>
+        <Reference Include="FSharp.Management.PowerShell.ExternalRuntime">
+          <HintPath>..\..\packages\FSharp.Management\lib\net40\FSharp.Management.PowerShell.ExternalRuntime.exe</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="FSharp.Management.PowerShell">
+          <HintPath>..\..\packages\FSharp.Management\lib\net40\FSharp.Management.PowerShell.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="FSharp.Management.WMI.DesignTime">
+          <HintPath>..\..\packages\FSharp.Management\lib\net40\FSharp.Management.WMI.DesignTime.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="FSharp.Management.WMI">
+          <HintPath>..\..\packages\FSharp.Management\lib\net40\FSharp.Management.WMI.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="System.Management.Automation">
+          <HintPath>..\..\packages\FSharp.Management\lib\net40\System.Management.Automation.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
     <Reference Include="nunit.framework">
       <HintPath>..\..\packages\NUnit\lib\nunit.framework.dll</HintPath>

--- a/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.LoadDirective.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.LoadDirective.fs
@@ -1,4 +1,4 @@
-﻿module GoToDefinitionTests
+﻿module FSharpVSPowerTools.Core.Tests.GoToDefinition.LoadDirectiveTests
 
 open System.IO
 open Microsoft.FSharp.Compiler.Range
@@ -18,7 +18,7 @@ let canonicalizeFilename filename = Path.GetFullPathSafe filename //(new FileInf
 let getAst filename = 
     let contents = File.ReadAllText(filename)
 
-      // Get compiler options for the 'project' implied by a single script file
+    // Get compiler options for the 'project' implied by a single script file
     let projOptions = 
         checker.GetProjectOptionsFromScript(filename, contents)
         |> Async.RunSynchronously
@@ -41,6 +41,7 @@ let ``test1.fsx: verify parsed #load directives``() =
        [
        Some <| FileInfo(dataFolder.ParseLoadDirectives.includes.``a.fs``).FullName
        Some <| FileInfo(dataFolder.ParseLoadDirectives.includes.``b.fs``).FullName
+       Some <| FileInfo(dataFolder.ParseLoadDirectives.includes.``b.fs``).FullName
        ]
    
    let results =
@@ -49,6 +50,7 @@ let ``test1.fsx: verify parsed #load directives``() =
           | Load(ExistingFile(filename), _) -> Some ((new FileInfo(filename)).FullName)
           | _ -> None
        )
+       |> Seq.filter (Option.isSome)
        |> Seq.toList
    
    Assert.AreEqual(expectedMatches, results)

--- a/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.LoadDirective.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/GoToDefinitionTests.LoadDirective.fs
@@ -1,0 +1,80 @@
+﻿module GoToDefinitionTests
+
+open System.IO
+open Microsoft.FSharp.Compiler.Range
+open Microsoft.FSharp.Compiler.SourceCodeServices
+open NUnit.Framework
+open FSharpVSPowerTools.Pervasive
+open FSharpVSPowerTools.UntypedAstUtils.HashDirectiveInfo
+
+[<Literal>]
+let dataFolderName = __SOURCE_DIRECTORY__ + "/../data/"
+type dataFolder = FSharp.Management.FileSystem<dataFolderName>
+
+let checker = FSharpChecker.Create()
+
+let canonicalizeFilename filename = Path.GetFullPathSafe filename //(new FileInfo(filename)).FullName
+
+let getAst filename = 
+    let contents = File.ReadAllText(filename)
+
+      // Get compiler options for the 'project' implied by a single script file
+    let projOptions = 
+        checker.GetProjectOptionsFromScript(filename, contents)
+        |> Async.RunSynchronously
+
+    let parseFileResults = 
+        checker.ParseFileInProject(filename, contents, projOptions) 
+        |> Async.RunSynchronously
+
+    match parseFileResults.ParseTree with
+    | Some tree -> tree
+    | None -> failwith "Something went wrong during parsing!"
+
+
+[<Test>]
+let ``test1.fsx: verify parsed #load directives``() =
+   let ast = getAst dataFolder.ParseLoadDirectives.``test1.fsx``
+   let directives = getIncludeAndLoadDirectives ast
+   
+   let expectedMatches =
+       [
+       Some <| FileInfo(dataFolder.ParseLoadDirectives.includes.``a.fs``).FullName
+       Some <| FileInfo(dataFolder.ParseLoadDirectives.includes.``b.fs``).FullName
+       ]
+   
+   let results =
+       directives
+       |> Seq.map (function
+          | Load(ExistingFile(filename), _) -> Some ((new FileInfo(filename)).FullName)
+          | _ -> None
+       )
+       |> Seq.toList
+   
+   Assert.AreEqual(expectedMatches, results)
+
+[<Test>]
+let ``test1.fsx: verify parsed position lookup of individual #load directives``() =
+   let ast = getAst dataFolder.ParseLoadDirectives.``test1.fsx``
+   
+   let expectations = [
+     (mkPos 1 1,       Some dataFolder.ParseLoadDirectives.includes.``a.fs``)
+     (mkPos 1 5,       Some dataFolder.ParseLoadDirectives.includes.``a.fs``)
+     (mkPos 2 1,       Some dataFolder.ParseLoadDirectives.includes.``b.fs``)
+     (mkPos 2 5,       Some dataFolder.ParseLoadDirectives.includes.``b.fs``)
+     (mkPos 3 1000,    None)
+     (mkPos 4 5,       Some dataFolder.ParseLoadDirectives.includes.``b.fs``)
+   ]
+   
+   let results =
+       expectations
+       |> Seq.map fst
+       |> Seq.map (fun pos -> 
+          let result = getHashLoadDirectiveResolvedPathAtPosition pos ast
+          match result with
+          | None      -> pos, None
+          | Some path -> pos, Some (canonicalizeFilename path)
+       )
+       |> Seq.toList
+   
+   Assert.AreEqual(expectations, results)

--- a/tests/FSharpVSPowerTools.Core.Tests/app.config
+++ b/tests/FSharpVSPowerTools.Core.Tests/app.config
@@ -10,6 +10,10 @@
         <bindingRedirect oldVersion="4.0.0.0" newVersion="4.3.1.0" />
         <bindingRedirect oldVersion="4.3.0.0" newVersion="4.3.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="12.0.0.0" newVersion="14.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>

--- a/tests/FSharpVSPowerTools.Core.Tests/paket.references
+++ b/tests/FSharpVSPowerTools.Core.Tests/paket.references
@@ -2,3 +2,4 @@ FsCheck
 FSharp.Compiler.Service
 NUnit
 FSharp.Core
+FSharp.Management

--- a/tests/FSharpVSPowerTools.Tests/FSharpVSPowerTools.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Tests/FSharpVSPowerTools.Tests.fsproj
@@ -97,6 +97,8 @@
     <Compile Include="ImplementInterfaceSmartTaggerTests.fs" />
     <Compile Include="GoToDefinitionFilterCommandTests.fs" />
     <Compile Include="LintTaggerTests.fs" />
+    <None Include="Scripts\load-references.fsx" />
+    <None Include="Scripts\load-project.fsx" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/tests/FSharpVSPowerTools.Tests/FSharpVSPowerTools.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Tests/FSharpVSPowerTools.Tests.fsproj
@@ -97,8 +97,6 @@
     <Compile Include="ImplementInterfaceSmartTaggerTests.fs" />
     <Compile Include="GoToDefinitionFilterCommandTests.fs" />
     <Compile Include="LintTaggerTests.fs" />
-    <None Include="Scripts\load-references.fsx" />
-    <None Include="Scripts\load-project.fsx" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />

--- a/tests/FSharpVSPowerTools.Tests/MockDTE.fs
+++ b/tests/FSharpVSPowerTools.Tests/MockDTE.fs
@@ -7,7 +7,7 @@ open System.Collections
 open FSharpVSPowerTools.ProjectSystem
 open FSharpVSPowerTools
 open System.Collections.Generic
-open FSharpVSPowerTools.Tests.TestHelpers
+
 /// Create a simple mock DTE for an F#-only solution
 type MockDTE() =
     let projects = Dictionary()

--- a/tests/FSharpVSPowerTools.Tests/MockDTE.fs
+++ b/tests/FSharpVSPowerTools.Tests/MockDTE.fs
@@ -7,7 +7,7 @@ open System.Collections
 open FSharpVSPowerTools.ProjectSystem
 open FSharpVSPowerTools
 open System.Collections.Generic
-
+open FSharpVSPowerTools.Tests.TestHelpers
 /// Create a simple mock DTE for an F#-only solution
 type MockDTE() =
     let projects = Dictionary()

--- a/tests/FSharpVSPowerTools.Tests/TestHelpers.fs
+++ b/tests/FSharpVSPowerTools.Tests/TestHelpers.fs
@@ -25,9 +25,6 @@ let createMockTextView buffer =
 let internal createVirtualProject(buffer, fileName) =
     VirtualProjectProvider(buffer, fileName, VisualStudioVersion.VS2013)
 
-let createVirtualProjectAsProjectProvider(buffer, fileName) =
-    createVirtualProject(buffer, fileName) :> IProjectProvider
-
 /// Tests that the specified condition is true.
 /// If not, calls Assert.Fail with a formatted string.
 let inline assertf (condition : bool) format : 'T =

--- a/tests/FSharpVSPowerTools.Tests/TestHelpers.fs
+++ b/tests/FSharpVSPowerTools.Tests/TestHelpers.fs
@@ -25,6 +25,9 @@ let createMockTextView buffer =
 let internal createVirtualProject(buffer, fileName) =
     VirtualProjectProvider(buffer, fileName, VisualStudioVersion.VS2013)
 
+let createVirtualProjectAsProjectProvider(buffer, fileName) =
+    createVirtualProject(buffer, fileName) :> IProjectProvider
+
 /// Tests that the specified condition is true.
 /// If not, calls Assert.Fail with a formatted string.
 let inline assertf (condition : bool) format : 'T =

--- a/tests/data/ParseLoadDirectives/test1.fsx
+++ b/tests/data/ParseLoadDirectives/test1.fsx
@@ -1,0 +1,4 @@
+#load @"./includes/a.fs"
+#load @".\includes\b.fs"
+#I "includes/"
+#load "b.fs"


### PR DESCRIPTION
I tested those changes on VS2015 and it seems to work, I had issues with VS2013 on one machine but they seem to be related to something else going on in my VS experimental instance (see commit message https://github.com/smoothdeveloper/VisualFSharpPowerTools/commit/094de24ac5419ae8262dee8ac81741c5ddbdf472)

Would appreciate if someone can try on other machines with VS2013, just load a .fsx which has #load directives and try "Go To Definition" on it.

Please let me know if you see any change in the code to be made.