### PR TITLE
Split lines refactoring

### DIFF
--- a/src/FSharpVSPowerTools.Core/DepthParser.fs
+++ b/src/FSharpVSPowerTools.Core/DepthParser.fs
@@ -372,7 +372,7 @@ type DepthParser private () =
     /// Note: The 'filename' is only used e.g. to look at the filename extension (e.g. ".fs" versus ".fsi"), this does not try to load the file off disk.  
     ///       Instead, 'sourceCodeOfTheFile' should contain the entire file as a giant string.
     static member GetRanges(sourceCodeOfTheFile: string, filename, ?checker: FSharpChecker) =
-        let sourceCodeLinesOfTheFile = sourceCodeOfTheFile.Split [|'\n'|]
+        let sourceCodeLinesOfTheFile = String.getLines sourceCodeOfTheFile
         DepthParser.Instance.GetRangesImpl(sourceCodeLinesOfTheFile, sourceCodeOfTheFile, filename, checker)
 
     /////////////////////////////////////////////////////
@@ -386,7 +386,7 @@ type DepthParser private () =
     ///       Instead, 'sourceCodeOfTheFile' should contain the entire file as a giant string.
     static member GetNonoverlappingDepthRanges(sourceCodeOfTheFile: string, filename, ?checker: FSharpChecker) =
         async {
-            let sourceCodeLinesOfTheFile = sourceCodeOfTheFile.Split([|"\r\n";"\n"|], StringSplitOptions.None)
+            let sourceCodeLinesOfTheFile = String.getLines sourceCodeOfTheFile
             let lineLens = sourceCodeLinesOfTheFile |> Seq.map (fun s -> s.TrimEnd(null).Length) |> (fun s -> Seq.append s [0]) |> Seq.toArray 
             let len line = lineLens.[line-1]  // line #s are 1-based
             let! nestedRanges = DepthParser.Instance.GetRangesImpl(sourceCodeLinesOfTheFile, sourceCodeOfTheFile, filename, checker)

--- a/src/FSharpVSPowerTools.Core/InterfaceStubGenerator.fs
+++ b/src/FSharpVSPowerTools.Core/InterfaceStubGenerator.fs
@@ -483,7 +483,7 @@ module InterfaceStubGenerator =
             (methodBody: string) (displayContext: FSharpDisplayContext) excludedMemberSignatures
             (e: FSharpEntity) verboseMode =
         Debug.Assert(isInterface e, "The entity should be an interface.")
-        let lines = methodBody.Replace("\r\n", "\n").Split('\n')
+        let lines = String.getLines methodBody
         use writer = new ColumnIndentedTextWriter()
         let typeParams = Seq.map getTypeParameterName e.GenericParameters
         let instantiations = 

--- a/src/FSharpVSPowerTools.Core/Lexer.fs
+++ b/src/FSharpVSPowerTools.Core/Lexer.fs
@@ -42,7 +42,7 @@ module Lexer =
                     loop lineTokenizer newLexState
 
             let sourceTokenizer = SourceTokenizer(defines, "/tmp.fsx")
-            let lines = source.Replace("\r\n","\n").Split('\r', '\n')
+            let lines = String.getLines source
             let lexState = ref 0L
             for line in lines do 
                 yield !lexState

--- a/src/FSharpVSPowerTools.Core/OpenDeclarationsGetter.fs
+++ b/src/FSharpVSPowerTools.Core/OpenDeclarationsGetter.fs
@@ -87,7 +87,7 @@ module OpenDeclarationGetter =
             |> List.choose (fun (s: string) ->
                  maybe {
                     let! name, from = 
-                        match s.Split ([|'\n'|], StringSplitOptions.RemoveEmptyEntries) with
+                        match String.getNonEmptyLines s with
                         | [|name; from|] -> Some (name, Some from)
                         | [|name|] -> Some (name, None)
                         | _ -> None

--- a/src/FSharpVSPowerTools.Core/SignatureGenerator.fs
+++ b/src/FSharpVSPowerTools.Core/SignatureGenerator.fs
@@ -843,7 +843,7 @@ and internal writeDocs writer docs getXmlDocSig xmlDocBySig =
         else docs :> seq<_>
 
     xmlDocs
-    |> Seq.collect (fun line -> line.Replace("\r\n", "\n").Split('\r', '\n'))
+    |> Seq.collect (String.getLines)
     |> Seq.iter (fun line -> writer.WriteLine("/// {0}", line.TrimStart()))
 
 and internal writeActivePattern ctx (case: FSharpActivePatternCase) =

--- a/src/FSharpVSPowerTools.Core/SignatureGenerator.fs
+++ b/src/FSharpVSPowerTools.Core/SignatureGenerator.fs
@@ -843,7 +843,7 @@ and internal writeDocs writer docs getXmlDocSig xmlDocBySig =
         else docs :> seq<_>
 
     xmlDocs
-    |> Seq.collect (String.getLines)
+    |> Seq.collect String.getLines
     |> Seq.iter (fun line -> writer.WriteLine("/// {0}", line.TrimStart()))
 
 and internal writeActivePattern ctx (case: FSharpActivePatternCase) =

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -420,7 +420,28 @@ module String =
         elif value.Contains(pattern) then
             Some value
         else None
-     
+    
+    open System.IO
+
+    let getLines (str: string) =
+        use reader = new StringReader(str)
+        [|
+        let line = ref (reader.ReadLine())
+        while (!line |> function | null -> false | _ -> true) do
+            yield !line
+            line := reader.ReadLine()
+        |]
+
+    let getNonEmptyLines (str: string) =
+        use reader = new StringReader(str)
+        [|
+        let line = ref (reader.ReadLine())
+        while ( !line |> function | null -> false | _ -> true ) do
+            if (!line).Length > 0 then
+                yield !line
+            line := reader.ReadLine()
+        |]
+
 [<AutoOpen; CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
 module Pervasive =
     open System.Diagnostics

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -375,77 +375,6 @@ module AsyncMaybe =
     let inline liftAsync (async : Async<'T>) : Async<_ option> =
         async |> Async.map Some
 
-[<RequireQualifiedAccess>]
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module String =
-    let lowerCaseFirstChar (str: string) =
-        match str with
-        | null -> null
-        | str ->
-            match str.ToCharArray() |> Array.toList with
-            | [] -> str
-            | h :: t when Char.IsUpper h -> String (Char.ToLower h :: t |> List.toArray)
-            | _ -> str
-
-    let extractTrailingIndex (str: string) =
-        match str with
-        | null -> null, None
-        | _ ->
-            str 
-            |> Seq.toList 
-            |> List.rev 
-            |> Seq.takeWhile Char.IsDigit 
-            |> Seq.toArray 
-            |> Array.rev
-            |> fun chars -> String(chars)
-            |> function
-               | "" -> str, None
-               | index -> str.Substring (0, str.Length - index.Length), Some (int index)
-
-    let trim (value: string) = match value with null -> null | x -> x.Trim()
-    
-    let split options (separator: string[]) (value: string) = 
-        match value with null -> null | x -> x.Split(separator, options)
-
-    let (|StartsWith|_|) pattern value =
-        if String.IsNullOrWhiteSpace(value) then
-            None
-        elif value.StartsWith(pattern) then
-            Some value
-        else None
-
-    let (|Contains|_|) pattern value =
-        if String.IsNullOrWhiteSpace(value) then
-            None
-        elif value.Contains(pattern) then
-            Some value
-        else None
-    
-    open System.IO
-
-    let getLines (str: string) =
-        use reader = new StringReader(str)
-        [|
-        let line = ref (reader.ReadLine())
-        while (!line |> function | null -> false | _ -> true) do
-            yield !line
-            line := reader.ReadLine()
-        if str.EndsWith("\n") then
-            // last trailing space not returned
-            // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak
-            yield String.Empty
-        |]
-
-    let getNonEmptyLines (str: string) =
-        use reader = new StringReader(str)
-        [|
-        let line = ref (reader.ReadLine())
-        while ( !line |> function | null -> false | _ -> true ) do
-            if (!line).Length > 0 then
-                yield !line
-            line := reader.ReadLine()
-        |]
-
 [<AutoOpen; CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
 module Pervasive =
     open System.Diagnostics
@@ -463,6 +392,9 @@ module Pervasive =
     let inline (===) a b = LanguagePrimitives.PhysicalEquality a b
     let inline debug msg = Printf.kprintf Debug.WriteLine msg
     let inline fail msg = Printf.kprintf Debug.Fail msg
+    let inline isNull v = match v with | null -> true | _ -> false
+    let inline isNotNull v = v |> (not << isNull)
+
     let maybe = MaybeBuilder()
     let asyncMaybe = AsyncMaybeBuilder()
     
@@ -539,6 +471,77 @@ module Pervasive =
 
     /// Path.Combine
     let (</>) path1 path2 = Path.Combine (path1, path2)
+
+[<RequireQualifiedAccess>]
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module String =
+    let lowerCaseFirstChar (str: string) =
+        match str with
+        | null -> null
+        | str ->
+            match str.ToCharArray() |> Array.toList with
+            | [] -> str
+            | h :: t when Char.IsUpper h -> String (Char.ToLower h :: t |> List.toArray)
+            | _ -> str
+
+    let extractTrailingIndex (str: string) =
+        match str with
+        | null -> null, None
+        | _ ->
+            str 
+            |> Seq.toList 
+            |> List.rev 
+            |> Seq.takeWhile Char.IsDigit 
+            |> Seq.toArray 
+            |> Array.rev
+            |> fun chars -> String(chars)
+            |> function
+               | "" -> str, None
+               | index -> str.Substring (0, str.Length - index.Length), Some (int index)
+
+    let trim (value: string) = match value with null -> null | x -> x.Trim()
+    
+    let split options (separator: string[]) (value: string) = 
+        match value with null -> null | x -> x.Split(separator, options)
+
+    let (|StartsWith|_|) pattern value =
+        if String.IsNullOrWhiteSpace(value) then
+            None
+        elif value.StartsWith(pattern) then
+            Some value
+        else None
+
+    let (|Contains|_|) pattern value =
+        if String.IsNullOrWhiteSpace(value) then
+            None
+        elif value.Contains(pattern) then
+            Some value
+        else None
+    
+    open System.IO
+
+    let getLines (str: string) =
+        use reader = new StringReader(str)
+        [|
+        let line = ref (reader.ReadLine())
+        while isNotNull (!line) do
+            yield !line
+            line := reader.ReadLine()
+        if str.EndsWith("\n") then
+            // last trailing space not returned
+            // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak
+            yield String.Empty
+        |]
+
+    let getNonEmptyLines (str: string) =
+        use reader = new StringReader(str)
+        [|
+        let line = ref (reader.ReadLine())
+        while isNotNull (!line) do
+            if (!line).Length > 0 then
+                yield !line
+            line := reader.ReadLine()
+        |]
 
 module Reflection =
     open System.Reflection

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -430,6 +430,10 @@ module String =
         while (!line |> function | null -> false | _ -> true) do
             yield !line
             line := reader.ReadLine()
+        if str.EndsWith("\n") then
+            // last trailing space not returned
+            // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak
+            yield String.Empty
         |]
 
     let getNonEmptyLines (str: string) =

--- a/src/FSharpVSPowerTools.Core/XmlDocParser.fs
+++ b/src/FSharpVSPowerTools.Core/XmlDocParser.fs
@@ -196,6 +196,6 @@ type XmlDocParser private () =
 
     /// Get the list of Xml documentation from current source code
     static member GetXmlDocables(sourceCodeOfTheFile: string, filename, ?checker) =
-        let sourceCodeLinesOfTheFile = sourceCodeOfTheFile.Split [|'\n'|]
+        let sourceCodeLinesOfTheFile = String.getLines sourceCodeOfTheFile
         let checker = defaultArg checker XmlDocParser.Instance.Checker
         getXmlDocablesImpl(sourceCodeLinesOfTheFile, sourceCodeOfTheFile, filename, checker)

--- a/src/FSharpVSPowerTools.Logic/QuickInfoMargin.fs
+++ b/src/FSharpVSPowerTools.Logic/QuickInfoMargin.fs
@@ -59,7 +59,7 @@ type QuickInfoMargin (textDocument: ITextDocument,
                 |> String.concat " ")
             |> Option.orElse (tooltip |> Option.bind (fun tooltip ->
                 tooltip 
-                |> String.split StringSplitOptions.RemoveEmptyEntries [|"\r\n"; "\r"; "\n"|] 
+                |> String.getNonEmptyLines
                 |> Array.toList 
                 |> List.tryHead
                 |> Option.map (fun str ->
@@ -76,7 +76,7 @@ type QuickInfoMargin (textDocument: ITextDocument,
         | null -> ""
         | x ->
             x 
-            |> String.split StringSplitOptions.RemoveEmptyEntries [|"\r\n"; "\r"; "\n"|]
+            |> String.getNonEmptyLines
             |> Array.mapi (fun i x -> 
                 if i > 0 && x.Length > 0 && Char.IsUpper x.[0] then ". " + (String.trim x) 
                 else " " + (String.trim x))

--- a/src/FSharpVSPowerTools.Logic/ReferenceSourceProvider.fs
+++ b/src/FSharpVSPowerTools.Logic/ReferenceSourceProvider.fs
@@ -25,7 +25,8 @@ type ReferenceSourceProvider(baseUrl: string) =
             use http = new HttpClient(handler)
             let! assemblyList = http.GetStringAsync(baseUrl + "/assemblies.txt") |> Async.AwaitTask
             let assemblies = 
-                assemblyList.Split([|'\r'; '\n'|], StringSplitOptions.RemoveEmptyEntries)
+                assemblyList 
+                |> String.getNonEmptyLines
                 |> Array.map (fun s -> s.Remove(s.IndexOf(';')))
                 |> Set.ofArray
             return availableAssemblies <- assemblies

--- a/src/FSharpVSPowerTools.Logic/TaskListCommentFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/TaskListCommentFilter.fs
@@ -3,6 +3,7 @@
 open System
 open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text
+open FSharpVSPowerTools
 open FSharpVSPowerTools.ProjectSystem
 
 type TaskListCommentFilter(view: IWpfTextView,
@@ -10,14 +11,13 @@ type TaskListCommentFilter(view: IWpfTextView,
                            taskListManager: TaskListManager) =
     let optionsReader = OptionsReader(serviceProvider)
 
-    static let newLines = [| Environment.NewLine; "\r\n"; "\r"; "\n" |]
     let handleTextChanged (newText: string) =
         match view.TextBuffer.Properties.TryGetProperty(typeof<ITextDocument>) with
         | true, x ->
             match box x with
             | :? ITextDocument as textDocument ->
                 let filePath = textDocument.FilePath
-                let lines = newText.Split(newLines, StringSplitOptions.None)
+                let lines = String.getLines newText
 
                 let comments = getComments (optionsReader.GetOptions()) filePath lines
                 taskListManager.MergeTaskListComments(filePath, comments)

--- a/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
@@ -79,7 +79,7 @@ type CodeGenerationTestService(languageService: LanguageService, compilerOptions
 
 type MockDocument(src: string) =
     let lines =
-        ResizeArray<_>(src.Split([|"\r\n"; "\n"|], StringSplitOptions.None))
+        ResizeArray<_>(String.getLines src)
 
     interface IDocument with
         member __.FullName = sprintf @"C:\file.fs"

--- a/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
@@ -92,7 +92,7 @@ type MockDocument(src: string) =
 [<AutoOpen>]
 module Helpers =
     let srcToLineArray (src: string) = 
-        src.Split([|"\r\n"; "\n"|], StringSplitOptions.None)
+        String.getLines src
         |> Array.map (fun line -> if line.Trim() = "" then "" else line)
 
     let assertSrcAreEqual expectedSrc actualSrc =

--- a/tests/FSharpVSPowerTools.Core.Tests/OpenDeclarationsGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/OpenDeclarationsGetterTests.fs
@@ -192,7 +192,7 @@ type OpenDecl = Parent option * Decl list
 
 let (=>) source (expected: (Line * (OpenDecl list)) list) = 
     let opts = opts source
-    let sourceLines = source.Replace("\r\n", "\n").Split('\n')
+    let sourceLines = String.getLines source
     let parseResults = languageService.ParseFileInProject(opts, fileName, source) |> Async.RunSynchronously
 
     let actualOpenDeclarations =

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -37,7 +37,7 @@ let opts source =
 let (=>) source (expected: (int * ((Cat * int * int) list)) list) = 
     let opts = opts source
     
-    let sourceLines = source.Replace("\r\n", "\n").Split('\n')
+    let sourceLines = String.getLines source
 
     let lexer = 
         { new LexerBase() with

--- a/tests/FSharpVSPowerTools.Core.Tests/TaskListCommentExtractorTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/TaskListCommentExtractorTests.fs
@@ -1,6 +1,7 @@
 ﻿module FSharpVSPowerTools.Core.Tests.TaskListCommentExtractorTests
 
 open NUnit.Framework
+open FSharpVSPowerTools
 open FSharpVSPowerTools.TaskList
 open System
 
@@ -32,7 +33,8 @@ let ``should match multi-line comments``() =
     let lines = "(* TODO x *)(* TODO y *) let x = 1
                  (*
                  TODO other things
-                 *)".Split(newlines, StringSplitOptions.None)
+                 *)"
+                 |> String.getLines
 
     (defaultOptions, "File1.fs", lines)
     => [|
@@ -115,7 +117,8 @@ let ``comments within strings are not considered``() =
                  let str2 = \"
                      (* TODO work *)
                      // TODO other stuff
-                 \"".Split(newlines, StringSplitOptions.None)
+                 \""
+                 |> String.getLines
 
     (defaultOptions, "File1.fs", lines)
     => [||]

--- a/tests/FSharpVSPowerTools.Tests/FindReferencesCommandTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/FindReferencesCommandTests.fs
@@ -59,8 +59,8 @@ type FindReferencesCommandHelper() =
     member __.ReferencesChanged = findReferencesBuffer.Changed
 
     member __.ReferencesResults = 
-        findReferencesBuffer.CurrentSnapshot.GetText().Split([|Environment.NewLine|], StringSplitOptions.RemoveEmptyEntries)
-        
+        findReferencesBuffer.CurrentSnapshot.GetText()
+        |> String.getNonEmptyLines
 
 module FindReferencesCommandTests =
     open System.IO


### PR DESCRIPTION
This replaces direct usages of String.Split whenever the intent was to get an array of lines.

Introduced two functions in Utils.fs:

* `String.getLines`
* `String.getNonEmptyLines`

the only non-obvious thing which happens is that in first function, an empty line has to be yielded at the end if the input string ends with a trailing linebreak, this is due to behaviour of `StringReader`.

I stepped through all the changes in debug, but couldn't step into those two places:
* `DepthParser.GetRange` I believe this method is not used anywhere, we might want to eventually delete it
* `XmlDocParser.GetXmlDocables` please let me know if you have a way to trigger this code, I tried adding comments after triple slashes and compiling a project, then using the documented member but couldn't step there