### PR TITLE
revert FCS project cache size to 50 (was 10)

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -169,7 +169,7 @@ type LanguageService (?fileSystem: IFileSystem) =
   // Create an instance of interactive checker.
   let checkerInstance = 
     FSharpChecker.Create(
-        projectCacheSize = 10, 
+        projectCacheSize = 50, 
         keepAllBackgroundResolutions = false,
         keepAssemblyContents = false)
 


### PR DESCRIPTION
Unfortunately, with project size set to 10 it turned out that projects which reference large number of other projects in same solution, are not processed *at all*. Symptoms:

* One of CPU cores is load at 100% *infinitely*
* devenv.exe private set increases linearly until reaches 2.5GB in about 1 minute
* VS becomes unusable due to GC

After reverting the cache size to 50 everything is ok.