### PR TITLE
Revert "move execution of all `updateAtCaretPosition` into ThreadPool"

### DIFF
--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -84,12 +84,17 @@ type HighlightUsageTagger(textDocument: ITextDocument,
         match buffer.GetSnapshotPoint view.Caret.Position, currentWord with
         | Some point, Some cw when cw.Snapshot = view.TextSnapshot && point.InSpan cw -> ()
         | Some point, _ ->
+            let res =
+                maybe {
+                    requestedPoint <- point
+                    let currentRequest = requestedPoint
+                    let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+                    let! doc = dte.GetCurrentDocument(textDocument.FilePath)
+                    let! project = projectFactory.CreateForDocument buffer doc 
+                    return currentRequest, doc, project }
+            
             asyncMaybe {
-                requestedPoint <- point
-                let currentRequest = requestedPoint
-                let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
-                let! doc = dte.GetCurrentDocument(textDocument.FilePath)
-                let! project = projectFactory.CreateForDocument buffer doc
+                let! currentRequest, doc, project = res
                 match vsLanguageService.GetSymbol(currentRequest, project) with
                 | Some (newWord, symbol) ->
                     // If this is the same word we currently have, we're done (e.g. caret moved within a word).
@@ -100,7 +105,7 @@ type HighlightUsageTagger(textDocument: ITextDocument,
                         return! doUpdate (currentRequest, symbol, newWord, doc.FullName, project) |> liftAsync
                 | None ->
                     return synchronousUpdate (currentRequest, NormalizedSnapshotSpanCollection(), None)
-            } 
+            }
             |> Async.map (Option.iter id)
             |> Async.StartInThreadPoolSafe
         | _ -> ()

--- a/src/FSharpVSPowerTools.Logic/QuickInfoMargin.fs
+++ b/src/FSharpVSPowerTools.Logic/QuickInfoMargin.fs
@@ -87,10 +87,14 @@ type QuickInfoMargin (textDocument: ITextDocument,
         let caretPos = view.Caret.Position
         match buffer.GetSnapshotPoint caretPos with
         | Some point ->
+            let project =
+                maybe {
+                    let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+                    let! doc = dte.GetCurrentDocument(textDocument.FilePath)
+                    let! project = projectFactory.CreateForDocument buffer doc
+                    return project }
             asyncMaybe {
-                let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
-                let! doc = dte.GetCurrentDocument(textDocument.FilePath)
-                let! project = projectFactory.CreateForDocument buffer doc
+                let! project = project
                 let! tooltip =
                     asyncMaybe {
                         let! newWord, longIdent = vsLanguageService.GetLongIdentSymbol (point, project)

--- a/src/FSharpVSPowerTools.Logic/RecordStubGeneratorSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/RecordStubGeneratorSmartTagger.fs
@@ -65,55 +65,50 @@ type RecordStubGenerator(textDocument: ITextDocument,
     // - Identify record expression binding
     // - Identify the '{' in 'let x: MyRecord = { }'
     let updateAtCaretPosition() =
-        let uiContext = SynchronizationContext.Current
-        async {
-            match buffer.GetSnapshotPoint view.Caret.Position, currentWord with
-            | Some point, Some word when word.Snapshot = view.TextSnapshot && point.InSpan word -> ()
-            | _ ->
-                let res =
-                    maybe {
+        match buffer.GetSnapshotPoint view.Caret.Position, currentWord with
+        | Some point, Some word when word.Snapshot = view.TextSnapshot && point.InSpan word -> ()
+        | _ ->
+            let res =
+                maybe {
+                    let! point = buffer.GetSnapshotPoint view.Caret.Position
+                    let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+                    let! doc = dte.GetCurrentDocument(textDocument.FilePath)
+                    let! project = projectFactory.CreateForDocument buffer doc
+                    let! word, _ = vsLanguageService.GetSymbol(point, project) 
+                    return point, doc, project, word
+                }
+            match res with
+            | Some (point, doc, project, newWord) ->
+                let wordChanged = 
+                    match currentWord with
+                    | None -> true
+                    | Some oldWord -> newWord <> oldWord
+                if wordChanged then
+                    currentWord <- Some newWord
+                    suggestions <- []
+                    let uiContext = SynchronizationContext.Current
+                    asyncMaybe {
+                        let vsDocument = VSDocument(doc, point.Snapshot)
+                        let! symbolRange, recordExpression, recordDefinition, insertionPos =
+                            tryFindRecordDefinitionFromPos codeGenService project point vsDocument
+                        // Recheck cursor position to ensure it's still in new word
                         let! point = buffer.GetSnapshotPoint view.Caret.Position
-                        let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
-                        let! doc = dte.GetCurrentDocument(textDocument.FilePath)
-                        let! project = projectFactory.CreateForDocument buffer doc
-                        let! word, _ = vsLanguageService.GetSymbol(point, project) 
-                        return point, doc, project, word
+                        if point.InSpan symbolRange && shouldGenerateRecordStub recordExpression recordDefinition then
+                            return! Some (recordExpression, recordDefinition, insertionPos)
+                        else
+                            return! None
                     }
-                match res with
-                | Some (point, doc, project, newWord) ->
-                    let wordChanged = 
-                        match currentWord with
-                        | None -> true
-                        | Some oldWord -> newWord <> oldWord
-                    do! if wordChanged then
-                            currentWord <- Some newWord
-                            suggestions <- []
-                            asyncMaybe {
-                                let vsDocument = VSDocument(doc, point.Snapshot)
-                                let! symbolRange, recordExpression, recordDefinition, insertionPos =
-                                    tryFindRecordDefinitionFromPos codeGenService project point vsDocument
-                                // Recheck cursor position to ensure it's still in new word
-                                let! point = buffer.GetSnapshotPoint view.Caret.Position
-                                if point.InSpan symbolRange && shouldGenerateRecordStub recordExpression recordDefinition then
-                                    return! Some (recordExpression, recordDefinition, insertionPos)
-                                else
-                                    return! None
-                            }
-                            |> Async.bind (fun result -> 
-                                async {
-                                    // Switch back to UI thread before firing events
-                                    do! Async.SwitchToContext uiContext
-                                    suggestions <- result |> Option.map (getSuggestions newWord.Snapshot) |> Option.getOrElse []
-                                    changed.Trigger self
-                                })
-                        else async.Return ()
-         
-                | _ -> 
-                    currentWord <- None 
-                    return! async {
-                        do! Async.SwitchToContext uiContext
-                        changed.Trigger self }
-        } |> Async.StartInThreadPoolSafe
+                    |> Async.bind (fun result -> 
+                        async {
+                            // Switch back to UI thread before firing events
+                            do! Async.SwitchToContext uiContext
+                            suggestions <- result |> Option.map (getSuggestions newWord.Snapshot) |> Option.getOrElse []
+                            changed.Trigger self
+                        })
+                    |> Async.StartInThreadPoolSafe
+            | _ -> 
+                currentWord <- None 
+                changed.Trigger self
 
     let docEventListener = new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
                                                       500us, updateAtCaretPosition)

--- a/src/FSharpVSPowerTools.Logic/ResolveUnopenedNamespaceTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/ResolveUnopenedNamespaceTagger.fs
@@ -102,101 +102,96 @@ type UnopenedNamespaceResolver
         | [], [] -> []
         | _ -> [ openNamespaceActions; qualifySymbolActions ]
 
-    let updateAtCaretPosition() = 
-        let uiContext = SynchronizationContext.Current
-        async {
-            match buffer.GetSnapshotPoint view.Caret.Position, currentWord with
-            | Some point, Some word when word.Snapshot = view.TextSnapshot && point.InSpan word -> ()
-            | _ ->
-                let res =
-                    maybe {
+    let updateAtCaretPosition() =
+        match buffer.GetSnapshotPoint view.Caret.Position, currentWord with
+        | Some point, Some word when word.Snapshot = view.TextSnapshot && point.InSpan word -> ()
+        | _ ->
+            let res =
+                maybe {
+                    let! point = buffer.GetSnapshotPoint view.Caret.Position
+                    let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+                    let! doc = dte.GetCurrentDocument(textDocument.FilePath)
+                    let! project = projectFactory.CreateForDocument buffer doc
+                    let! word, _ = vsLanguageService.GetSymbol(point, project) 
+                    return point, doc, project, word
+                }
+            match res with
+            | Some (point, doc, project, newWord) ->
+                let wordChanged = 
+                    match currentWord with
+                    | None -> true
+                    | Some oldWord -> newWord <> oldWord
+                if wordChanged then
+                    currentWord <- Some newWord
+                    suggestions <- []
+                    let uiContext = SynchronizationContext.Current
+                    asyncMaybe {
+                        let! newWord, sym = vsLanguageService.GetSymbol (point, project)
+                        // Recheck cursor position to ensure it's still in new word
                         let! point = buffer.GetSnapshotPoint view.Caret.Position
-                        let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
-                        let! doc = dte.GetCurrentDocument(textDocument.FilePath)
-                        let! project = projectFactory.CreateForDocument buffer doc
-                        let! word, _ = vsLanguageService.GetSymbol(point, project) 
-                        return point, doc, project, word
-                    }
-                do! match res with
-                    | Some (point, doc, project, newWord) ->
-                        let wordChanged = 
-                            match currentWord with
-                            | None -> true
-                            | Some oldWord -> newWord <> oldWord
-                        if wordChanged then
-                            currentWord <- Some newWord
-                            suggestions <- []
-                            asyncMaybe {
-                                let! newWord, sym = vsLanguageService.GetSymbol (point, project)
-                                // Recheck cursor position to ensure it's still in new word
-                                let! point = buffer.GetSnapshotPoint view.Caret.Position
-                                if not (point.InSpan newWord) then return! None
-                                else
-                                    let! res = 
-                                        vsLanguageService.GetFSharpSymbolUse(newWord, sym, doc.FullName, project, AllowStaleResults.No) |> liftAsync
-                                    
-                                    match res with
-                                    | Some _ -> return! None
-                                    | None ->
-                                        let! checkResults = 
-                                            vsLanguageService.ParseFileInProject (doc.FullName, newWord.Snapshot.GetText(), project) |> liftAsync
-                    
-                                        let pos = codeGenService.ExtractFSharpPos point
-                                        let! parseTree = checkResults.ParseTree
-                                        let! entityKind = ParsedInput.getEntityKind parseTree pos
-                                        let! entities = vsLanguageService.GetAllEntities (doc.FullName, newWord.Snapshot.GetText(), project)
-                    
-                                        //entities |> Seq.map string |> fun es -> System.IO.File.WriteAllLines (@"l:\entities.txt", es)
-                    
-                                        let isAttribute = entityKind = EntityKind.Attribute
-                                        let entities =
-                                            entities |> List.filter (fun e ->
-                                                match entityKind, e.Kind with
-                                                | EntityKind.Attribute, EntityKind.Attribute 
-                                                | EntityKind.Type, (EntityKind.Type | EntityKind.Attribute)
-                                                | EntityKind.FunctionOrValue _, _ -> true 
-                                                | EntityKind.Attribute, _
-                                                | _, EntityKind.Module _
-                                                | EntityKind.Module _, _
-                                                | EntityKind.Type, _ -> false)
-                    
-                                        let entities = 
-                                            entities
-                                            |> List.map (fun e -> 
-                                                 [ yield e.TopRequireQualifiedAccessParent, e.AutoOpenParent, e.Namespace, e.CleanedIdents
-                                                   if isAttribute then
-                                                       let lastIdent = e.CleanedIdents.[e.CleanedIdents.Length - 1]
-                                                       if e.Kind = EntityKind.Attribute && lastIdent.EndsWith "Attribute" then
-                                                           yield 
-                                                               e.TopRequireQualifiedAccessParent, 
-                                                               e.AutoOpenParent,
-                                                               e.Namespace,
-                                                               e.CleanedIdents 
-                                                               |> Array.replace (e.CleanedIdents.Length - 1) (lastIdent.Substring(0, lastIdent.Length - 9)) ])
-                                            |> List.concat
-                    
-                                        debug "[ResolveUnopenedNamespaceSmartTagger] %d entities found" (List.length entities)
-                                        
-                                        let! idents = UntypedAstUtils.getLongIdentAt parseTree (Range.mkPos pos.Line sym.RightColumn)
-                                        let createEntity = ParsedInput.tryFindInsertionContext pos.Line parseTree idents
-                                        return entities |> Seq.map createEntity |> Seq.concat |> Seq.toList |> getSuggestions newWord 
-                            }
-                            |> Async.bind (fun result -> 
-                                async {
-                                    // Switch back to UI thread before firing events
-                                    do! Async.SwitchToContext uiContext
-                                    suggestions <- result |> Option.getOrElse []
-                                    changed.Trigger self
-                                })
-                        else async.Return()
-                        
-                    | _ -> 
-                        currentWord <- None 
-                        async {
-                            do! Async.SwitchToContext uiContext
-                            changed.Trigger self }
+                        if not (point.InSpan newWord) then return! None
+                        else
+                            let! res = 
+                                vsLanguageService.GetFSharpSymbolUse(newWord, sym, doc.FullName, project, AllowStaleResults.No) |> liftAsync
+                            
+                            match res with
+                            | Some _ -> return! None
+                            | None ->
+                                let! checkResults = 
+                                    vsLanguageService.ParseFileInProject (doc.FullName, newWord.Snapshot.GetText(), project) |> liftAsync
 
-        } |> Async.StartInThreadPoolSafe
+                                let pos = codeGenService.ExtractFSharpPos point
+                                let! parseTree = checkResults.ParseTree
+                                let! entityKind = ParsedInput.getEntityKind parseTree pos
+                                let! entities = vsLanguageService.GetAllEntities (doc.FullName, newWord.Snapshot.GetText(), project)
+
+                                //entities |> Seq.map string |> fun es -> System.IO.File.WriteAllLines (@"l:\entities.txt", es)
+
+                                let isAttribute = entityKind = EntityKind.Attribute
+                                let entities =
+                                    entities |> List.filter (fun e ->
+                                        match entityKind, e.Kind with
+                                        | EntityKind.Attribute, EntityKind.Attribute 
+                                        | EntityKind.Type, (EntityKind.Type | EntityKind.Attribute)
+                                        | EntityKind.FunctionOrValue _, _ -> true 
+                                        | EntityKind.Attribute, _
+                                        | _, EntityKind.Module _
+                                        | EntityKind.Module _, _
+                                        | EntityKind.Type, _ -> false)
+
+                                let entities = 
+                                    entities
+                                    |> List.map (fun e -> 
+                                         [ yield e.TopRequireQualifiedAccessParent, e.AutoOpenParent, e.Namespace, e.CleanedIdents
+                                           if isAttribute then
+                                               let lastIdent = e.CleanedIdents.[e.CleanedIdents.Length - 1]
+                                               if e.Kind = EntityKind.Attribute && lastIdent.EndsWith "Attribute" then
+                                                   yield 
+                                                       e.TopRequireQualifiedAccessParent, 
+                                                       e.AutoOpenParent,
+                                                       e.Namespace,
+                                                       e.CleanedIdents 
+                                                       |> Array.replace (e.CleanedIdents.Length - 1) (lastIdent.Substring(0, lastIdent.Length - 9)) ])
+                                    |> List.concat
+
+                                debug "[ResolveUnopenedNamespaceSmartTagger] %d entities found" (List.length entities)
+                                
+                                let! idents = UntypedAstUtils.getLongIdentAt parseTree (Range.mkPos pos.Line sym.RightColumn)
+                                let createEntity = ParsedInput.tryFindInsertionContext pos.Line parseTree idents
+                                return entities |> Seq.map createEntity |> Seq.concat |> Seq.toList |> getSuggestions newWord 
+                    }
+                    |> Async.bind (fun result -> 
+                        async {
+                            // Switch back to UI thread before firing events
+                            do! Async.SwitchToContext uiContext
+                            suggestions <- result |> Option.getOrElse []
+                            changed.Trigger self
+                        })
+                    |> Async.StartInThreadPoolSafe
+                    
+            | _ -> 
+                currentWord <- None 
+                changed.Trigger self
 
     let docEventListener = new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
                                                       100us, updateAtCaretPosition)

--- a/src/FSharpVSPowerTools.Logic/UnionPatternMatchCaseGeneratorSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/UnionPatternMatchCaseGeneratorSmartTagger.fs
@@ -57,57 +57,52 @@ type UnionPatternMatchCaseGenerator
         ]
 
     let updateAtCaretPosition() =
-        let uiContext = SynchronizationContext.Current
-        async {
-            match buffer.GetSnapshotPoint view.Caret.Position, currentWord with
-            | Some point, Some word when word.Snapshot = view.TextSnapshot && point.InSpan word -> ()
-            | _ ->
-                let res =
-                    maybe {
+        match buffer.GetSnapshotPoint view.Caret.Position, currentWord with
+        | Some point, Some word when word.Snapshot = view.TextSnapshot && point.InSpan word -> ()
+        | _ ->
+            let res =
+                maybe {
+                    let! point = buffer.GetSnapshotPoint view.Caret.Position
+                    let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+                    let! doc = dte.GetCurrentDocument(textDocument.FilePath)
+                    let! project = projectFactory.CreateForDocument buffer doc
+                    let! word, _ = vsLanguageService.GetSymbol(point, project) 
+                    return point, doc, project, word
+                }
+
+            match res with
+            | Some (point, doc, project, newWord) ->
+                let wordChanged = 
+                    match currentWord with
+                    | None -> true
+                    | Some oldWord -> newWord <> oldWord
+
+                if wordChanged then
+                    currentWord <- Some newWord
+                    suggestions <- []
+                    let uiContext = SynchronizationContext.Current
+                    asyncMaybe {
+                        let vsDocument = VSDocument(doc, point.Snapshot)
+                        let! symbolRange, patMatchExpr, unionTypeDefinition, insertionPos =
+                            tryFindUnionDefinitionFromPos codeGenService project point vsDocument
+                        // Recheck cursor position to ensure it's still in new word
                         let! point = buffer.GetSnapshotPoint view.Caret.Position
-                        let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
-                        let! doc = dte.GetCurrentDocument(textDocument.FilePath)
-                        let! project = projectFactory.CreateForDocument buffer doc
-                        let! word, _ = vsLanguageService.GetSymbol(point, project) 
-                        return point, doc, project, word
+                        if point.InSpan symbolRange && shouldGenerateUnionPatternMatchCases patMatchExpr unionTypeDefinition then
+                            return! Some(patMatchExpr, unionTypeDefinition, insertionPos)
+                        else
+                            return! None
                     }
-            
-                match res with
-                | Some (point, doc, project, newWord) ->
-                    let wordChanged = 
-                        match currentWord with
-                        | None -> true
-                        | Some oldWord -> newWord <> oldWord
-            
-                    do! if wordChanged then
-                            currentWord <- Some newWord
-                            suggestions <- []
-                            asyncMaybe {
-                                let vsDocument = VSDocument(doc, point.Snapshot)
-                                let! symbolRange, patMatchExpr, unionTypeDefinition, insertionPos =
-                                    tryFindUnionDefinitionFromPos codeGenService project point vsDocument
-                                // Recheck cursor position to ensure it's still in new word
-                                let! point = buffer.GetSnapshotPoint view.Caret.Position
-                                if point.InSpan symbolRange && shouldGenerateUnionPatternMatchCases patMatchExpr unionTypeDefinition then
-                                    return! Some(patMatchExpr, unionTypeDefinition, insertionPos)
-                                else
-                                    return! None
-                            }
-                            |> Async.bind (fun result -> 
-                                async {
-                                    // Switch back to UI thread before firing events
-                                    do! Async.SwitchToContext uiContext
-                                    suggestions <- result |> Option.map (getSuggestions newWord.Snapshot) |> Option.getOrElse []
-                                    changed.Trigger self
-                                })
-                        else async.Return ()
-         
-                | _ -> 
-                    currentWord <- None
-                    return! async {
-                        do! Async.SwitchToContext uiContext
-                        changed.Trigger self }
-        } |> Async.StartInThreadPoolSafe
+                    |> Async.bind (fun result -> 
+                        async {
+                            // Switch back to UI thread before firing events
+                            do! Async.SwitchToContext uiContext
+                            suggestions <- result |> Option.map (getSuggestions newWord.Snapshot) |> Option.getOrElse []
+                            changed.Trigger self
+                        })
+                    |> Async.StartInThreadPoolSafe
+            | _ -> 
+                currentWord <- None
+                changed.Trigger self
 
     let docEventListener = new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 
                                                       500us, updateAtCaretPosition)


### PR DESCRIPTION
This reverts commit 80a2b10ea26fae685b1bc633f16daf1ed00fd518.

It 1. may cause VS UI thread dead locked 2. bring little value