### PR TITLE
cache SnapshotSpan and translate it to new ITextSnapshot if needed

### DIFF
--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -22,10 +22,7 @@ type Category =
 
 type CategorizedColumnSpan<'T> =
     { Category: Category
-      WordSpan: WordSpan
-      /// Snapshot for which the span was created.
-      /// None if the right Snapshot is maintained separately
-      Snapshot: 'T option }
+      WordSpan: WordSpan }
 
 module private QuotationCategorizer =
     let private categorize (lexer: LexerBase) ranges =
@@ -39,8 +36,7 @@ module private QuotationCategorizer =
                         WordSpan = { SymbolKind = SymbolKind.Other
                                      Line = r.StartLine
                                      StartCol = r.StartColumn
-                                     EndCol = r.EndColumn }
-                        Snapshot = None } ]
+                                     EndCol = r.EndColumn }} ]
             else
                 [r.StartLine..r.EndLine]
                 |> Seq.choose (fun line ->
@@ -68,8 +64,7 @@ module private QuotationCategorizer =
                                WordSpan = { SymbolKind = SymbolKind.Other
                                             Line = line
                                             StartCol = minCol
-                                            EndCol = maxCol }
-                               Snapshot = None }))
+                                            EndCol = maxCol }}))
 
     let getCategories ast lexer = UntypedAstUtils.getQuotationRanges ast |> categorize lexer
 
@@ -102,8 +97,7 @@ module private StringCategorizers =
                           { SymbolKind = SymbolKind.Other
                             Line = line
                             StartCol = startColumn + m.Index
-                            EndCol = startColumn + m.Index + m.Length }
-                        Snapshot = None }
+                            EndCol = startColumn + m.Index + m.Length }}
                   category :: acc  
                 ) [])
          
@@ -133,8 +127,7 @@ module private OperatorCategorizer =
             |> Array.choose (fun (_, span) -> 
                 if span.SymbolKind = SymbolKind.Operator then
                     Some { Category = Category.Operator
-                           WordSpan = span
-                           Snapshot = None }
+                           WordSpan = span }
                 else None)
 
         let spansBasedOnLexer =
@@ -165,8 +158,7 @@ module private OperatorCategorizer =
                             { SymbolKind = SymbolKind.Operator
                               Line = line + 1
                               StartCol = lCol
-                              EndCol = rCol }
-                          Snapshot = None })
+                              EndCol = rCol }})
                 acc.AddRange(operatorTokens)
                 acc) (ResizeArray())
 
@@ -306,8 +298,7 @@ module SourceCodeClassifier =
                     else Some { Category = 
                                     if not symbolUse.IsUsed then Category.Unused 
                                     else getCategory symbolUse.SymbolUse
-                                WordSpan = span' 
-                                Snapshot = None }
+                                WordSpan = span' }
         
                 categorizedSpan)
             |> Seq.groupBy (fun span -> span.WordSpan)
@@ -353,15 +344,13 @@ module SourceCodeClassifier =
                   WordSpan = { SymbolKind = SymbolKind.Other
                                Line = decl.DeclarationRange.StartLine 
                                StartCol = decl.DeclarationRange.StartColumn
-                               EndCol = decl.DeclarationRange.EndColumn }
-                  Snapshot = None })
+                               EndCol = decl.DeclarationRange.EndColumn }})
     
-        let printfSpecifiersRanges =        
+        let printfSpecifiersRanges =
             checkResults.GetFormatSpecifierLocations()
             |> Option.map (fun ranges ->
                  ranges |> Array.map (fun r -> 
-                    { Snapshot = None
-                      Category = Category.Printf
+                    { Category = Category.Printf
                       WordSpan = 
                         { SymbolKind = SymbolKind.Other
                           Line = r.StartLine

--- a/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SyntaxConstructClassifier.fs
@@ -146,12 +146,12 @@ type SyntaxConstructClassifier
 
     let triggerClassificationChanged snapshot reason =
         let span = SnapshotSpan(snapshot, 0, snapshot.Length)
-        classificationChanged.Trigger(self, ClassificationChangedEventArgs(span))
+        classificationChanged.Trigger(self, ClassificationChangedEventArgs span)
         debug "[SyntaxConstructClassifier] ClassificationChanged event has been triggered by %s" reason
 
     let triggerUnusedDeclarationChanged snapshot =
         let span = SnapshotSpan(snapshot, 0, snapshot.Length)
-        unusedDeclarationChanged.Trigger(self, SnapshotSpanEventArgs(span))
+        unusedDeclarationChanged.Trigger(self, SnapshotSpanEventArgs span)
 
     let getOpenDeclarations source project ast getTextLineOneBased (pf: Profiler) = async {
         let! entities = pf.TimeAsync "GetAllEntities" <| fun _ ->
@@ -175,8 +175,8 @@ type SyntaxConstructClassifier
                     |> Option.map
                      (Seq.groupBy (fun e -> e.FullName)
                      >> Seq.map (fun (key, es) -> key, es |> Seq.map (fun e -> e.CleanedIdents) |> Seq.toList)
-                     >> Dict.ofSeq)
-                                    , openDecls)
+                     >> Dict.ofSeq),
+                openDecls)
         }
     }
 

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -108,8 +108,9 @@ type VSLanguageService
         let source = point.Snapshot.GetText()
         let line = point.Snapshot.GetLineNumberFromPosition point.Position
         let col = point.Position - point.GetContainingLine().Start.Position
-        let lineStr = point.GetContainingLine().GetText()                
+        let lineStr = point.GetContainingLine().GetText()
         let args = projectProvider.CompilerOptions
+        
         let snapshotSpanFromRange (snapshot: ITextSnapshot) (lineStart, colStart, lineEnd, colEnd) =
             let startPos = snapshot.GetLineFromLineNumber(lineStart).Start.Position + colStart
             let endPos = snapshot.GetLineFromLineNumber(lineEnd).Start.Position + colEnd


### PR DESCRIPTION
After the recent changes `SnapshotSpan`s were `translate`d each time VS request it. It resulted with huge UI lags. 

Now we keep list of `CategorizedSnapshotSpan` which contains `CategorizedColumnSpan` + `ITextSnapshot` for which `CategorizedColumnSpan` was calculated + cached `SnapshotSpan`. It guaranties that spans are created for the right (original) snapshot, then translated to fresh snapshots, as needed. I hope it's resolve performance and inconsistencies of all kinds. 

Also, MB-based `ProjectProvider` cache is replaced with `ConcurrentDictionary` to avoid blocking get operations while an expensive instance is being created.