### PR TITLE
Highlight active pattern usage as functions

### DIFF
--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -235,10 +235,12 @@ module SourceCodeClassifier =
                     let r = fsSymbolUse.RangeAlternate
                     match fsSymbolUse.Symbol with
                     | MemberFunctionOrValue func when func.IsActivePattern && not fsSymbolUse.IsFromDefinition ->
+                        // Usage of Active Patterns '(|A|_|)' has the range of '|A|_|',
+                        // so we expand the ranges in order to include parentheses into the results
                         Some (su, { SymbolKind = SymbolKind.Ident
                                     Line = r.End.Line
-                                    StartCol = r.Start.Column
-                                    EndCol = r.End.Column })
+                                    StartCol = r.Start.Column - 1 
+                                    EndCol = r.End.Column + 1})
                     | _ ->
                         lexer.GetSymbolFromTokensAtLocation (tokens, line - 1, r.End.Column - 1) 
                         |> Option.bind (fun sym -> 

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -863,14 +863,24 @@ let func1: FuncAliasOfAlias = fun () -> ()
          4, [ Cat.ReferenceType, 5, 21; Cat.Operator, 22, 23; Cat.ReferenceType, 24, 33 ]
          5, [ Cat.Function, 4, 9; Cat.ReferenceType, 11, 27; Cat.Operator, 28, 29 ]]
 
-[<Test; Ignore "Lexer cannot recognize (|P|_|) as an Ident at position of the last bar">]
-let ``active pattern``() =
+[<Test>]
+let ``partial active patterns``() =
     """
 let (|ActivePattern|_|) x = Some x
 let _ = (|ActivePattern|_|) 1
 """
-    => [ 2, [ Cat.PatternCase, 6, 19; Cat.PatternCase, 28, 32 ]
-         3, [ Cat.Function, 8, 27 ]]
+    => [ 2, [(Cat.PatternCase, 6, 19); (Cat.Operator, 26, 27); (Cat.PatternCase, 28, 32)]
+         3, [(Cat.Operator, 6, 7); (Cat.Function, 9, 26)] ]
+
+[<Test>]
+let ``total active patterns``() =
+    """
+let (|A|B|) _ = failwith ""
+let _ = (|A|B|) 1
+"""
+    => [ 2, [(Cat.PatternCase, 6, 7); (Cat.PatternCase, 8, 9); (Cat.Operator, 14, 15); (Cat.Function, 16, 24)]
+         3, [(Cat.Operator, 6, 7); (Cat.Function, 9, 14)] ]
+
 
 [<Test>]
 let ``non public module``() =

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -870,7 +870,7 @@ let (|ActivePattern|_|) x = Some x
 let _ = (|ActivePattern|_|) 1
 """
     => [ 2, [(Cat.PatternCase, 6, 19); (Cat.Operator, 26, 27); (Cat.PatternCase, 28, 32)]
-         3, [(Cat.Operator, 6, 7); (Cat.Function, 9, 26)] ]
+         3, [(Cat.Operator, 6, 7); (Cat.Function, 8, 27)] ]
 
 [<Test>]
 let ``total active patterns``() =
@@ -879,7 +879,7 @@ let (|A|B|) _ = failwith ""
 let _ = (|A|B|) 1
 """
     => [ 2, [(Cat.PatternCase, 6, 7); (Cat.PatternCase, 8, 9); (Cat.Operator, 14, 15); (Cat.Function, 16, 24)]
-         3, [(Cat.Operator, 6, 7); (Cat.Function, 9, 14)] ]
+         3, [(Cat.Operator, 6, 7); (Cat.Function, 8, 15)] ]
 
 
 [<Test>]

--- a/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/SyntaxConstructClassifierTests.fs
@@ -100,7 +100,7 @@ module Module1 =
               { Classification = "FSharp.Module"; Span = (7, 8) => (7, 14) } 
               { Classification = "FSharp.Operator"; Span = (7, 16) => (7, 16) }
               { Classification = "FSharp.Operator"; Span = (8, 11) => (8, 11) }] 
-        CollectionAssert.AreEquivalent(expected, actual)
+        actual |> assertEqual expected
 
     [<Test>]
     let ``should be able to get classification spans for unused items``() = 
@@ -132,7 +132,7 @@ let internal f() = ()
                   { Classification = "FSharp.Unused"; Span = (3, 6) => (3, 31) }
                   { Classification = "FSharp.Unused"; Span = (4, 14) => (4, 14) }
                   {Classification = "FSharp.Operator"; Span = (4, 18) => (4, 18) } ]
-            CollectionAssert.AreEquivalent(expected, actual)
+            actual |> assertEqual expected
         File.Delete(fileName)
         
 
@@ -181,4 +181,4 @@ let _ = XmlProvider< "<root><value>\"1\"</value></root>">.GetSample() |> ignore
                   { Classification = "FSharp.Function"; Span = (7, 59, 7, 67) }
                   { Classification = "FSharp.Operator"; Span = (7, 71, 7, 72) } 
                   { Classification = "FSharp.Function"; Span = (7, 74, 7, 79) } ]
-            CollectionAssert.AreEquivalent(expected, actual)
+            actual |> assertEqual expected


### PR DESCRIPTION
Another attempt to fix #1137.

The changes are only limited to coloring; they don't affect any other feature.