### PR TITLE
fixed: SyntaxConstructClassifier uses old spans after deleting lines somewhere in the middle of file

### DIFF
--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -198,11 +198,13 @@ type SyntaxConstructClassifier
         let oldTcSpans, (oldStartLine, oldEndLine) = getLineRange oldSpans
         let isNewRangeLarger = newStartLine <= oldStartLine && newEndLine >= oldEndLine
         
-        let isFirstOrLastSpanChanged() = 
+        // returns `true` if both first and last spans are still here, which means
+        // that new spans are not produced from partially valid source file. 
+        let areFirstAndLastSpansNotChanged() = 
             let sameWordSpan x y =
                 x.SymbolKind = y.SymbolKind
                 && x.StartCol = y.StartCol
-                && x.EndCol = y.EndCol 
+                && x.EndCol = y.EndCol
             match newTcSpans, oldTcSpans with
             | [||], [||] -> false
             | _, [||] | [||], _ -> true
@@ -210,7 +212,7 @@ type SyntaxConstructClassifier
                 sameWordSpan x.[0].WordSpan y.[0].WordSpan
                 && sameWordSpan x.[x.Length - 1].WordSpan y.[y.Length - 1].WordSpan
 
-        if isNewRangeLarger || isFirstOrLastSpanChanged() then
+        if isNewRangeLarger || areFirstAndLastSpansNotChanged() then
             debug "[SyntaxConstructClassifier] Replace spans entirely."
             Logging.logInfo (fun _ -> "[SyntaxConstructClassifier] Replace spans entirely.")
             newSpans

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -198,7 +198,7 @@ type SyntaxConstructClassifier
         let oldTcSpans, (oldStartLine, oldEndLine) = getLineRange oldSpans
         let isNewRangeLarger = newStartLine <= oldStartLine && newEndLine >= oldEndLine
         
-        let isFirstOrLastSpanDisappear() = 
+        let isFirstOrLastSpanChanged() = 
             let sameWordSpan x y =
                 x.SymbolKind = y.SymbolKind
                 && x.StartCol = y.StartCol
@@ -210,7 +210,7 @@ type SyntaxConstructClassifier
                 sameWordSpan x.[0].WordSpan y.[0].WordSpan
                 && sameWordSpan x.[x.Length - 1].WordSpan y.[y.Length - 1].WordSpan
 
-        if isNewRangeLarger || isFirstOrLastSpanDisappear() then
+        if isNewRangeLarger || isFirstOrLastSpanChanged() then
             debug "[SyntaxConstructClassifier] Replace spans entirely."
             Logging.logInfo (fun _ -> "[SyntaxConstructClassifier] Replace spans entirely.")
             newSpans

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -175,29 +175,51 @@ type SyntaxConstructClassifier
         else Some()
 
     let mergeSpans (oldSpans: CategorizedColumnSpan<_>[]) (newSpans: CategorizedColumnSpan<_>[]) =
+        let getTypeCheckerSpans spans =
+            spans
+            |> Array.filter (fun x -> 
+                match x.Category with
+                | Category.Escaped 
+                | Category.Operator
+                | Category.Other
+                | Category.Printf
+                | Category.Quotation 
+                | Category.Unused -> false
+                | _ -> true) 
+
         let getLineRange spans =
-            let lines = 
-                spans 
-                |> Array.filter (fun x -> 
-                    match x.Category with
-                    | Category.Escaped 
-                    | Category.Operator
-                    | Category.Other
-                    | Category.Printf
-                    | Category.Quotation 
-                    | Category.Unused -> false
-                    | _ -> true) 
-                |> Array.map (fun x -> x.WordSpan.Line)
-            Array.min lines, Array.max lines
+            let typeCheckerSpans = getTypeCheckerSpans spans
+            typeCheckerSpans,
+            typeCheckerSpans
+            |> Array.map (fun x -> x.WordSpan.Line)
+            |> function [||] -> -1, -1 | lines -> Array.min lines, Array.max lines
             
-        let newStartLine, newEndLine = getLineRange newSpans
-        let oldStartLine, oldEndLine = getLineRange oldSpans
-        if newStartLine <= oldStartLine && newEndLine >= oldEndLine then
+        let newTcSpans, (newStartLine, newEndLine) = getLineRange newSpans
+        let oldTcSpans, (oldStartLine, oldEndLine) = getLineRange oldSpans
+        let isNewRangeLarger = newStartLine <= oldStartLine && newEndLine >= oldEndLine
+        
+        let isFirstOrLastSpanDisappear() = 
+            let sameWordSpan x y =
+                x.SymbolKind = y.SymbolKind
+                && x.StartCol = y.StartCol
+                && x.EndCol = y.EndCol 
+            match newTcSpans, oldTcSpans with
+            | [||], [||] -> false
+            | _, [||] | [||], _ -> true
+            | x, y ->
+                sameWordSpan x.[0].WordSpan y.[0].WordSpan
+                && sameWordSpan x.[x.Length - 1].WordSpan y.[y.Length - 1].WordSpan
+
+        if isNewRangeLarger || isFirstOrLastSpanDisappear() then
             debug "[SyntaxConstructClassifier] Replace spans entirely."
+            Logging.logInfo (fun _ -> "[SyntaxConstructClassifier] Replace spans entirely.")
             newSpans
         else
-            debug "[SyntaxConstructClassifier] Mergin spans (new range %A < old range %A)."
+            debug "[SyntaxConstructClassifier] Merging spans (new range %A < old range %A)."
                   (newStartLine, newEndLine) (oldStartLine, oldEndLine)
+            Logging.logInfo (fun _ -> 
+                sprintf "[SyntaxConstructClassifier] Merging spans (new range %A < old range %A)."
+                        (newStartLine, newEndLine) (oldStartLine, oldEndLine))
 
             let oldSpans = 
                 seq { yield! oldSpans |> Seq.takeWhile (fun x -> x.WordSpan.Line < newStartLine)


### PR DESCRIPTION
It's becoming really tricky :(