### PR TITLE
Add F# Lint's underline greedier.

### DIFF
--- a/src/FSharpVSPowerTools.Logic/LintTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/LintTagger.fs
@@ -69,8 +69,10 @@ type LintTagger(textDocument: ITextDocument,
                             let r = warn.Range
                             let endCol =
                                 if r.StartLine = r.EndLine then
-                                    min r.EndColumn (r.StartColumn + 2)
-                                else r.StartColumn + 2
+                                    r.EndColumn
+                                else
+                                    let line = buffer.CurrentSnapshot.GetLineFromLineNumber(r.StartLine - 1).GetText()
+                                    line.Length
                             let range =
                                 Range.mkRange "" 
                                     (Range.mkPos r.StartLine r.StartColumn)


### PR DESCRIPTION
In particular:
1. When warning's range is in a line (i.e. StartLine and EndLine is the same), entire text which has some warnings will be marked.
2. When it spreads over multiple lines, text which is in the StartLine and is from StartColumn to the end of the StartLine will be marked.