### PR TITLE
Remove `System.Windows.Interactivity` from FSharpLint settings view

### DIFF
--- a/src/FSharpVSPowerTools.Logic/LintOptionsPageControl.xaml
+++ b/src/FSharpVSPowerTools.Logic/LintOptionsPageControl.xaml
@@ -5,7 +5,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:FSharpVSPowerTools.Linting;assembly=FSharpVSPowerTools.Logic"
              xmlns:fsxaml="http://github.com/fsprojects/FsXaml" 
-             xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"   
              xmlns:fsx="clr-namespace:FsXaml;assembly=FsXaml.Wpf"
              fsxaml:ViewController.Custom="{x:Type local:LintOptionsPageControl}"
              mc:Ignorable="d" 
@@ -47,7 +46,7 @@
                     </Style.Triggers>
                 </Style>
             </Grid.Style>
-            
+
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -78,14 +77,6 @@
                             Grid.Row="1" 
                             ItemsSource="{Binding Rules}"
                             Width="{Binding ActualWidth}">
-                                <i:Interaction.Triggers>
-                                    <i:EventTrigger EventName="SelectedItemChanged">
-                                        <i:InvokeCommandAction 
-                                            Command="{Binding SelectedRuleChanged}" 
-                                            CommandParameter="{Binding ElementName=RulesTreeView, Path=SelectedItem}"/>
-                                    </i:EventTrigger>
-                                </i:Interaction.Triggers>
-
                                 <TreeView.Resources>
                                     <HierarchicalDataTemplate DataType="{x:Type local:RuleViewModel}" 
                                                             ItemsSource="{Binding Rules}">
@@ -262,12 +253,12 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                        
+
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
-                        
+
                             <Button Command="{Binding AddHintCommand}" Content="Add Hint" />
                             <TextBox Margin="5,0" 
                                      Text="{Binding NewHint}" 

--- a/src/FSharpVSPowerTools.Logic/Linting/LintOptionsPageControl.xaml.fs
+++ b/src/FSharpVSPowerTools.Logic/Linting/LintOptionsPageControl.xaml.fs
@@ -34,14 +34,25 @@ type LintOptionsPageControl() =
                     | _ -> ()
                 | _ -> ())
 
-    let selectedFileChanged =
+    let selectedTreeViewItemChanged handleChange =
         RoutedPropertyChangedEventHandler(fun control _ -> 
             match control with
             | :? TreeView as control ->
-                match control.DataContext, control.SelectedItem with
-                | (:? OptionsViewModel as viewModel), (:? FileViewModel as selected) ->
-                    viewModel.SelectedFile <- selected
-                | _ -> ()
+                handleChange (control.DataContext, control.SelectedItem)
+            | _ -> ())
+
+    let selectedFileChanged =
+        selectedTreeViewItemChanged 
+            (function
+            | (:? OptionsViewModel as viewModel), (:? FileViewModel as selected) ->
+                viewModel.SelectedFile <- selected
+            | _ -> ())
+
+    let selectedRuleChanged =
+        selectedTreeViewItemChanged 
+            (function
+            | (:? OptionsViewModel as viewModel), (:? RuleViewModel as selected) ->
+                viewModel.SelectedRule <- Some(selected)
             | _ -> ())
     
     override __.OnLoaded control = 
@@ -53,6 +64,8 @@ type LintOptionsPageControl() =
 
         control.FilesTreeView.SelectedItemChanged.AddHandler(selectedFileChanged)
 
+        control.RulesTreeView.SelectedItemChanged.AddHandler(selectedRuleChanged)
+
     override __.OnUnloaded control =
         control.HintsListView.SelectionChanged.RemoveHandler(selectionChanged)
         control.IgnoreFilesListView.KeyDown.RemoveHandler(onKeydown)
@@ -61,3 +74,5 @@ type LintOptionsPageControl() =
         control.HintsListView.KeyDown.RemoveHandler(onKeydown)
 
         control.FilesTreeView.SelectedItemChanged.RemoveHandler(selectedFileChanged)
+
+        control.RulesTreeView.SelectedItemChanged.RemoveHandler(selectedRuleChanged)

--- a/src/FSharpVSPowerTools.Logic/Linting/OptionsViewModel.fs
+++ b/src/FSharpVSPowerTools.Logic/Linting/OptionsViewModel.fs
@@ -208,11 +208,8 @@ type OptionsViewModel(getConfigForDirectory, files, selectedFile:FileViewModel) 
     let selectedFile = this.Factory.Backing(<@ this.SelectedFile @>, selectedFile)
 
     member __.SelectedRule 
-        with get() = selectedRule.Value
+        with get() : RuleViewModel option = selectedRule.Value
         and set (value) = selectedRule.Value <- value
-
-    member __.SelectedRuleChanged = 
-        this.Factory.CommandSyncParam(fun p -> this.SelectedRule <- Some(p))
 
     member __.CurrentFilePath = currentFilePath.Value
     


### PR DESCRIPTION
This should hopefully resolve: https://github.com/fsprojects/VisualFSharpPowerTools/issues/1153  `System.Windows.Interactivity` was being used to have an event execute a command via xaml, this pull request moves this functionality into the code behind so `System.Windows.Interactivity` is no longer used in the view