### PR TITLE
Automatic upload to Visual Studio gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,5 @@ tests/data/*/*.pdb
 
 _NCrunch_*
 build_PRIVATE.cmd
+gallerycredentials.txt
+.fake

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -26,5 +26,8 @@ source http://nuget.org/api/v2
 nuget FSharp.Formatting
 nuget FAKE
 nuget Nuget.CommandLine
+nuget FSharp.Core 3.1.2.5 redirects:on
+nuget canopy
+nuget Selenium.WebDriver.ChromeDriver
 
 github fsharp/FAKE modules/Octokit/Octokit.fsx

--- a/paket.lock
+++ b/paket.lock
@@ -20,8 +20,14 @@ GROUP Build
 NUGET
   remote: http://nuget.org/api/v2
   specs:
+    canopy (0.9.36)
+      FSharp.Core (>= 3.0.2)
+      Selenium.Support (2.48.0)
+      Selenium.WebDriver (2.48.0)
+      SizSelCsZzz (0.3.36.0)
     FAKE (4.4.0)
     FSharp.Compiler.Service (0.0.90)
+    FSharp.Core (3.1.2.5) - redirects: on
     FSharp.Formatting (2.11.0)
       FSharp.Compiler.Service (>= 0.0.90 <= 1.3)
       FSharpVSPowerTools.Core (1.9.0)
@@ -33,13 +39,22 @@ NUGET
     Microsoft.Net.Http (2.2.29)
       Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
+    Newtonsoft.Json (7.0.1)
     NuGet.CommandLine (2.8.6)
     Octokit (0.16.0)
       Microsoft.Net.Http
+    Selenium.Support (2.48.0)
+      Selenium.WebDriver (>= 2.48.0)
+    Selenium.WebDriver (2.48.0)
+    Selenium.WebDriver.ChromeDriver (2.20.0)
+    SizSelCsZzz (0.3.36.0)
+      Newtonsoft.Json (>= 6.0)
+      Selenium.Support (>= 2.40)
+      Selenium.WebDriver (>= 2.40)
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (7543f29800c1245a04f96b5f1be063b0568fd5d6)
+    modules/Octokit/Octokit.fsx (4982e503ccc973ed1f047a52ff69a675ec4b66e1)
       Octokit
 GROUP Test
 NUGET


### PR DESCRIPTION
This is taken from Paket.VisualStudio project. I was not able to test it here since I don't own your gallery account.

In oder to use this you need a gallerycredentials.txt in the root. First line your email, second line password. The file is already gitignored.

This is how it looks in Paket.VisualStudio:

![gallery](https://cloud.githubusercontent.com/assets/57396/10477868/f43d4e22-7259-11e5-950b-c182b857b23f.gif)
