### PR TITLE
optimize OpenDeclarationsGetter by optimizing arrays equality

### DIFF
--- a/src/FSharpVSPowerTools.Core/OpenDeclarationsGetter.fs
+++ b/src/FSharpVSPowerTools.Core/OpenDeclarationsGetter.fs
@@ -24,7 +24,7 @@ type OpenDeclaration =
 [<CompilationRepresentation (CompilationRepresentationFlags.ModuleSuffix)>]
 module OpenDeclWithAutoOpens =
     let updateBySymbolPrefix (symbolPrefix: Idents) (decl: OpenDeclWithAutoOpens) =
-        let matched = decl.Declarations |> List.exists ((=) symbolPrefix)
+        let matched = decl.Declarations |> List.exists (Array.areEqual symbolPrefix)
         //if not decl.IsUsed && matched then debug "OpenDeclarationWithAutoOpens %A is used by %A" decl symbolPrefix
         matched, { decl with IsUsed = decl.IsUsed || matched }
 
@@ -124,7 +124,7 @@ module OpenDeclarationGetter =
                 decl.Declarations 
                 |> List.map (fun d -> 
                     if d.IsUsed then d
-                    else { d with IsUsed = d.Declarations |> List.exists ((=) idents) })
+                    else { d with IsUsed = d.Declarations |> List.exists (Array.areEqual idents) })
             let isUsed = declarations |> List.exists (fun d -> d.IsUsed)
             { decl with Declarations = declarations; IsUsed = isUsed })
 
@@ -332,7 +332,7 @@ module OpenDeclarationGetter =
                             //debug "[SourceCodeClassifier] One clean FullName %A -> %A" fullName cleanIdents
                             cleanIdents
                         | Some (firstCleanIdents :: _ as cleanIdentsList) ->
-                            if cleanIdentsList |> List.exists ((=) fullName) then
+                            if cleanIdentsList |> List.exists (Array.areEqual fullName) then
                                 //debug "[SourceCodeClassifier] An exact match found among several clean idents: %A" fullName
                                 fullName
                             else

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -100,9 +100,11 @@ module Array =
 
     /// Optimized arrays equality. ~100x faster than `array1 = array2`.
     let inline areEqual (x: 'a[]) (y: 'a[]) =
-        if x.Length <> y.Length then false
-        elif x.Length = 0 then true
-        else
+        match x, y with
+        | null, null -> true
+        | [||], [||] -> true
+        | _ when x.Length <> y.Length -> false
+        | _ ->
             let mutable break' = false
             let mutable i = 0
             let mutable result = true

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -35,7 +35,6 @@ module Array =
         | null -> nullArg argName 
         | _ -> ()
 
-
     /// Returns true if one array has another as its subset from index 0.
     let startsWith (prefix: _ []) (whole: _ []) =
         let rec loop index =
@@ -98,6 +97,21 @@ module Array =
                 i <- i + 1
 
         Array.sub temp 0 i 
+
+    /// Optimized arrays equality. ~100x faster than `array1 = array2`.
+    let inline areEqual (x: 'a[]) (y: 'a[]) =
+        if x.Length <> y.Length then false
+        elif x.Length = 0 then true
+        else
+            let mutable break' = false
+            let mutable i = 0
+            let mutable result = true
+            while i < x.Length && not break' do
+                if x.[i] <> y.[i] then 
+                    break' <- true
+                    result <- false
+                i <- i + 1
+            result
 
 [<RequireQualifiedAccess>]
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -68,7 +68,7 @@ type OutliningTagger
     // drills down into the snapshot text to find the first non whitespace line 
     // to display as the text inside the collapse box preceding the `...`
     let getHintText (snapshotSpan:SnapshotSpan) =
-        let snapshot= snapshotSpan.Snapshot        
+        let snapshot= snapshotSpan.Snapshot
         let firstLineNum = snapshot.GetLineNumberFromPosition(snapshotSpan.Start.Position)
         let rec loop acc =
             if acc >= snapshot.LineCount + firstLineNum then "" else

--- a/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
@@ -55,6 +55,7 @@
     <Content Include="app.config" />
     <None Include="paket.references" />
     <Compile Include="TestHelpers.fs" />
+    <Compile Include="UtilsTests.fs" />
     <Compile Include="LexerTests.fs" />
     <Compile Include="LanguageServiceTests.fs" />
     <Compile Include="DepthColorizerTests.fs" />

--- a/tests/FSharpVSPowerTools.Core.Tests/UtilsTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/UtilsTests.fs
@@ -1,0 +1,10 @@
+﻿module FSharpVSPowerTools.Core.Tests.UtilsTests
+
+open FsCheck
+open NUnit.Framework
+open FSharpVSPowerTools
+
+[<Test>]
+let ``Array areEqual``() =
+    Check.QuickThrowOnFailure <| fun (x: int[]) (y: int[]) ->
+        (x = y) = (Array.areEqual x y)


### PR DESCRIPTION
It's about 100x faster, then `array1 = array2` which was used in tight loops.