### PR TITLE
Make logging more lightweight

### DIFF
--- a/src/FSharpVSPowerTools.Logic/FolderMenuCommands.fs
+++ b/src/FSharpVSPowerTools.Logic/FolderMenuCommands.fs
@@ -168,8 +168,8 @@ type FolderMenuCommands(dte: DTE2, mcs: OleMenuCommandService, shell: IVsUIShell
             project?SetProjectFileDirty true
             project?ComputeSourcesAndFlags()
             ()
-        | [] -> Logging.logError "performVerticalMoveAction called with empty info.Items"
-        | _ -> Logging.logError "performVerticalMoveAction called with more than one item in info.Items"
+        | [] -> Logging.logError (fun _ -> "performVerticalMoveAction called with empty info.Items")
+        | _ -> Logging.logError (fun _ -> "performVerticalMoveAction called with more than one item in info.Items")
     
     let askForDestinationFolder resources = 
         let model = MoveToFolderDialogModel resources
@@ -298,7 +298,7 @@ type FolderMenuCommands(dte: DTE2, mcs: OleMenuCommandService, shell: IVsUIShell
                 project?SetProjectFileDirty true
                 project?ComputeSourcesAndFlags()
             | _ -> 
-                Logging.logWarning "Can't find folder '%s'for renaming." name
+                Logging.logWarning (fun _ -> sprintf "Can't find folder '%s' for renaming." name)
 
     let performNameAction (info: ActionInfo) action name =
         match action with
@@ -320,7 +320,7 @@ type FolderMenuCommands(dte: DTE2, mcs: OleMenuCommandService, shell: IVsUIShell
                     | VisualStudioVersion.VS2015 -> 
                         false
                     | v ->
-                        Logging.logWarning "Unknown Visual Studio version detected while adding/renaming folder: %O" v
+                        Logging.logWarning (fun _ -> sprintf "Unknown Visual Studio version detected while adding/renaming folder: %O" v)
                         true
 
                 let resources = 

--- a/src/FSharpVSPowerTools.Logic/FsiReferenceCommand.fs
+++ b/src/FSharpVSPowerTools.Logic/FsiReferenceCommand.fs
@@ -179,7 +179,7 @@ type FsiReferenceCommand(dte2: DTE2, mcs: OleMenuCommandService) =
             let! currentConfiguration = 
                 try Some (project.ConfigurationManager.ActiveConfiguration.ConfigurationName.ToLower())
                 with e -> 
-                    Logging.logError "[FsiReference] Cannot get current configuration name: %O" e
+                    Logging.logError (fun _ -> sprintf "[FsiReference] Cannot get current configuration name: %O" e)
                     None
             let loadRefsFileName = sprintf "load-references-%s.fsx" currentConfiguration
             use projectProvider = createProjectProvider project
@@ -202,12 +202,12 @@ type FsiReferenceCommand(dte2: DTE2, mcs: OleMenuCommandService) =
                 generateReferenceFiles project)
 
     let onBuildDoneHandler = EnvDTE._dispBuildEvents_OnBuildDoneEventHandler (fun _ _ ->
-            Logging.logInfo "Checking projects after build done..."
+            Logging.logInfo (fun _ -> "Checking projects after build done...")
             let dte = dte2 :?> DTE
             listFSharpProjectsInSolution dte
             |> Seq.iter (fun project ->
                 if containsReferenceScript project then
-                    Logging.logInfo "Re-generating reference scripts for '%s'..." project.Name
+                    Logging.logInfo (fun _ -> sprintf "Re-generating reference scripts for '%s'..." project.Name)
                     generateReferenceFiles project))
 
     let events = dte2.Events.BuildEvents

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -218,7 +218,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                     vsTextManager.NavigateToLineAndColumn(vsTextBuffer, ref Constants.guidLogicalTextView, startRow, startCol, startRow, startCol) 
                     |> ensureSucceeded)
             | None ->
-                Logging.logInfo "Can't find a matching symbol for '%A'" currentSymbol
+                Logging.logInfo (fun _ -> sprintf "Can't find a matching symbol for '%A'" currentSymbol)
         }
 
     // Now the input is an entity or a member/value.
@@ -247,7 +247,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                 | Some (_, signature), Some signatureProject ->
                     do! gotoExactLocation signature filePath signatureProject fsSymbol vsTextBuffer
                 | _ -> 
-                    Logging.logInfo "Can't find a signature or signature project for '%s'" filePath
+                    Logging.logInfo (fun _ -> sprintf "Can't find a signature or signature project for '%s'" filePath)
                 // If the buffer has been opened, we will not re-generate signatures
                 windowFrame.Show() |> ensureSucceeded
             | _ ->
@@ -444,7 +444,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                     | NavigationPreference.SymbolSourceOrMetadata
                     | NavigationPreference.SymbolSource as pref ->   
                         let symbol = fsSymbolUse.Symbol
