### PR TITLE
FCS project cache size reduced from 50 to 10

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -166,11 +166,12 @@ type LanguageService (?fileSystem: IFileSystem) =
   let handleCriticalErrors e file source opts = 
       errorHandler |> Option.iter (fun handle -> handle e file source opts)
 
-  // Create an instance of interactive checker. The callback is called by the F# compiler service
-  // when its view of the prior-typechecking-state of the start of a file has changed, for example
-  // when the background typechecker has "caught up" after some other file has been changed, 
-  // and its time to re-typecheck the current file.
-  let checkerInstance = FSharpChecker.Create (projectCacheSize = 50, keepAllBackgroundResolutions = false)
+  // Create an instance of interactive checker.
+  let checkerInstance = 
+    FSharpChecker.Create(
+        projectCacheSize = 10, 
+        keepAllBackgroundResolutions = false,
+        keepAssemblyContents = false)
 
   let checkerAsync (f: FSharpChecker -> Async<'a>) = 
     let ctx = System.Threading.SynchronizationContext.Current

--- a/src/FSharpVSPowerTools.Core/Lexer.fs
+++ b/src/FSharpVSPowerTools.Core/Lexer.fs
@@ -28,7 +28,7 @@ type internal DraftToken =
     { Kind: SymbolKind
       Token: FSharpTokenInfo 
       RightColumn: int }
-    static member Create kind token = 
+    static member inline Create kind token = 
         { Kind = kind; Token = token; RightColumn = token.LeftColumn + token.FullMatchedLength - 1 }
 
 module Lexer =
@@ -88,7 +88,7 @@ module Lexer =
         let isIdentifier t = t.CharClass = FSharpTokenCharKind.Identifier
         let isOperator t = t.ColorClass = FSharpTokenColorKind.Operator
     
-        let (|GenericTypeParameterPrefix|StaticallyResolvedTypeParameterPrefix|Other|) (token: FSharpTokenInfo) =
+        let inline (|GenericTypeParameterPrefix|StaticallyResolvedTypeParameterPrefix|Other|) (token: FSharpTokenInfo) =
             if token.Tag = FSharpTokenTag.QUOTE then GenericTypeParameterPrefix
             elif token.Tag = FSharpTokenTag.INFIX_AT_HAT_OP then
                  // The lexer return INFIX_AT_HAT_OP token for both "^" and "@" symbols.

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -332,7 +332,7 @@ type SyntaxConstructClassifier
                             updateUnusedDeclarations()
                         else
                             let! currentProjectOpts = vsLanguageService.GetProjectCheckerOptions currentProject
-                            vsLanguageService.StartBackgroundCompile currentProjectOpts
+                            vsLanguageService.CheckProjectInBackground currentProjectOpts
 
                     pf.Stop()
                     Logging.logInfo "[SyntaxConstructClassifier] [Fast stage] %s" pf.Result
@@ -374,7 +374,7 @@ type SyntaxConstructClassifier
                     match projects |> List.tryFind (fun p -> not p.Checked) with
                     | Some { Options = opts } -> 
                         // there is at least one yet unchecked project, start compilation on it
-                        vsLanguageService.StartBackgroundCompile opts
+                        vsLanguageService.CheckProjectInBackground opts
                     | None -> 
                         // all the needed projects have been checked in background, let's calculate 
                         // Slow Stage (unused symbols and opens)

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -351,9 +351,9 @@ type VSLanguageService
         instance.RawChecker.InvalidateAll()
         entityCache.Clear()
     
-    member __.StartBackgroundCompile (opts: FSharpProjectOptions) =
+    member __.CheckProjectInBackground (opts: FSharpProjectOptions) =
         debug "[LanguageService] StartBackgroundCompile (%s)" opts.ProjectFileName
-        instance.RawChecker.StartBackgroundCompile opts
+        instance.RawChecker.CheckProjectInBackground opts
 
     member __.CheckerAsync x = instance.CheckerAsync x
     member __.RawChecker = instance.RawChecker


### PR DESCRIPTION
also set `FSharpChecker`'s `keepAssemblyContents = false`