### PR TITLE
Fix the issue where Lint configs in nested folders weren't recognized

### DIFF
--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.1.13" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.2.3" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A collection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>

--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.2.3" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.1.20" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A collection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>


### PR DESCRIPTION
Read all F# projects in the solution recursively.

Fix #1251.