### PR TITLE
Treat warnings as errors

### DIFF
--- a/src/FSharpVSPowerTools.Core/FSharpVSPowerTools.Core.fsproj
+++ b/src/FSharpVSPowerTools.Core/FSharpVSPowerTools.Core.fsproj
@@ -25,6 +25,8 @@
     <DocumentationFile>bin\Debug\FSharpVSPowerTools.Core.XML</DocumentationFile>
     <OtherFlags>--warnon:1182</OtherFlags>
     <NoWarn>52</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -997,7 +997,7 @@ module Outlining =
             | SynMemberDefn.Member (binding,r) ->
                 yield! rcheck Scope.Member Collapse.Below r
                 yield! visitBinding binding
-            | SynMemberDefn.LetBindings (bindings,_,_,r) ->
+            | SynMemberDefn.LetBindings (bindings,_,_,_r) ->
                 //yield! rcheck Scope.LetOrUse Collapse.Below r
                 yield! visitBindings bindings
             | SynMemberDefn.Interface (tp,iMembers,_) ->

--- a/src/FSharpVSPowerTools.Logic.VS2013/FSharpVSPowerTools.Logic.VS2013.fsproj
+++ b/src/FSharpVSPowerTools.Logic.VS2013/FSharpVSPowerTools.Logic.VS2013.fsproj
@@ -25,6 +25,8 @@
     <DocumentationFile>bin\Debug\FSharpVSPowerTools.Logic.VS2013.XML</DocumentationFile>
     <OtherFlags>--warnon:1182</OtherFlags>
     <NoWarn>52</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/FSharpVSPowerTools.Logic.VS2015/FSharpVSPowerTools.Logic.VS2015.fsproj
+++ b/src/FSharpVSPowerTools.Logic.VS2015/FSharpVSPowerTools.Logic.VS2015.fsproj
@@ -24,8 +24,12 @@
     <Tailcalls>false</Tailcalls>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
+    <WarningLevel>5</WarningLevel>
     <DocumentationFile>bin\Debug\FSharpVSPowerTools.Logic.VS2015.XML</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    <NoWarn>52</NoWarn>
+    <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -25,6 +25,8 @@
     <DocumentationFile>bin\Debug\FSharpVSPowerTools.Logic.XML</DocumentationFile>
     <OtherFlags>--warnon:1182</OtherFlags>
     <NoWarn>52</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
@@ -22,8 +22,12 @@
     <Tailcalls>false</Tailcalls>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <WarningLevel>3</WarningLevel>
+    <WarningLevel>5</WarningLevel>
     <DocumentationFile>bin\Release\FSharpVSPowerTools.Core.Tests.XML</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    <NoWarn>52</NoWarn>
+    <OtherFlags>--warnon:1182</OtherFlags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/tests/FSharpVSPowerTools.Core.Tests/LanguageServiceTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/LanguageServiceTests.fs
@@ -378,9 +378,9 @@ let ``ProcessParseTree should prefer open documents``() =
 
     assertTrue (seen.Count = 1)
     match seen.[0] with
-    | Ast.ParsedInput.ImplFile(Ast.ParsedImplFileInput(name, _isScript, _fileName, _scopedPragmas, _hashDirectives, [m], _)) -> 
+    | Ast.ParsedInput.ImplFile(Ast.ParsedImplFileInput(_name, _isScript, _fileName, _scopedPragmas, _hashDirectives, [m], _)) -> 
         match m with
-        | Ast.SynModuleOrNamespace([name], isModule, decls, _xmldoc, _attributes, _access, _range) ->
+        | Ast.SynModuleOrNamespace([name], _isModule, _decls, _xmldoc, _attributes, _access, _range) ->
             assertEqual name.idText "Bar"
         | x -> 
             Assert.Fail (sprintf "Expected empty module named Bar got %+A" x)

--- a/tests/FSharpVSPowerTools.Core.Tests/RecordStubGeneratorTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/RecordStubGeneratorTests.fs
@@ -48,6 +48,7 @@ let tryFindRecordDefinitionFromPos codeGenInfra (pos: pos) (document: IDocument)
     tryFindRecordDefinitionFromPos codeGenInfra (projectOptions document.FullName) pos document
     |> Async.RunSynchronously
 
+[<NoComparison; NoEquality>]
 type CodeGenDiagnostic = {
     mutable Range: range option
     mutable RecordExpr: RecordExpr option

--- a/tests/FSharpVSPowerTools.Tests/FSharpVSPowerTools.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Tests/FSharpVSPowerTools.Tests.fsproj
@@ -23,10 +23,14 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DefineConstants Condition="'$(AppVeyor)' != ''">APPVEYOR</DefineConstants>
-    <WarningLevel>3</WarningLevel>
+    <WarningLevel>5</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Debug\FSharpVSPowerTools.Tests.XML</DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
+    <NoWarn>52</NoWarn>
+    <OtherFlags>--warnon:1182</OtherFlags>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
For all F# projects:
- Raise to warning level 5
- Enable unused value warning
- Treat warnings as errors

It's a bit strict, but it will make maintenance easier in the long term.