-                        Logging.logInfo "Checking symbol source of %s..." symbol.FullName
+                        Logging.logInfo (fun _ -> sprintf "Checking symbol source of %s..." symbol.FullName)
                         if symbol.Assembly.FileName
                            |> Option.map (Path.GetFileNameWithoutExtension >> referenceSourceProvider.AvailableAssemblies.Contains)
                            |> Option.getOrElse false then
@@ -455,7 +455,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                                     urlChanged |> Option.iter (fun event -> event.Trigger(UrlChangeEventArgs(url)))                                    
                                 Process.Start url |> ignore
                             | None ->
-                                Logging.logWarning "Can't find navigation information for %s." symbol.FullName
+                                Logging.logWarning (fun _ -> sprintf "Can't find navigation information for %s." symbol.FullName)
                         else
                             match tryFindSourceUrl symbol with
                             | Some url ->

--- a/src/FSharpVSPowerTools.Logic/Linting/LintUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/Linting/LintUtils.fs
@@ -36,10 +36,10 @@ module LintUtils =
                 File.ReadAllText filename |> configuration |> Some
             with
                 | ConfigurationException(message) ->
-                    Logging.logWarning "Failed to load config file %s: %s" filename message
+                    Logging.logWarning (fun _ -> sprintf "Failed to load config file %s: %s" filename message)
                     None
                 | e ->
-                    Logging.logWarning "Failed to load config file %s: %s" filename e.Message
+                    Logging.logWarning (fun _ -> sprintf "Failed to load config file %s: %s" filename e.Message)
                     None
         else
             None

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -125,7 +125,7 @@ type OutliningTagger
             let! parseFileResults = languageService.ParseFileInProject (doc.FullName, source, project) |> AsyncMaybe.liftAsync
             let! ast = parseFileResults.ParseTree
             //Logging.logInfo "[Outlining]\nAST Range\n%A" ast.Range
-            Logging.logInfo "[Outlining]\nAST\n%A" ast
+            Logging.logInfo (fun _ -> sprintf "[Outlining]\nAST\n%A" ast)
             if checkAST oldAST ast then
                 oldAST <- Some ast
                 let scopedSpans = (getOutliningRanges >> Seq.choose (fromScopeRange snapshot) >> Array.ofSeq) ast
@@ -308,7 +308,7 @@ type OutliningTagger
                     }) :> ITagSpan<_> |> Some
         with
         | :? ArgumentOutOfRangeException ->
-            Logging.logInfo "ArgumentOutOfRangeException in Outlining.Tagger.createTagSpan"
+            Logging.logInfo (fun _ -> "ArgumentOutOfRangeException in Outlining.Tagger.createTagSpan")
             None
 
     /// viewUpdate -=> doUpdate -=> triggerUpdate -=> tagsChanged -=> getTags

--- a/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
@@ -203,7 +203,7 @@ type ProjectFactory
             let isSymbolLocalForProject = TypedAstUtils.isSymbolLocalForProject symbol 
             match Option.orElse symbol.ImplementationLocation symbol.DeclarationLocation with
             | Some loc ->
-                Logging.logInfo "Trying to find symbol '%O' declared at '%O' from current file '%O'..." symbol loc.FileName currentFile
+                Logging.logInfo (fun _ -> sprintf "Trying to find symbol '%O' declared at '%O' from current file '%O'..." symbol loc.FileName currentFile)
                 let filePath = Path.GetFullPathSafe loc.FileName
                 if currentProject.IsForStandaloneScript && filePath = currentFile then 
                     Some SymbolDeclarationLocation.File

--- a/src/FSharpVSPowerTools.Logic/ReferenceSourceProvider.fs
+++ b/src/FSharpVSPowerTools.Logic/ReferenceSourceProvider.fs
@@ -81,7 +81,7 @@ type ReferenceSourceProvider(baseUrl: string) =
             |> Option.map Path.GetFileNameWithoutExtension
             |> Option.map (fun assemblyName ->
                 let url = baseUrl + "/" + assemblyName + "/a.html#" + getMD5Hash xmlDocSig
-                Logging.logInfo "Go to definition at '%s'." url
+                Logging.logInfo (fun _ -> sprintf "Go to definition at '%s'." url)
                 url))
         
     interface IDisposable with

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -218,7 +218,7 @@ type SyntaxConstructClassifier
                 slowState.Swap (fun _ -> SlowStage.Data { Snapshot = snapshot; UnusedSpans = notUsedSpans; IsUpdating = false }) |> ignore
                 debug "[SyntaxConstructClassifier] UpdateUnusedDeclarations: slowState swapped"
                 pf.Stop()
