### PR TITLE
FSharpChecker.ImplicitlyStartBackgroundWork <- false

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -173,6 +173,8 @@ type LanguageService (?fileSystem: IFileSystem) =
         keepAllBackgroundResolutions = false,
         keepAssemblyContents = false)
 
+  do checkerInstance.ImplicitlyStartBackgroundWork <- false
+
   let checkerAsync (f: FSharpChecker -> Async<'a>) = 
     let ctx = System.Threading.SynchronizationContext.Current
     async {


### PR DESCRIPTION
With the flag set to `true` editing files is not smooth. For example, editing `VSUtils.fs`, which is at top of the largest VFPT project, is not comfortable enough. 

Maybe we should add a setting for this. 