### PR TITLE
Colorize active patterns application as functions (WIP)

### DIFF
--- a/src/FSharpVSPowerTools.Core/Lexer.fs
+++ b/src/FSharpVSPowerTools.Core/Lexer.fs
@@ -120,10 +120,11 @@ module Lexer =
                     | LeftParenToken, _ -> acc, [ token ]
                     | BarToken, LeftParenToken :: _ -> acc, token :: lastTokens
                     | RightParenToken, BarToken :: (LeftParenToken as start) :: _ ->
+                        // do not include `(` and `)` since `FSharpSymbolUse` does not include them either.
                         let draftToken =
                             { Kind = Ident 
-                              LeftColumn = start.LeftColumn
-                              RightColumn = token.RightColumn
+                              LeftColumn = start.LeftColumn - 1
+                              RightColumn = token.RightColumn - 1
                               Tag = FSharpTokenTag.IDENT }
                         draftToken :: acc, []
                     | _, _ ->

--- a/src/FSharpVSPowerTools.Core/Lexer.fs
+++ b/src/FSharpVSPowerTools.Core/Lexer.fs
@@ -127,33 +127,33 @@ module Lexer =
                               Tag = FSharpTokenTag.IDENT }
                         draftToken :: acc, []
                     | _, _ ->
-                        let draftToken =
+                        let draftToken, lastTokens =
                             match token, lastTokens with
                             | IdentToken, GenericTypeParameterPrefix :: _ ->
                                 { Kind = GenericTypeParameter
-                                  LeftColumn = token.LeftColumn - 1  
-                                  RightColumn = token.LeftColumn + token.FullMatchedLength
-                                  Tag = token.Tag }
+                                  LeftColumn = token.LeftColumn - 1
+                                  RightColumn = token.LeftColumn + token.FullMatchedLength - 1
+                                  Tag = token.Tag }, []
                             | IdentToken, StaticallyResolvedTypeParameterPrefix lineStr :: _ ->
                                 { Kind = StaticallyResolvedTypeParameter 
-                                  LeftColumn = token.LeftColumn
-                                  RightColumn = token.LeftColumn + token.FullMatchedLength
-                                  Tag = token.Tag }
+                                  LeftColumn = token.LeftColumn - 1
+                                  RightColumn = token.LeftColumn + token.FullMatchedLength - 1
+                                  Tag = token.Tag }, []
                             | IdentToken, _ -> 
                                 { Kind = Ident 
                                   LeftColumn = token.LeftColumn
                                   RightColumn = token.LeftColumn + token.FullMatchedLength - 1
-                                  Tag = token.Tag }
+                                  Tag = token.Tag }, lastTokens
                             | OperatorToken, _ -> 
                                 { Kind = Operator
                                   LeftColumn = token.LeftColumn
                                   RightColumn = token.LeftColumn + token.FullMatchedLength - 1
-                                  Tag = token.Tag }
+                                  Tag = token.Tag }, lastTokens
                             | _, _ -> 
-                                { Kind = Ident 
+                                { Kind = Other 
                                   LeftColumn = token.LeftColumn
                                   RightColumn = token.LeftColumn + token.FullMatchedLength - 1
-                                  Tag = token.Tag }
+                                  Tag = token.Tag }, lastTokens
                         draftToken :: acc, lastTokens
                 ) ([], [])
             |> fst

--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -127,7 +127,8 @@ module private StringCategorizers =
             |> Seq.collect (categorize Category.Escaped escapingSymbolsRegex getTextLine) 
                                               
 module private OperatorCategorizer = 
-    let getSpans (symbolUses: (SymbolUse * WordSpan) []) (spansByLine: Map<int, seq<WordSpan>>) tokensByLine =
+    let getSpans (symbolUses: (SymbolUse * WordSpan) []) (spansByLine: Map<int, seq<WordSpan>>) 
+                 (tokensByLine: FSharpTokenInfo list []) =
         let spansBasedOnSymbolUse =
             symbolUses
             |> Array.choose (fun (_, span) -> 

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -869,8 +869,8 @@ let ``active pattern``() =
 let (|ActivePattern|_|) x = Some x
 let _ = (|ActivePattern|_|) 1
 """
-    => [ 2, [ Cat.PatternCase, 6, 19; Cat.PatternCase, 28, 32 ]
-         3, [ Cat.Function, 8, 27 ]]
+    => [ 2, [ Cat.PatternCase, 6, 19; Cat.Operator, 26, 27; Cat.PatternCase, 28, 32 ]
+         3, [ Cat.Operator, 6, 7; Cat.Function, 8, 27 ]]
 
 [<Test>]
 let ``non public module``() =

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -863,7 +863,7 @@ let func1: FuncAliasOfAlias = fun () -> ()
          4, [ Cat.ReferenceType, 5, 21; Cat.Operator, 22, 23; Cat.ReferenceType, 24, 33 ]
          5, [ Cat.Function, 4, 9; Cat.ReferenceType, 11, 27; Cat.Operator, 28, 29 ]]
 
-[<Test; Ignore "Lexer cannot recognize (|P|_|) as an Ident at position of the last bar">]
+[<Test>] //; Ignore "Lexer cannot recognize (|P|_|) as an Ident at position of the last bar">]
 let ``active pattern``() =
     """
 let (|ActivePattern|_|) x = Some x

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -870,7 +870,7 @@ let (|ActivePattern|_|) x = Some x
 let _ = (|ActivePattern|_|) 1
 """
     => [ 2, [ Cat.PatternCase, 6, 19; Cat.Operator, 26, 27; Cat.PatternCase, 28, 32 ]
-         3, [ Cat.Operator, 6, 7; Cat.Function, 8, 27 ]]
+         3, [ Cat.Operator, 6, 7; Cat.Function, 9, 26 ]]
 
 [<Test>]
 let ``non public module``() =


### PR DESCRIPTION
The idea is to form `DraftToken` of kind `Ident` for each token sequence of the following shape:

`(|.....any other tokens here....|)`

Problems:

* inner tokens, like `Foo` and `Bar` in `(|Foo|Bar|_|)` seem to disappear
* definition and application must processed separately, which requires typed ast 