-                Logging.logInfo "[SyntaxConstructClassifier] [Slow stage] %s" pf.Result
+                Logging.logInfo (fun _ -> sprintf "[SyntaxConstructClassifier] [Slow stage] %s" pf.Result)
                 triggerClassificationChanged snapshot "UpdateUnusedDeclarations"
 
                 // Switch back to UI thread before firing events
@@ -335,7 +335,7 @@ type SyntaxConstructClassifier
                             vsLanguageService.CheckProjectInBackground currentProjectOpts
 
                     pf.Stop()
-                    Logging.logInfo "[SyntaxConstructClassifier] [Fast stage] %s" pf.Result
+                    Logging.logInfo (fun _ -> sprintf "[SyntaxConstructClassifier] [Fast stage] %s" pf.Result)
                     
                 | _ -> () } 
             Async.StartInThreadPoolSafe (worker, cancelToken.Token) 

--- a/src/FSharpVSPowerTools.Logic/ThemeManager.fs
+++ b/src/FSharpVSPowerTools.Logic/ThemeManager.fs
@@ -45,10 +45,10 @@ type ThemeManager [<ImportingConstructor>]
             |> Option.bind (function 
                             | [|_; _; themeId|] -> Some themeId 
                             | arr -> 
-                                Logging.logWarning "Parsed Visual Studio theme settings are not well-formed %A." arr
+                                Logging.logWarning (fun _ -> sprintf "Parsed Visual Studio theme settings are not well-formed %A." arr)
                                 None)
         | _ ->
-            Logging.logWarning "Can't recognize Visual Studio version %A." version
+            Logging.logWarning (fun _ -> sprintf "Can't recognize Visual Studio version %A." version)
             None
 
     member __.GetCurrentTheme() =
@@ -71,5 +71,5 @@ type ThemeManager [<ImportingConstructor>]
                 | 30uy, 30uy, 30uy -> VisualStudioTheme.Dark
                 | _ -> VisualStudioTheme.Light
             with _ -> 
-                Logging.logError "Can't read Visual Studio themes from Fonts and Colors Items."
+                Logging.logError (fun _ -> "Can't read Visual Studio themes from Fonts and Colors Items.")
                 VisualStudioTheme.Unknown)

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -65,7 +65,7 @@ type VSLanguageService
     /// Log exceptions to 'ActivityLog' if users run 'devenv.exe /Log'.
     /// Clean up instructions are displayed on status bar.
     let suggestRecoveryAfterFailure ex fileName _source opts =
-        Logging.logError "The following exception: %A occurs for file '%O' and options '%A'." ex fileName opts
+        Logging.logError (fun _ -> sprintf "The following exception: %A occurs for file '%O' and options '%A'." ex fileName opts)
         let statusBar = serviceProvider.GetService<IVsStatusbar, SVsStatusbar>()
         statusBar.SetText(Resource.languageServiceErrorMessage) |> ignore 
                 

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -238,7 +238,7 @@ type DTE with
                 |> Option.bind (fun item -> Option.ofNull item.Document)
             match docOpt, result with
             | Some doc, None ->
-                Logging.logWarning "Can't match between active document '%O' and current path '%O' in current solution." doc.FullName filePath
+                Logging.logWarning (fun _ -> sprintf "Can't match between active document '%O' and current path '%O' in current solution." doc.FullName filePath)
             | _ -> ()
             result
 

--- a/src/FSharpVSPowerTools/Commands/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/SyntaxConstructClassifierProvider.cs
@@ -170,7 +170,7 @@ namespace FSharpVSPowerTools
                     color = new FontColor(Color.FromRgb(220, 220, 220), Color.FromRgb(30, 30, 30));
                     success = themeColors[currentTheme].TryGetValue(category, out color);
                     if (!success)
-                        LoggingModule.logWarningMessage(String.Format("Theme manager can't read colors correctly from {0} theme.", currentTheme));
+                        LoggingModule.logWarningMessage(() => String.Format("Theme manager can't read colors correctly from {0} theme.", currentTheme));
                     return color;
 
                 case VisualStudioTheme.Light:
@@ -179,7 +179,7 @@ namespace FSharpVSPowerTools
                     color = new FontColor(Colors.Black, Colors.White);
                     success = themeColors[currentTheme].TryGetValue(category, out color);
                     if (!success)
-                        LoggingModule.logWarningMessage(String.Format("Theme manager can't read colors correctly from {0} theme.", currentTheme));
+                        LoggingModule.logWarningMessage(() => String.Format("Theme manager can't read colors correctly from {0} theme.", currentTheme));
                     return color;
             }
         }


### PR DESCRIPTION
Avoid the cost of building printf specifiers although there is no printing.

See http://stackoverflow.com/questions/31442608/how-to-wrap-sprintf-conditionally-in-f.

I was trying to keep the printf-like logging functions but we can't get zero-cost abstraction here.