### PR TITLE
memoize SyntaxConstructClassifier.getClassificationType

### DIFF
--- a/src/FSharpVSPowerTools.Core/OpenDeclarationsGetter.fs
+++ b/src/FSharpVSPowerTools.Core/OpenDeclarationsGetter.fs
@@ -327,7 +327,7 @@ module OpenDeclarationGetter =
                 let fullNames =
                     symbolUse.FullNames
                     |> Array.map (fun fullName ->
-                        match entities |> Map.tryFind (String.Join (".", fullName)) with
+                        match entities |> Dict.tryFind (String.Join (".", fullName)) with
                         | Some [cleanIdents] ->
                             //debug "[SourceCodeClassifier] One clean FullName %A -> %A" fullName cleanIdents
                             cleanIdents

--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -173,6 +173,8 @@ module private OperatorCategorizer =
         Array.append spansBasedOnSymbolUse (spansBasedOnLexer.ToArray()) |> Array.distinct 
 
 module SourceCodeClassifier =
+    open System.Collections.Generic
+
     let getIdentifierCategory = function
         | Entity e ->
             match e with
@@ -220,7 +222,8 @@ module SourceCodeClassifier =
         else from
 
     let getCategoriesAndLocations (allSymbolsUses: SymbolUse[], checkResults: ParseAndCheckResults, lexer: LexerBase, 
-                                   getTextLine: int -> string, openDeclarations: OpenDeclaration list, allEntities: Map<string, Idents list> option) =
+                                   getTextLine: int -> string, openDeclarations: OpenDeclaration list, 
+                                   allEntities: Dictionary<string, Idents list> option) =
 
         let tokensByLine = lexer.TokenizeAll()
 

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -521,6 +521,28 @@ module Pervasive =
     let (</>) path1 path2 = Path.Combine (path1, path2)
 
 [<RequireQualifiedAccess>]
+module Dict = 
+    open System.Collections.Generic
+
+    let add key value (dict: Dictionary<_,_>) =
+        dict.[key] <- value
+        dict
+
+    let remove (key: 'k) (dict: Dictionary<'k,_>) =
+        dict.Remove key |> ignore
+        dict
+
+    let tryFind key (dict: Dictionary<'k, 'v>) = 
+        let mutable value = Unchecked.defaultof<_>
+        if dict.TryGetValue (key, &value) then Some value
+        else None
+
+    let ofSeq (xs: ('k * 'v) seq) = 
+        let dict = Dictionary()
+        for k, v in xs do dict.[k] <- v
+        dict
+
+[<RequireQualifiedAccess>]
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module String =
     let lowerCaseFirstChar (str: string) =

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -462,6 +462,16 @@ module Pervasive =
             | _, _ when Object.Equals(ctx, nctx) && thread.Equals(Thread.CurrentThread) -> g arg
             | _ -> ctx.Post((fun _ -> g (arg)), null))
 
+    let memoize f =
+        let cache = System.Collections.Generic.Dictionary()
+        fun x ->
+            match cache.TryGetValue x with
+            | true, x -> x
+            | _ ->
+                let res = f x
+                cache.[x] <- res
+                res
+
     type Microsoft.FSharp.Control.Async with
         static member EitherEvent(ev1: IObservable<'T>, ev2: IObservable<'U>) = 
             synchronize (fun f -> 

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -59,7 +59,7 @@ type SyntaxConstructClassifier
         includeUnusedOpens: bool
     ) as self =
     
-    let getClassificationType cat =
+    let getClassificationType = memoize <| fun cat ->
         match cat with
         | Category.ReferenceType -> Some Constants.fsharpReferenceType
         | Category.ValueType -> Some Constants.fsharpValueType

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -161,7 +161,7 @@ type SyntaxConstructClassifier
                      entities 
                      |> Seq.groupBy (fun e -> e.FullName)
                      |> Seq.map (fun (key, es) -> key, es |> Seq.map (fun e -> e.CleanedIdents) |> Seq.toList)
-                     |> Map.ofSeq),
+                     |> Dict.ofSeq),
                 openDecls
         }
     }

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -88,7 +88,7 @@ let (=>) source (expected: (int * ((Cat * int * int) list)) list) =
                 entities 
                 |> Seq.groupBy (fun e -> e.FullName)
                 |> Seq.map (fun (key, es) -> key, es |> Seq.map (fun e -> e.CleanedIdents) |> Seq.toList)
-                |> Map.ofSeq)
+                |> Dict.ofSeq)
 
         SourceCodeClassifier.getCategoriesAndLocations (symbolsUses, checkResults, lexer, 
                                                         (fun line -> sourceLines.[line]), openDeclarations, allEntities)


### PR DESCRIPTION
The function popped up in profiler as the #1 in UI thread. 
Also replaced `Map` with `Dictionary` in SyntaxConstaructClassifier` and `ProjectFactory`.