### PR TITLE
Remove Strict mode option

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 #### 2.2.0 - Unreleased
 * Implement outlining support ([#1147](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1147))
+* Fix conflicts between FSharpLint Options dialog and ReSharper ([1166](https://github.com/fsprojects/VisualFSharpPowerTools/pull/1166))
+* Use FCS operation queues more effectively ([1177](https://github.com/fsprojects/VisualFSharpPowerTools/pull/1177), [1178](https://github.com/fsprojects/VisualFSharpPowerTools/pull/1178))
+* Add more advanced outlining ([1175](https://github.com/fsprojects/VisualFSharpPowerTools/pull/1175), [1202](https://github.com/fsprojects/VisualFSharpPowerTools/pull/1202)) 
+* Add colored outlining hints ([1200](https://github.com/fsprojects/VisualFSharpPowerTools/pull/1200))
+* Generate seperate reference scripts for each project configuration ([1197](https://github.com/fsprojects/VisualFSharpPowerTools/pull/1197))
+* No longer check for existence of urls before navigating to source ([1199](https://github.com/fsprojects/VisualFSharpPowerTools/pull/1199))
 
 #### 2.1.0 - October 11 2015
 * Fix fonts and colors' appearance on VS 2015 ([#1064](https://github.com/fsprojects/VisualFSharpPowerTools/issues/1064))

--- a/docs/content/faq.fsx
+++ b/docs/content/faq.fsx
@@ -23,6 +23,8 @@ Our suggestion is to disable automatic features including
  - Resolve unopened namespaces
  - Task List comments
  - Quick info panel
+ - FSharpLint integration
+ - Outlining
 
 and enable them one by one to identify the features causing slowness. 
 If you found a scenario that is slow, please let us know on [the issue tracker](https://github.com/fsprojects/VisualFSharpPowerTools/issues).
@@ -33,15 +35,6 @@ Why is unused declaration option divided into two separate options in v1.6.0?
 There are some performance penalties on checking unused declarations. 
 Until the performance issue is sorted out, we divide the option into two settings to provide more granularity to users.
 The new options are disabled by default.
-
-What is Strict mode? When should I use it?
------------------------
-
-`FSharp.Compiler.Service` (one of our main components) makes extensive use of caching.
-In Strict mode, cache invalidation is done more aggressively. 
-Consequently, type checking results are more up-to-date but there might be performance degradation.
-This setting is disabled by default.
-We recommend to use it if there are frequent intermittent errors on syntax coloring.
 
 What is Diagnostic mode? When should I use it?
 -----------------------

--- a/src/FSharpVSPowerTools.Logic/FsiReferenceCommand.fs
+++ b/src/FSharpVSPowerTools.Logic/FsiReferenceCommand.fs
@@ -171,7 +171,7 @@ type FsiReferenceCommand(dte2: DTE2, mcs: OleMenuCommandService) =
     let rec createProjectProvider project =
         let getProjectProvider project =
             Some (createProjectProvider project :> IProjectProvider)
-        new ProjectProvider(project, getProjectProvider, (fun _ -> ()), id)
+        new ProjectProvider(project, getProjectProvider, ignore)
 
     let generateReferenceFiles (project: Project) =
         maybe {

--- a/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
@@ -142,7 +142,7 @@ type ProjectFactory
     default x.CreateForProject (project: Project): IProjectProvider = 
         let createProjectProvider project = Some (x.CreateForProject project)
         cache.Get project.FullName (fun _ ->
-            new ProjectProvider (project, createProjectProvider, onProjectChanged, vsLanguageService.FixProjectLoadTime)) :> _
+            new ProjectProvider (project, createProjectProvider, onProjectChanged)) :> _
 
     member x.CreateForDocument buffer (doc: Document) =
         let filePath = doc.FullName

--- a/src/FSharpVSPowerTools.Logic/ProjectProvider.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectProvider.fs
@@ -11,8 +11,7 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 
 type internal ProjectProvider(project: Project, 
                               getProjectProvider: Project -> IProjectProvider option, 
-                              onChanged: Project -> unit, 
-                              fixProjectLoadTime: FSharpProjectOptions -> FSharpProjectOptions) =
+                              onChanged: Project -> unit) =
     static let mutable getField = None
     do Debug.Assert(project <> null, "Input project should be well-formed.")
     let refAdded = _dispReferencesEvents_ReferenceAddedEventHandler (fun _ -> onChanged project)
@@ -128,12 +127,10 @@ type internal ProjectProvider(project: Project,
                     |> Array.choose (fun (fullPath, opts) -> 
                         fullPath |> Option.map (fun x -> x, opts))
                 
-                // Fix project load time to ensure each project provider instance has its correct project load time.    
                 let opts = 
                     languageService.GetProjectCheckerOptions (
                         projectFileName.Value, sourceFiles.Value, compilerOptions.Value, referencedProjects)
-                    |> fixProjectLoadTime 
-
+  
                 (*
                 // Disable due to a bug in Visual F# Tools' project system (https://visualfsharp.codeplex.com/workitem/164)
                 let orphanedProjects = lazy (

--- a/src/FSharpVSPowerTools.Logic/Setting.fs
+++ b/src/FSharpVSPowerTools.Logic/Setting.fs
@@ -48,7 +48,6 @@ type ICodeGenerationOptions =
     abstract InterfaceMemberIdentifier: string with get, set
      
 type IGlobalOptions =
-    abstract StrictMode: bool with get, set
     abstract DiagnosticMode: bool with get, set
     abstract BackgroundCompilation: bool with get, set
     abstract ProjectCacheSize: int with get, set

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -118,37 +118,8 @@ type VSLanguageService
         Lexer.getSymbol source line col lineStr kind args (buildQueryLexState point.Snapshot.TextBuffer)
         |> Option.map (fun symbol -> snapshotSpanFromRange point.Snapshot symbol.Range, symbol)
 
-
-    static let initializationTime = DateTime.Now
     let entityCache = EntityCache()
 
-    /// If we are on the strict mode, set project load time to that of the last recently-changed open document.
-    /// When there is no open document, use initialization time as project load time.
-    let fixProjectLoadTime =
-        // Make sure that the options are retrieved after options dialogs have been initialized.
-        // Otherwise, the calls will throw exceptions.
-        let globalOptions = lazy (Setting.getGlobalOptions(serviceProvider))
-        fun opts ->
-            if globalOptions.Value.StrictMode then
-                let projectFiles = Set.ofArray opts.ProjectFileNames
-                let openDocumentsChangeTimes = 
-                    openDocumentsTracker.MapOpenDocuments (fun (KeyValue (file, doc)) -> file, doc)
-                    |> Seq.choose (fun (file, doc) -> 
-                        if doc.Document.IsDirty && Set.contains file projectFiles then 
-                            Some doc.LastChangeTime 
-                        else None)
-                    |> Seq.toList
-        
-                match openDocumentsChangeTimes with
-                | [] -> 
-                    { opts with LoadTime = initializationTime }
-                | changeTimes -> 
-                    { opts with LoadTime = List.max changeTimes }  
-            else
-                opts
-
-    member __.FixProjectLoadTime opts = fixProjectLoadTime opts
-        
     member __.GetSymbol(point, projectProvider) =
         getSymbolUsing SymbolLookupKind.Fuzzy point projectProvider
 

--- a/src/FSharpVSPowerTools/UI/GlobalOptionsPage.cs
+++ b/src/FSharpVSPowerTools/UI/GlobalOptionsPage.cs
@@ -9,16 +9,10 @@ namespace FSharpVSPowerTools
     {
         public GlobalOptionsPage()
         {
-            StrictMode = false;
             DiagnosticMode = false;
             BackgroundCompilation = true;
             ProjectCacheSize = 50;
         }
-
-        [Category("Caching")]
-        [DisplayName("Strict Mode")]
-        [Description("Invalidate caches aggressively in order to provide more up-to-date results.")]
-        public bool StrictMode { get; set; }
 
         [Category("Debugging")]
         [DisplayName("Diagnostic Mode")]
@@ -27,13 +21,13 @@ namespace FSharpVSPowerTools
 
         [Category("Performance")]
         [DisplayName("Background Compilation")]
-        [Description("Compiling current project in background. May cause high CPU load on large projects.")]
+        [Description("Compile current project in background. Enabling the option may cause high CPU load on large projects.")]
         public bool BackgroundCompilation { get; set; }
 
         [Category("Performance")]
         [DisplayName("Project Cache Size")]
-        [Description("How many project's parse and check results are cached. Too large value may cause high memory load, " +
-                     "which will make Visual Studio unusable.")]
+        [Description("The number of projects where their parse and check results are cached. A large value may cause high memory load, " +
+                     "which will make Visual Studio sluggish.")]
         public int ProjectCacheSize { get; set; }
     }
 }

--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.1.2" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.1.3" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A collection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>


### PR DESCRIPTION
It was a desperate effort to bypass a serious bug in FCS. The bug has been fixed long ago; it's safe to remove the hack.