### PR TITLE
Fix - Tooltips contain extra end line characters

### DIFF
--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -28,7 +28,7 @@ type OutliningTagger
     (textDocument: ITextDocument,
      serviceProvider : IServiceProvider,
      projectFactory: ProjectFactory,
-     languageService: VSLanguageService) as self = 
+     languageService: VSLanguageService) as self =
 
     let buffer = textDocument.TextBuffer
     let tagsChanged = Event<_,_> ()
@@ -93,7 +93,7 @@ type OutliningTagger
             let rec loop acc  =
                 if acc >= charr.Length then acc 
                 elif not (Char.IsWhiteSpace charr.[acc]) then acc else loop (acc+1) in loop 0
-        let lines = text.Split [|'\n'|]
+        let lines = lineSplit text
         let minlead = 
             let seed = if lines = [||] then 0 else lines.[0] |> leadingWhitespace
             (seed, lines) ||> Array.fold (fun acc elm -> leadingWhitespace elm |> min acc)

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -437,3 +437,37 @@ let listFSharpProjectsInSolution (dte: DTE) =
 
     [ for p in dte.Solution.Projects do
         yield! handleProject p ]
+
+
+
+/// Linux linebreak `\n`
+let [<Literal>] linuxLineBreak = "\n"
+
+/// Windows linebreak `\r\n`
+let [<Literal>] windowsLineBreak = "\r\n"
+
+/// Mac linebreak `\r`
+let [<Literal>] macLineBreak = "\r"
+
+/// Replaces pattern in the string with the replacement
+let inline replace (pattern:string) replacement (text:string) = text.Replace(pattern, replacement)
+
+/// Converts all linebreaks in a string to windows linebreaks
+let convertToWindowsLineBreaks text = 
+    replace windowsLineBreak linuxLineBreak 
+        >> replace macLineBreak linuxLineBreak 
+            >> replace linuxLineBreak windowsLineBreak <| text
+
+/// Splits a string into lines for all platform's linebreaks.
+/// If the string mixes windows, mac, and linux linebreaks, all will be respected
+let lineSplit str = (convertToWindowsLineBreaks str).Split([|windowsLineBreak|],StringSplitOptions.None)
+
+type String with
+    /// Replaces pattern in the string with the replacement
+    static member inline replace pattern replacement text = replace pattern replacement text
+    /// Splits a string into lines for all platform's linebreaks.
+    /// If the string mixes windows, mac, and linux linebreaks, all will be respected
+    static member toLineArray str = lineSplit str
+    /// Splits a string into lines for all platform's linebreaks.
+    /// If the string mixes windows, mac, and linux linebreaks, all will be respected
+    member self.ToLineArray () = lineSplit self


### PR DESCRIPTION
The issue was caused by only accounting for lines that terminate with a
`\n`, as per the configuration of the VFPT repo.  Now the string
extracted from the span of the buffer being outlined will be split
accounting for the linebreak characters of windows, linux, and osx.

- added type extension to `String` for replace
- added type extension to `String` for splitting into a string array
accounting for linux, windows, osx
- added extension method ^ same functionality

### VS 2013 `\r\n`
![](http://i.imgur.com/41NQp6h.png)

### VS 2013 `\n`
![](http://i.imgur.com/VECce9b.png)

### VS 2015 `\r\n`
![](http://i.imgur.com/kIUoyTH.png)

### VS 2015 `\n`
![](http://i.imgur.com/c1TIg3K.png)