### PR TITLE
Printf specifiers tagger

### DIFF
--- a/src/FSharpVSPowerTools.Core/FSharpVSPowerTools.Core.fsproj
+++ b/src/FSharpVSPowerTools.Core/FSharpVSPowerTools.Core.fsproj
@@ -89,6 +89,7 @@
     <Compile Include="UnopenedNamespacesResolver.fs" />
     <Compile Include="SignatureGenerator.fs" />
     <Compile Include="TaskListCommentExtractor.fs" />
+    <Compile Include="PrintfSpecifiersUsageGetter.fs" />
     <None Include="Scratchpad.fsx" />
     <Content Include="paket.references" />
   </ItemGroup>

--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -26,16 +26,19 @@ let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
                 let ownSpecifiers, restSpecifiers = 
                     specifierRanges 
                     |> Array.partition (Range.rangeContainsRange func.String)
-            
-                if func.Args.Length > ownSpecifiers.Length then
-                    failwithf "Too many Printf arguments for %+A (%d > %d)" func func.Args.Length ownSpecifiers.Length
-
-                let uses = 
-                    func.Args
-                    |> Array.sortBy sortRange
-                    |> Array.zip (ownSpecifiers.[0..func.Args.Length - 1] |> Array.sortBy sortRange)
-                    |> Array.map (fun (specifier, arg) -> { SpecifierRange = specifier; ArgumentRange = arg })
-                restSpecifiers, uses :: acc
+                
+                match ownSpecifiers with
+                | [||] -> restSpecifiers, acc
+                | _ ->
+                    if func.Args.Length > ownSpecifiers.Length then
+                        failwithf "Too many Printf arguments for %+A (%d > %d)" func func.Args.Length ownSpecifiers.Length
+                    
+                    let uses = 
+                        func.Args
+                        |> Array.sortBy sortRange
+                        |> Array.zip (ownSpecifiers.[0..func.Args.Length - 1] |> Array.sortBy sortRange)
+                        |> Array.map (fun (specifier, arg) -> { SpecifierRange = specifier; ArgumentRange = arg })
+                    restSpecifiers, uses :: acc
                ) (specifierRanges, [])
             |> snd
             |> List.toArray

--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -27,14 +27,14 @@ let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
                     specifierRanges 
                     |> Array.partition (Range.rangeContainsRange func.String)
             
-                if ownSpecifiers.Length > func.Args.Length then
-                    failwithf "Too many Printf specifiers for %+A (%d > %d)" func ownSpecifiers.Length func.Args.Length
+                if func.Args.Length > ownSpecifiers.Length then
+                    failwithf "Too many Printf arguments for %+A (%d > %d)" func func.Args.Length ownSpecifiers.Length
 
                 let uses = 
-                    ownSpecifiers
+                    func.Args
                     |> Array.sortBy sortRange
-                    |> Array.zip (func.Args.[0..ownSpecifiers.Length - 1] |> Array.sortBy sortRange)
-                    |> Array.map (fun (arg, specifier) -> { SpecifierRange = specifier; ArgumentRange = arg })
+                    |> Array.zip (ownSpecifiers.[0..func.Args.Length - 1] |> Array.sortBy sortRange)
+                    |> Array.map (fun (specifier, arg) -> { SpecifierRange = specifier; ArgumentRange = arg })
                 restSpecifiers, uses :: acc
                ) (specifierRanges, [])
             |> snd

--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -25,7 +25,7 @@ let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
             |> Array.fold (fun (specifierRanges, acc) func ->
                 let ownSpecifiers, restSpecifiers = 
                     specifierRanges 
-                    |> Array.partition (Range.rangeContainsRange func.Full)
+                    |> Array.partition (Range.rangeContainsRange func.String)
             
                 if ownSpecifiers.Length > func.Args.Length then
                     failwithf "Too many Printf specifiers for %+A (%d > %d)" func ownSpecifiers.Length func.Args.Length

--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -1,11 +1,16 @@
 ﻿module FSharpVSPowerTools.PrintfSpecifiersUsageGetter
 
 open Microsoft.FSharp.Compiler
+open FSharpVSPowerTools.UntypedAstUtils
 
 [<NoComparison>]
 type PrintfSpecifierUse =
     { SpecifierRange: Range.range
       ArgumentRange: Range.range }
 
-let getAll (_input: ParseAndCheckResults): PrintfSpecifierUse[] option =
-    Some [||]
+let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
+    asyncMaybe {
+        let! specifierRanges = input.GetFormatSpecifierLocations()
+        let _printfFunctions = Printf.getAll input.ParseTree
+        return specifierRanges |> Array.map (fun x -> { SpecifierRange = x; ArgumentRange = x })
+    }

--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -8,7 +8,7 @@ type PrintfSpecifierUse =
     { SpecifierRange: Range.range
       ArgumentRange: Range.range }
 
-let private sortRange (r: Range.range) = r.StartLine, r.StartColumn
+let private startPos (r: Range.range) = r.StartLine, r.StartColumn
 
 let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
     asyncMaybe {
@@ -25,7 +25,7 @@ let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
             |> Array.fold (fun (specifierRanges, acc) func ->
                 let ownSpecifiers, restSpecifiers = 
                     specifierRanges 
-                    |> Array.partition (Range.rangeContainsRange func.String)
+                    |> Array.partition (Range.rangeContainsRange func.FormatString)
                 
                 match ownSpecifiers with
                 | [||] -> restSpecifiers, acc
@@ -35,8 +35,8 @@ let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
                     
                     let uses = 
                         func.Args
-                        |> Array.sortBy sortRange
-                        |> Array.zip (ownSpecifiers.[0..func.Args.Length - 1] |> Array.sortBy sortRange)
+                        |> Array.sortBy startPos
+                        |> Array.zip (ownSpecifiers.[0..func.Args.Length - 1] |> Array.sortBy startPos)
                         |> Array.map (fun (specifier, arg) -> { SpecifierRange = specifier; ArgumentRange = arg })
                     restSpecifiers, uses :: acc
                ) (specifierRanges, [])

--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -1,0 +1,11 @@
+﻿module FSharpVSPowerTools.PrintfSpecifiersUsageGetter
+
+open Microsoft.FSharp.Compiler
+
+[<NoComparison>]
+type PrintfSpecifierUse =
+    { SpecifierRange: Range.range
+      ArgumentRange: Range.range }
+
+let getAll (_input: ParseAndCheckResults): PrintfSpecifierUse[] option =
+    Some [||]

--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -8,9 +8,36 @@ type PrintfSpecifierUse =
     { SpecifierRange: Range.range
       ArgumentRange: Range.range }
 
+let private sortRange (r: Range.range) = r.StartLine, r.StartColumn
+
 let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
     asyncMaybe {
         let! specifierRanges = input.GetFormatSpecifierLocations()
-        let _printfFunctions = Printf.getAll input.ParseTree
-        return specifierRanges |> Array.map (fun x -> { SpecifierRange = x; ArgumentRange = x })
+        let specifierRanges = 
+            specifierRanges 
+            |> Array.map (fun x -> 
+                Range.mkRange x.FileName x.Start (Range.mkPos x.EndLine (x.EndColumn + 1)))
+
+        let printfFunctions = Printf.getAll input.ParseTree
+
+        return 
+            printfFunctions
+            |> Array.fold (fun (specifierRanges, acc) func ->
+                let ownSpecifiers, restSpecifiers = 
+                    specifierRanges 
+                    |> Array.partition (Range.rangeContainsRange func.Full)
+            
+                if ownSpecifiers.Length > func.Args.Length then
+                    failwithf "Too many Printf specifiers for %+A (%d > %d)" func ownSpecifiers.Length func.Args.Length
+
+                let uses = 
+                    ownSpecifiers
+                    |> Array.sortBy sortRange
+                    |> Array.zip (func.Args.[0..ownSpecifiers.Length - 1] |> Array.sortBy sortRange)
+                    |> Array.map (fun (arg, specifier) -> { SpecifierRange = specifier; ArgumentRange = arg })
+                restSpecifiers, uses :: acc
+               ) (specifierRanges, [])
+            |> snd
+            |> List.toArray
+            |> Array.concat
     }

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -1159,7 +1159,7 @@ module Outlining =
 module Printf =
     [<NoComparison>]
     type PrintfFunction = 
-        { String: Range.range
+        { FormatString: Range.range
           Args: Range.range[] }
     
     [<NoComparison>]
@@ -1254,7 +1254,7 @@ module Printf =
                         |> List.rev
                         |> List.map (fun x -> x.Arg)
                         |> List.toArray
-                    let res = { String = stringRange
+                    let res = { FormatString = stringRange
                                 Args = args }
                     result.Add res
                 | _ -> ()

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -1161,7 +1161,7 @@ module Printf =
     type PrintfFunction = 
         { Full: Range.range
           String: Range.range
-          Args: Range.range list }
+          Args: Range.range[] }
 
     let internal getAll (input: ParsedInput option) : PrintfFunction[] =
         let result = ResizeArray()
@@ -1221,12 +1221,14 @@ module Printf =
                 | [] -> ()
                 | (fullExpr :: _) as apps ->
                     let args =
-                        List.foldBack (fun app res -> 
+                        apps 
+                        |> List.fold (fun res app -> 
                             match app with 
                             | SynExpr.App (_, _, _, arg, _) ->
                                 arg.Range :: res
                             | _ -> res
-                        ) apps []
+                        ) []
+                        |> List.toArray
                     let res = { Full = fullExpr.Range
                                 String = stringRange
                                 Args = args }

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -735,11 +735,6 @@ module Outlining =
         /// Create a range beginning at the start of r1 and finishing at the end of r2
         let inline startToEnd (r1: range) (r2: range) = mkFileIndexRange r1.FileIndex r1.Start r2.End
 
-        /// Create a range starting at the end of r1 modified by m1 and finishing at the end of r2 modified by m2
-        let inline endToEndmod (r1: range) (m1:int) (r2: range) (m2:int) =
-            let modstart, modend = mkPos r1.EndLine (r1.EndColumn + m1), mkPos r2.EndLine (r2.EndColumn + m2)
-            mkFileIndexRange r1.FileIndex modstart modend
-
         /// Create a new range from r by shifting the starting column by m
         let inline modStart (r: range) (m:int) =
             let modstart = mkPos r.StartLine (r.StartColumn+m)
@@ -751,9 +746,6 @@ module Outlining =
             let rStart = Range.mkPos r.StartLine (r.StartColumn+modStart)
             let rEnd   = Range.mkPos r.EndLine   (r.EndColumn - modEnd)
             mkFileIndexRange r.FileIndex rStart rEnd
-
-        let inline ofAttributes (attrs:SynAttributes) =
-            match attrs with | [] -> range () | _  -> startToEnd attrs.[0].Range attrs.[List.length attrs - 1].ArgExpr.Range
 
     /// Scope indicates the way a range/snapshot should be collapsed. |Scope.Scope.Same| is for a scope inside
     /// some kind of scope delimiter, e.g. `[| ... |]`, `[ ... ]`, `{ ... }`, etc.  |Scope.Below| is for expressions
@@ -1163,3 +1155,227 @@ module Outlining =
             let (ParsedImplFileInput (_, _, _, _, _, modules, _)) = implFile
             Seq.collect parseModuleOrNamespace modules
         | _ -> Seq.empty
+
+module Printf =
+    [<NoComparison>]
+    type PrintfFunction = 
+        { Full: Range.range
+          String: Range.range
+          Args: Range.range list }
+
+    let internal getAll (input: ParsedInput option) : PrintfFunction[] =
+        let result = ResizeArray()
+        let appStack: SynExpr list ref = ref []
+
+        let rec walkImplFileInput (ParsedImplFileInput(_, _, _, _, _, moduleOrNamespaceList, _)) =
+            List.iter walkSynModuleOrNamespace moduleOrNamespaceList
+
+        and walkSynModuleOrNamespace (SynModuleOrNamespace(_, _, decls, _, _, _, _)) =
+            List.iter walkSynModuleDecl decls
+
+        and walkTypeConstraint = function
+            | SynTypeConstraint.WhereTyparDefaultsToType (_, ty, _)
+            | SynTypeConstraint.WhereTyparSubtypeOfType (_, ty, _) -> walkType ty
+            | SynTypeConstraint.WhereTyparIsEnum (_, ts, _)
+            | SynTypeConstraint.WhereTyparIsDelegate (_, ts, _) -> List.iter walkType ts
+            | SynTypeConstraint.WhereTyparSupportsMember (_, sign, _) -> walkMemberSig sign
+            | _ -> ()
+
+        and walkBinding (SynBinding.Binding (_, _, _, _, _, _, _, _, returnInfo, e, _, _)) =
+            walkExpr e
+            returnInfo |> Option.iter (fun (SynBindingReturnInfo (t, _, _)) -> walkType t)
+
+        and walkInterfaceImpl (InterfaceImpl(_, bindings, _)) = List.iter walkBinding bindings
+
+        and walkIndexerArg = function
+            | SynIndexerArg.One e -> walkExpr e
+            | SynIndexerArg.Two (e1, e2) -> List.iter walkExpr [e1; e2]
+
+        and walkType = function
+            | SynType.Array (_, t, _)
+            | SynType.HashConstraint (t, _)
+            | SynType.MeasurePower (t, _, _) -> walkType t
+            | SynType.Fun (t1, t2, _)
+            | SynType.MeasureDivide (t1, t2, _) -> walkType t1; walkType t2
+            | SynType.App (ty, _, types, _, _, _, _) -> walkType ty; List.iter walkType types
+            | SynType.LongIdentApp (_, _, _, types, _, _, _) -> List.iter walkType types
+            | SynType.Tuple (ts, _) -> ts |> List.iter (fun (_, t) -> walkType t)
+            | SynType.WithGlobalConstraints (t, typeConstraints, _) ->
+                walkType t; List.iter walkTypeConstraint typeConstraints
+            | _ -> ()
+
+        and walkClause (Clause (_, e1, e2, _, _)) =
+            walkExpr e2
+            e1 |> Option.iter walkExpr
+
+        and walkSimplePats = function
+            | SynSimplePats.SimplePats (pats, _) -> List.iter walkSimplePat pats
+            | SynSimplePats.Typed (pats, ty, _) -> 
+                walkSimplePats pats
+                walkType ty
+
+        and walkExpr e =
+            match e with
+            | SynExpr.App (_, _, SynExpr.Ident _, SynExpr.Const (SynConst.String (_, stringRange), _), _) ->
+                match !appStack |> List.rev with
+                | [] -> ()
+                | (fullExpr :: _) as apps ->
+                    let args =
+                        List.foldBack (fun app res -> 
+                            match app with 
+                            | SynExpr.App (_, _, _, arg, _) ->
+                                arg.Range :: res
+                            | _ -> res
+                        ) apps []
+                    let res = { Full = fullExpr.Range
+                                String = stringRange
+                                Args = args }
+                    result.Add res
+                appStack := []
+            | SynExpr.App (_, _, e1, e2, _) ->
+                appStack := e :: !appStack 
+                walkExpr e1
+                walkExpr e2
+            | _ ->
+                match e with
+                | SynExpr.Paren (e, _, _, _)
+                | SynExpr.Quote (_, _, e, _, _)
+                | SynExpr.Typed (e, _, _)
+                | SynExpr.InferredUpcast (e, _)
+                | SynExpr.InferredDowncast (e, _)
+                | SynExpr.AddressOf (_, e, _, _)
+                | SynExpr.DoBang (e, _)
+                | SynExpr.YieldOrReturn (_, e, _)
+                | SynExpr.ArrayOrListOfSeqExpr (_, e, _)
+                | SynExpr.CompExpr (_, _, e, _)
+                | SynExpr.Do (e, _)
+                | SynExpr.Assert (e, _)
+                | SynExpr.Lazy (e, _)
+                | SynExpr.YieldOrReturnFrom (_, e, _) -> walkExpr e
+                | SynExpr.Lambda (_, _, pats, e, _) ->
+                    walkSimplePats pats
+                    walkExpr e
+                | SynExpr.New (_, t, e, _)
+                | SynExpr.TypeTest (e, t, _)
+                | SynExpr.Upcast (e, t, _)
+                | SynExpr.Downcast (e, t, _) -> walkExpr e; walkType t
+                | SynExpr.Tuple (es, _, _)
+                | Sequentials es
+                | SynExpr.ArrayOrList (_, es, _) -> List.iter walkExpr es
+                | SynExpr.TryFinally (e1, e2, _, _, _)
+                | SynExpr.While (_, e1, e2, _) -> List.iter walkExpr [e1; e2]
+                | SynExpr.Record (_, _, fields, _) ->
+                    fields |> List.iter (fun (_, e, _) -> e |> Option.iter walkExpr)
+                | SynExpr.ObjExpr(ty, argOpt, bindings, ifaces, _, _) ->
+                    argOpt |> Option.iter (fun (e, _) -> walkExpr e)
+                    walkType ty
+                    List.iter walkBinding bindings
+                    List.iter walkInterfaceImpl ifaces
+                | SynExpr.For (_, _, e1, _, e2, e3, _) -> List.iter walkExpr [e1; e2; e3]
+                | SynExpr.ForEach (_, _, _, _, e1, e2, _) -> List.iter walkExpr [e1; e2]
+                | SynExpr.MatchLambda (_, _, synMatchClauseList, _, _) ->
+                    List.iter walkClause synMatchClauseList
+                | SynExpr.Match (_, e, synMatchClauseList, _, _) ->
+                    walkExpr e
+                    List.iter walkClause synMatchClauseList
+                | SynExpr.TypeApp (e, _, tys, _, _, _, _) ->
+                    List.iter walkType tys; walkExpr e
+                | SynExpr.LetOrUse (_, _, bindings, e, _) ->
+                    List.iter walkBinding bindings; walkExpr e
+                | SynExpr.TryWith (e, _, clauses, _, _, _, _) ->
+                    List.iter walkClause clauses;  walkExpr e
+                | SynExpr.IfThenElse (e1, e2, e3, _, _, _, _) ->
+                    List.iter walkExpr [e1; e2]
+                    e3 |> Option.iter walkExpr
+                | SynExpr.LongIdentSet (_, e, _)
+                | SynExpr.DotGet (e, _, _, _) -> walkExpr e
+                | SynExpr.DotSet (e1, _, e2, _) ->
+                    walkExpr e1
+                    walkExpr e2
+                | SynExpr.DotIndexedGet (e, args, _, _) ->
+                    walkExpr e
+                    List.iter walkIndexerArg args
+                | SynExpr.DotIndexedSet (e1, args, e2, _, _, _) ->
+                    walkExpr e1
+                    List.iter walkIndexerArg args
+                    walkExpr e2
+                | SynExpr.NamedIndexedPropertySet (_, e1, e2, _) -> List.iter walkExpr [e1; e2]
+                | SynExpr.DotNamedIndexedPropertySet (e1, _, e2, e3, _) -> List.iter walkExpr [e1; e2; e3]
+                | SynExpr.JoinIn (e1, _, e2, _) -> List.iter walkExpr [e1; e2]
+                | SynExpr.LetOrUseBang (_, _, _, _, e1, e2, _) -> List.iter walkExpr [e1; e2]
+                | SynExpr.TraitCall (_, sign, e, _) ->
+                    walkMemberSig sign
+                    walkExpr e
+                | SynExpr.Const (SynConst.Measure(_, m), _) -> walkMeasure m
+                | _ -> ()
+
+        and walkMeasure = function
+            | SynMeasure.Product (m1, m2, _)
+            | SynMeasure.Divide (m1, m2, _) -> walkMeasure m1; walkMeasure m2
+            | SynMeasure.Seq (ms, _) -> List.iter walkMeasure ms
+            | SynMeasure.Power (m, _, _) -> walkMeasure m
+            | SynMeasure.One
+            | SynMeasure.Anon _
+            | SynMeasure.Named _
+            | SynMeasure.Var _ -> ()
+
+        and walkSimplePat = function
+            | SynSimplePat.Attrib (pat, _, _) -> walkSimplePat pat
+            | SynSimplePat.Typed(_, t, _) -> walkType t
+            | _ -> ()
+
+        and walkField (SynField.Field(_, _, _, t, _, _, _, _)) = walkType t
+
+        and walkMemberSig = function
+            | SynMemberSig.Inherit (t, _)
+            | SynMemberSig.Interface(t, _) -> walkType t
+            | SynMemberSig.ValField(f, _) -> walkField f
+            | SynMemberSig.NestedType(SynTypeDefnSig.TypeDefnSig (_, repr, memberSigs, _), _) ->
+                walkTypeDefnSigRepr repr
+                List.iter walkMemberSig memberSigs
+            | SynMemberSig.Member _ -> ()
+
+        and walkMember = function
+            | SynMemberDefn.Member (binding, _) -> walkBinding binding
+            | SynMemberDefn.ImplicitCtor (_, _, pats, _, _) -> List.iter walkSimplePat pats
+            | SynMemberDefn.ImplicitInherit (t, e, _, _) -> walkType t; walkExpr e
+            | SynMemberDefn.LetBindings (bindings, _, _, _) -> List.iter walkBinding bindings
+            | SynMemberDefn.Interface (t, members, _) ->
+                walkType t
+                members |> Option.iter (List.iter walkMember)
+            | SynMemberDefn.Inherit (t, _, _) -> walkType t
+            | SynMemberDefn.ValField (field, _) -> walkField field
+            | SynMemberDefn.NestedType (tdef, _, _) -> walkTypeDefn tdef
+            | SynMemberDefn.AutoProperty (_, _, _, t, _, _, _, _, e, _, _) ->
+                Option.iter walkType t
+                walkExpr e
+            | _ -> ()
+
+        and walkTypeDefnRepr = function
+            | SynTypeDefnRepr.ObjectModel (_, defns, _) -> List.iter walkMember defns
+            | SynTypeDefnRepr.Simple _ -> ()
+
+        and walkTypeDefnSigRepr = function
+            | SynTypeDefnSigRepr.ObjectModel (_, defns, _) -> List.iter walkMemberSig defns
+            | SynTypeDefnSigRepr.Simple _ -> ()
+
+        and walkTypeDefn (TypeDefn (_, repr, members, _)) =
+            walkTypeDefnRepr repr
+            List.iter walkMember members
+
+        and walkSynModuleDecl (decl: SynModuleDecl) =
+            match decl with
+            | SynModuleDecl.NamespaceFragment fragment -> walkSynModuleOrNamespace fragment
+            | SynModuleDecl.NestedModule (_, modules, _, _) ->
+                List.iter walkSynModuleDecl modules
+            | SynModuleDecl.Let (_, bindings, _) -> List.iter walkBinding bindings
+            | SynModuleDecl.DoExpr (_, expr, _) -> walkExpr expr
+            | SynModuleDecl.Types (types, _) -> List.iter walkTypeDefn types
+            | _ -> ()
+
+        match input with
+        | Some (ParsedInput.ImplFile input) ->
+             walkImplFileInput input
+        | _ -> ()
+        //debug "%A" idents
+        result.ToArray()

--- a/src/FSharpVSPowerTools.Logic/Constants.fs
+++ b/src/FSharpVSPowerTools.Logic/Constants.fs
@@ -38,6 +38,8 @@ let [<Literal>] fsharpPrintf = "FSharp.Printf"
 let [<Literal>] fsharpEscaped = "FSharp.Escaped"
 let [<Literal>] fsharpOperator = "FSharp.Operator"
 
+let [<Literal>] fsharpPrintfTagType = "MarkerFormatDefinition/HighlightPrintf"
+
 let [<Literal>] depthAdornmentLayerName = "FSharpDepthFullLineAdornment"
 
 let cmdidStandardRenameCommand = uint32 VSConstants.VSStd2KCmdID.RENAME // ECMD_RENAME

--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -174,6 +174,9 @@
     <Compile Include="HighlightUsageFilter.fs">
       <Link>Symbol/HighlightUsageFilter.fs</Link>
     </Compile>
+	<Compile Include="PrintfSpecifiersUsageTagger.fs">
+      <Link>Symbol/PrintfSpecifiersUsageTagger.fs</Link>
+    </Compile>
     <Compile Include="RenameDialog.fs">
       <Link>Symbol/RenameDialog.fs</Link>
     </Compile>

--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -149,5 +149,4 @@ type HighlightUsageTagger(textDocument: ITextDocument,
         member __.TagsChanged = tagsChanged.Publish
 
     interface IDisposable with
-        member __.Dispose() = 
-            (docEventListener :> IDisposable).Dispose()
+        member __.Dispose() = dispose docEventListener

--- a/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
@@ -9,24 +9,9 @@ open FSharpVSPowerTools
 open FSharpVSPowerTools.ProjectSystem
 open FSharpVSPowerTools.PrintfSpecifiersUsageGetter
 open Microsoft.FSharp.Compiler
-open System.ComponentModel.Composition
-open Microsoft.VisualStudio.Text.Classification
-open Microsoft.VisualStudio.Utilities
-open System.Windows.Media
 
 type PrintfSpecifiersUsageTag() = 
-    inherit TextMarkerTag("MarkerFormatDefinition/HighlightPrintf") 
-
-[<Export(typeof<EditorFormatDefinition>)>]
-[<Name("MarkerFormatDefinition/HighlightPrintf")>]
-[<UserVisible(true)>]
-type HighlightIdentifierFormatDefinition() =
-    inherit MarkerFormatDefinition()
-    do  
-      base.BackgroundColor <- Nullable(Color.FromRgb(245uy, 222uy, 179uy))
-      //base.ForegroundColor <- Nullable(Color.FromRgb(231uy, 231uy, 214uy))
-      base.DisplayName <- "F# Highlight Printf"
-      base.ZOrder <- 5
+    inherit TextMarkerTag(Constants.fsharpPrintfTagType) 
 
 // Reference at http://msdn.microsoft.com/en-us/library/vstudio/dd885121.aspx
 

--- a/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
@@ -1,0 +1,103 @@
+﻿namespace FSharpVSPowerTools.PrintfSpecifiersHighlightUsage
+
+open System
+open Microsoft.VisualStudio.Text
+open Microsoft.VisualStudio.Text.Editor
+open Microsoft.VisualStudio.Text.Tagging
+open Microsoft.VisualStudio.Shell.Interop
+open FSharpVSPowerTools
+open FSharpVSPowerTools.ProjectSystem
+open FSharpVSPowerTools.PrintfSpecifiersUsageGetter
+
+type PrintfSpecifiersUsageTag() = 
+    // todo change type to allow different (dark yellow?) color, same as R# uses
+    inherit TextMarkerTag("MarkerFormatDefinition/HighlightedReference") 
+
+// Reference at http://msdn.microsoft.com/en-us/library/vstudio/dd885121.aspx
+
+/// This tagger will provide tags for every printf format specifier under the cursor.
+type PrintfSpecifiersUsageTagger
+    (
+        textDocument: ITextDocument,
+        view: ITextView, 
+        vsLanguageService: VSLanguageService, 
+        serviceProvider: IServiceProvider,
+        projectFactory: ProjectFactory
+    ) as self =
+    
+    let tagsChanged = Event<_, _>()
+    let mutable spans: NormalizedSnapshotSpanCollection option = None
+    let mutable usages: PrintfSpecifierUse[] option = None
+    let buffer = view.TextBuffer
+
+    let printfSpecifierUseToSpans (u: PrintfSpecifierUse): SnapshotSpan[] =
+        [| fromFSharpRange buffer.CurrentSnapshot u.SpecifierRange
+           fromFSharpRange buffer.CurrentSnapshot u.ArgumentRange |]
+        |> Array.choose id
+    
+    let findUsagesAtPoint (_point: SnapshotPoint) (_usages: PrintfSpecifierUse[]): PrintfSpecifierUse option =
+        None
+
+    let onCaretMove (CallInUIContext callInUIContext) =
+        asyncMaybe {
+            let! point = buffer.GetSnapshotPoint view.Caret.Position
+            let! usages = usages
+            let! usages = findUsagesAtPoint point usages
+            let spans = printfSpecifierUseToSpans usages
+            return NormalizedSnapshotSpanCollection spans
+        } 
+        |> Async.bind (fun x ->
+            async {
+                spans <- x
+                return! callInUIContext <| fun _ -> tagsChanged.Trigger(self, SnapshotSpanEventArgs buffer.CurrentSnapshot.FullSpan)
+            }
+        )
+
+    let onBufferChanged callInUIContext =
+        asyncMaybe {
+            let dte = serviceProvider.GetService<EnvDTE.DTE, SDTE>()
+            let! doc = dte.GetCurrentDocument(textDocument.FilePath)
+            let! project = projectFactory.CreateForDocument buffer doc
+            try
+                let! checkResults = vsLanguageService.ParseAndCheckFileInProject (doc.FullName, project)
+                return! PrintfSpecifiersUsageGetter.getAll checkResults
+            with e ->
+                Logging.logExceptionWithContext(e, "Failed to update printf specifier usages.")
+                return! None
+        } 
+        |> Async.bind (fun x -> 
+            async {
+                usages <- x
+                return! onCaretMove callInUIContext
+            })
+
+    let bufferChangedEventListener = new DocumentEventListener ([ViewChange.bufferEvent buffer], 200us, onBufferChanged)
+
+    let docEventListener = 
+        new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 200us, onCaretMove)
+
+    let tagSpan span = TagSpan<PrintfSpecifiersUsageTag>(span, PrintfSpecifiersUsageTag()) :> ITagSpan<_>
+
+    let getTags (targetSpans: NormalizedSnapshotSpanCollection): ITagSpan<PrintfSpecifiersUsageTag> list = 
+        match spans with
+        | Some spans when spans.Count > 0 -> 
+            let targetSnapshot = targetSpans.[0].Snapshot
+            let spans = 
+                if targetSnapshot = spans.[0].Snapshot then spans
+                else NormalizedSnapshotSpanCollection
+                         (spans |> Seq.map (fun span -> span.TranslateTo(targetSnapshot, SpanTrackingMode.EdgeExclusive)))
+            
+            spans |> Seq.map tagSpan |> Seq.toList
+        | _ -> []
+
+    interface ITagger<PrintfSpecifiersUsageTag> with
+        member __.GetTags spans =
+            upcast (protectOrDefault (fun _ -> getTags spans) [])
+        
+        [<CLIEvent>]
+        member __.TagsChanged = tagsChanged.Publish
+
+    interface IDisposable with
+        member __.Dispose() = 
+            dispose bufferChangedEventListener
+            dispose docEventListener

--- a/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
@@ -9,10 +9,24 @@ open FSharpVSPowerTools
 open FSharpVSPowerTools.ProjectSystem
 open FSharpVSPowerTools.PrintfSpecifiersUsageGetter
 open Microsoft.FSharp.Compiler
+open System.ComponentModel.Composition
+open Microsoft.VisualStudio.Text.Classification
+open Microsoft.VisualStudio.Utilities
+open System.Windows.Media
 
 type PrintfSpecifiersUsageTag() = 
-    // todo change type to allow different (dark yellow?) color, same as R# uses
-    inherit TextMarkerTag("MarkerFormatDefinition/HighlightedReference") 
+    inherit TextMarkerTag("MarkerFormatDefinition/HighlightPrintf") 
+
+[<Export(typeof<EditorFormatDefinition>)>]
+[<Name("MarkerFormatDefinition/HighlightPrintf")>]
+[<UserVisible(true)>]
+type HighlightIdentifierFormatDefinition() =
+    inherit MarkerFormatDefinition()
+    do  
+      base.BackgroundColor <- Nullable(Color.FromRgb(245uy, 222uy, 179uy))
+      //base.ForegroundColor <- Nullable(Color.FromRgb(231uy, 231uy, 214uy))
+      base.DisplayName <- "F# Highlight Printf"
+      base.ZOrder <- 5
 
 // Reference at http://msdn.microsoft.com/en-us/library/vstudio/dd885121.aspx
 

--- a/src/FSharpVSPowerTools.Logic/Setting.fs
+++ b/src/FSharpVSPowerTools.Logic/Setting.fs
@@ -5,6 +5,7 @@ type IGeneralOptions =
     abstract FormattingEnabled: bool with get, set
     abstract NavBarEnabled: bool with get, set
     abstract HighlightUsageEnabled: bool with get, set
+    abstract HighlightPrintfUsageEnabled: bool with get, set
     abstract RenameRefactoringEnabled: bool with get, set
     abstract DepthColorizerEnabled: bool with get, set
     abstract NavigateToEnabled: bool with get, set

--- a/src/FSharpVSPowerTools/Commands/FontColor.cs
+++ b/src/FSharpVSPowerTools/Commands/FontColor.cs
@@ -1,0 +1,16 @@
+﻿using System.Windows.Media;
+
+namespace FSharpVSPowerTools
+{
+    public class FontColor
+    {
+        public readonly Color? Foreground;
+        public readonly Color? Background;
+
+        public FontColor(Color? foreground = null, Color? background = null)
+        {
+            Foreground = foreground;
+            Background = background;
+        }
+    }
+}

--- a/src/FSharpVSPowerTools/Commands/HighlightUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/HighlightUsageTaggerProvider.cs
@@ -48,7 +48,7 @@ namespace FSharpVSPowerTools
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
                 return buffer.Properties.GetOrCreateSingletonProperty(
-                    () => new HighlightUsageTagger(doc, textView, _fsharpVsLanguageService, _serviceProvider, _projectFactory) as ITagger<T>);
+                    () => new HighlightUsageTagger(doc, textView, _fsharpVsLanguageService, _serviceProvider, _projectFactory)) as ITagger<T>;
             }
 
             return null;

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -79,10 +79,10 @@ namespace FSharpVSPowerTools
         VisualStudioTheme lastTheme = VisualStudioTheme.Unknown;
 
         [Import]
-        ThemeManager themeManager;
+        ThemeManager themeManager = null;
 
         [Import]
-        IEditorFormatMapService editorFormatMapService;
+        IEditorFormatMapService editorFormatMapService = null;
 
         public Color GetDefaultColor()
         {

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -72,7 +72,7 @@ namespace FSharpVSPowerTools
     public class PrintfColorManager
     {
         static readonly Color LightThemeColor = Color.FromRgb(245, 222, 179);
-        static readonly Color DarkThemeColor = Color.FromRgb(145, 122, 110);
+        static readonly Color DarkThemeColor = Color.FromRgb(0, 77, 77);
         VisualStudioTheme lastTheme = VisualStudioTheme.Unknown;
 
         [Import]

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -74,7 +74,7 @@ namespace FSharpVSPowerTools
     [Export]
     public class PrintfColorManager
     {
-        static readonly Color LightThemeColor = Color.FromRgb(249, 235, 210);
+        static readonly Color LightThemeColor = Color.FromRgb(245, 222, 179);
         static readonly Color DarkThemeColor = Color.FromRgb(0, 77, 77);
         VisualStudioTheme lastTheme = VisualStudioTheme.Unknown;
         ThemeManager _themeManager;

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -74,29 +74,32 @@ namespace FSharpVSPowerTools
     [Export]
     public class PrintfColorManager
     {
-        static readonly Color LightThemeColor = Color.FromRgb(245, 222, 179);
+        static readonly Color LightThemeColor = Color.FromRgb(249, 235, 210);
         static readonly Color DarkThemeColor = Color.FromRgb(0, 77, 77);
         VisualStudioTheme lastTheme = VisualStudioTheme.Unknown;
+        ThemeManager _themeManager;
+        IEditorFormatMapService _editorFormatMapService;
 
-        [Import]
-        ThemeManager themeManager = null;
-
-        [Import]
-        IEditorFormatMapService editorFormatMapService = null;
+        [ImportingConstructor]
+        public PrintfColorManager(ThemeManager themeManager, IEditorFormatMapService editorFormatMapService) 
+        {
+            _themeManager = themeManager;
+            _editorFormatMapService = editorFormatMapService;
+        }
 
         public Color GetDefaultColor()
         {
-            return themeManager.GetCurrentTheme() == VisualStudioTheme.Dark ? DarkThemeColor : LightThemeColor;
+            return _themeManager.GetCurrentTheme() == VisualStudioTheme.Dark ? DarkThemeColor : LightThemeColor;
         }
 
         public void UpdateColors()
         {
-            var currentTheme = themeManager.GetCurrentTheme();
+            var currentTheme = _themeManager.GetCurrentTheme();
 
             if (currentTheme != VisualStudioTheme.Unknown && currentTheme != lastTheme)
             {
                 lastTheme = currentTheme;
-                var formatMap = editorFormatMapService.GetEditorFormatMap(category: "text");
+                var formatMap = _editorFormatMapService.GetEditorFormatMap(category: "text");
 
                 try
                 {

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -9,15 +9,13 @@ using System;
 using FSharpVSPowerTools.PrintfSpecifiersHighlightUsage;
 using System.Windows.Media;
 using Microsoft.VisualStudio.Text.Classification;
-using Microsoft.VisualStudio.Text.Formatting;
-using System.Windows;
 
 namespace FSharpVSPowerTools
 {
     [Export(typeof(IViewTaggerProvider))]
     [ContentType("F#")]
     [TagType(typeof(PrintfSpecifiersUsageTag))]
-    public class PrintfSpecifiersUsageTaggerProvider : IViewTaggerProvider
+    public class PrintfSpecifiersUsageTaggerProvider : IViewTaggerProvider, IDisposable
     {
         readonly IServiceProvider _serviceProvider;
         readonly ITextDocumentFactoryService _textDocumentFactoryService;
@@ -44,7 +42,7 @@ namespace FSharpVSPowerTools
             _shellEventListener.ThemeChanged += UpdateTheme;
         }
 
-        private void UpdateTheme(object sender, EventArgs e)
+        void UpdateTheme(object sender, EventArgs e)
         {
             _printfColorManager.UpdateColors();
         }
@@ -66,6 +64,11 @@ namespace FSharpVSPowerTools
 
             return null;
         }
+
+        public void Dispose()
+        {
+            _shellEventListener.ThemeChanged -= UpdateTheme;
+        }
     }
 
     [Export]
@@ -76,10 +79,10 @@ namespace FSharpVSPowerTools
         VisualStudioTheme lastTheme = VisualStudioTheme.Unknown;
 
         [Import]
-        private ThemeManager themeManager = null;
+        ThemeManager themeManager;
 
         [Import]
-        private IEditorFormatMapService editorFormatMapService = null;
+        IEditorFormatMapService editorFormatMapService;
 
         public Color GetDefaultColor()
         {

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -45,7 +45,7 @@ namespace FSharpVSPowerTools
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
                 return buffer.Properties.GetOrCreateSingletonProperty(
-                    () => new PrintfSpecifiersUsageTagger(doc, textView, _fsharpVsLanguageService, _serviceProvider, _projectFactory) as ITagger<T>);
+                    () => new PrintfSpecifiersUsageTagger(doc, textView, _fsharpVsLanguageService, _serviceProvider, _projectFactory)) as ITagger<T>;
             }
 
             return null;

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -7,6 +7,9 @@ using Microsoft.VisualStudio.Shell;
 using FSharpVSPowerTools.ProjectSystem;
 using System;
 using FSharpVSPowerTools.PrintfSpecifiersHighlightUsage;
+using System.Windows.Media;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Text.Formatting;
 
 namespace FSharpVSPowerTools
 {
@@ -49,6 +52,83 @@ namespace FSharpVSPowerTools
             }
 
             return null;
+        }
+    }
+
+    [Export]
+    public class PrintfColorManager
+    {
+        static readonly FontColor LightThemeColor = new FontColor(null, Color.FromRgb(245, 222, 179));
+        static readonly FontColor DarkThemeColor = new FontColor(null, Color.FromRgb(145, 122, 110));
+        VisualStudioTheme lastTheme = VisualStudioTheme.Unknown;
+
+        [Import]
+        private ThemeManager themeManager = null;
+
+        [Import]
+        private IClassificationFormatMapService classificationFormatMapService = null;
+
+        [Import]
+        private IClassificationTypeRegistryService classificationTypeRegistry = null;
+
+        public FontColor GetDefaultColor()
+        {
+            return themeManager.GetCurrentTheme() == VisualStudioTheme.Dark ? DarkThemeColor : LightThemeColor;
+        }
+
+        public void UpdateColors()
+        {
+            var currentTheme = themeManager.GetCurrentTheme();
+
+            if (currentTheme != VisualStudioTheme.Unknown && currentTheme != lastTheme)
+            {
+                lastTheme = currentTheme;
+                var color = GetDefaultColor();
+                var formatMap = classificationFormatMapService.GetClassificationFormatMap(category: "text");
+
+                try
+                {
+                    formatMap.BeginBatchUpdate();
+                    var classificationType = classificationTypeRegistry.GetClassificationType(Constants.fsharpPrintfTagType);
+                    var oldProp = formatMap.GetTextProperties(classificationType);
+
+                    var foregroundBrush =
+                        color.Foreground == null
+                            ? null
+                            : new SolidColorBrush(color.Foreground.Value);
+
+                    var backgroundBrush =
+                        color.Background == null
+                            ? null
+                            : new SolidColorBrush(color.Background.Value);
+
+                    var newProp = TextFormattingRunProperties.CreateTextFormattingRunProperties(
+                        foregroundBrush, backgroundBrush, oldProp.Typeface, null, null, oldProp.TextDecorations,
+                        oldProp.TextEffects, oldProp.CultureInfo);
+
+                    formatMap.SetTextProperties(classificationType, newProp);
+                }
+                finally
+                {
+                    formatMap.EndBatchUpdate();
+                }
+            }
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [Name(Constants.fsharpPrintfTagType)]
+    [UserVisible(true)]
+    public class HighlightIdentifierFormatDefinition: MarkerFormatDefinition
+    {
+        [ImportingConstructor]
+        public HighlightIdentifierFormatDefinition(PrintfColorManager colorManager) 
+        {
+            var color = colorManager.GetDefaultColor();
+            BackgroundColor = color.Background;
+            ForegroundColor = color.Foreground;
+            DisplayName = "F# Highlight Printf";
+            ZOrder = 5;
         }
     }
 }

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -53,7 +53,7 @@ namespace FSharpVSPowerTools
             if (textView.TextBuffer != buffer) return null;
 
             var generalOptions = Setting.getGeneralOptions(_serviceProvider);
-            if (generalOptions == null || !generalOptions.HighlightUsageEnabled) return null;
+            if (generalOptions == null || !generalOptions.HighlightPrintfUsageEnabled) return null;
 
             ITextDocument doc;
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -1,22 +1,19 @@
-﻿using System.Diagnostics;
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 using Microsoft.VisualStudio.Shell;
-using EnvDTE;
-using FSharpVSPowerTools.HighlightUsage;
 using FSharpVSPowerTools.ProjectSystem;
 using System;
+using FSharpVSPowerTools.PrintfSpecifiersHighlightUsage;
 
 namespace FSharpVSPowerTools
 {
     [Export(typeof(IViewTaggerProvider))]
     [ContentType("F#")]
-    [TagType(typeof(HighlightUsageTag))]
-    public class HighlightUsageTaggerProvider : IViewTaggerProvider
+    [TagType(typeof(PrintfSpecifiersUsageTag))]
+    public class PrintfSpecifiersUsageTaggerProvider : IViewTaggerProvider
     {
         readonly IServiceProvider _serviceProvider;
         readonly ITextDocumentFactoryService _textDocumentFactoryService;
@@ -24,7 +21,7 @@ namespace FSharpVSPowerTools
         readonly VSLanguageService _fsharpVsLanguageService;
 
         [ImportingConstructor]
-        public HighlightUsageTaggerProvider(
+        public PrintfSpecifiersUsageTaggerProvider(
             [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
             ITextDocumentFactoryService textDocumentFactoryService,
             ProjectFactory projectFactory,
@@ -48,7 +45,7 @@ namespace FSharpVSPowerTools
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
                 return buffer.Properties.GetOrCreateSingletonProperty(
-                    () => new HighlightUsageTagger(doc, textView, _fsharpVsLanguageService, _serviceProvider, _projectFactory) as ITagger<T>);
+                    () => new PrintfSpecifiersUsageTagger(doc, textView, _fsharpVsLanguageService, _serviceProvider, _projectFactory) as ITagger<T>);
             }
 
             return null;

--- a/src/FSharpVSPowerTools/Commands/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/SyntaxConstructClassifierProvider.cs
@@ -88,18 +88,6 @@ namespace FSharpVSPowerTools
         internal static ClassificationTypeDefinition FSharpOperatorClassificationType = null;
     }
 
-    public class FontColor
-    {
-        public readonly Color? Foreground;
-        public readonly Color? Background;
-
-        public FontColor(Color? foreground = null, Color? background = null)
-        {
-            Foreground = foreground;
-            Background = background;
-        }
-    }
-
     [Export]
     public class ClassificationColorManager 
     {

--- a/src/FSharpVSPowerTools/Commands/SyntaxConstructClassifierProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/SyntaxConstructClassifierProvider.cs
@@ -8,12 +8,9 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Windows.Media;
 
 namespace FSharpVSPowerTools

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -134,6 +134,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\PrintfSpecifiersUsageTaggerProvider.cs" />
     <Compile Include="Commands\OutliningTaggerProvider.cs" />
     <Compile Include="Resources\FSharpVSPowerTools.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -134,6 +134,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Commands\FontColor.cs" />
     <Compile Include="Commands\PrintfSpecifiersUsageTaggerProvider.cs" />
     <Compile Include="Commands\OutliningTaggerProvider.cs" />
     <Compile Include="Resources\FSharpVSPowerTools.Designer.cs">

--- a/src/FSharpVSPowerTools/UI/GeneralOptionsControl.Designer.cs
+++ b/src/FSharpVSPowerTools/UI/GeneralOptionsControl.Designer.cs
@@ -56,13 +56,16 @@ namespace FSharpVSPowerTools
             this.chbGoToSymbolSource = new System.Windows.Forms.CheckBox();
             this.chbQuickInfoPanel = new System.Windows.Forms.CheckBox();
             this.chbLinter = new System.Windows.Forms.CheckBox();
+            this.chbOutlining = new System.Windows.Forms.CheckBox();
             this.lblInformation = new System.Windows.Forms.Label();
             this.lblInfo = new System.Windows.Forms.Label();
-            this.chbOutlining = new System.Windows.Forms.CheckBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.chbHighlightPrintf = new System.Windows.Forms.CheckBox();
             this.grbOptions.SuspendLayout();
             this.tblLayoutPanel.SuspendLayout();
             this.flowLayoutPanel.SuspendLayout();
             this.tblLayoutPanelSyntax.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // grbOptions
@@ -125,7 +128,7 @@ namespace FSharpVSPowerTools
             this.flowLayoutPanel.Controls.Add(this.chbXmlDoc);
             this.flowLayoutPanel.Controls.Add(this.chbFormatting);
             this.flowLayoutPanel.Controls.Add(this.chbNavBar);
-            this.flowLayoutPanel.Controls.Add(this.chbHighlightUsage);
+            this.flowLayoutPanel.Controls.Add(this.tableLayoutPanel1);
             this.flowLayoutPanel.Controls.Add(this.chbRenameRefactoring);
             this.flowLayoutPanel.Controls.Add(this.chbDepthColorizer);
             this.flowLayoutPanel.Controls.Add(this.chbNavigateTo);
@@ -148,7 +151,7 @@ namespace FSharpVSPowerTools
             this.flowLayoutPanel.Location = new System.Drawing.Point(2, 2);
             this.flowLayoutPanel.Margin = new System.Windows.Forms.Padding(2);
             this.flowLayoutPanel.Name = "flowLayoutPanel";
-            this.flowLayoutPanel.Size = new System.Drawing.Size(453, 258);
+            this.flowLayoutPanel.Size = new System.Drawing.Size(453, 254);
             this.flowLayoutPanel.TabIndex = 0;
             // 
             // chbXmlDoc
@@ -161,7 +164,7 @@ namespace FSharpVSPowerTools
             this.chbXmlDoc.Name = "chbXmlDoc";
             this.chbXmlDoc.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
             this.chbXmlDoc.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.chbXmlDoc.Size = new System.Drawing.Size(151, 17);
+            this.chbXmlDoc.Size = new System.Drawing.Size(170, 19);
             this.chbXmlDoc.TabIndex = 1;
             this.chbXmlDoc.Text = "Auto-generating XmlDoc";
             this.chbXmlDoc.UseVisualStyleBackColor = true;
@@ -171,11 +174,11 @@ namespace FSharpVSPowerTools
             this.chbFormatting.AutoSize = true;
             this.chbFormatting.Checked = true;
             this.chbFormatting.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbFormatting.Location = new System.Drawing.Point(3, 24);
+            this.chbFormatting.Location = new System.Drawing.Point(3, 26);
             this.chbFormatting.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbFormatting.Name = "chbFormatting";
             this.chbFormatting.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbFormatting.Size = new System.Drawing.Size(146, 17);
+            this.chbFormatting.Size = new System.Drawing.Size(163, 19);
             this.chbFormatting.TabIndex = 2;
             this.chbFormatting.Text = "Source code formatting";
             this.chbFormatting.UseVisualStyleBackColor = true;
@@ -183,11 +186,11 @@ namespace FSharpVSPowerTools
             // chbNavBar
             // 
             this.chbNavBar.AutoSize = true;
-            this.chbNavBar.Location = new System.Drawing.Point(3, 45);
+            this.chbNavBar.Location = new System.Drawing.Point(3, 49);
             this.chbNavBar.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbNavBar.Name = "chbNavBar";
             this.chbNavBar.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbNavBar.Size = new System.Drawing.Size(120, 17);
+            this.chbNavBar.Size = new System.Drawing.Size(133, 19);
             this.chbNavBar.TabIndex = 6;
             this.chbNavBar.Text = "Navigation bar ***";
             this.chbNavBar.UseVisualStyleBackColor = true;
@@ -197,11 +200,11 @@ namespace FSharpVSPowerTools
             this.chbHighlightUsage.AutoSize = true;
             this.chbHighlightUsage.Checked = true;
             this.chbHighlightUsage.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbHighlightUsage.Location = new System.Drawing.Point(3, 66);
+            this.chbHighlightUsage.Location = new System.Drawing.Point(3, 3);
             this.chbHighlightUsage.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbHighlightUsage.Name = "chbHighlightUsage";
             this.chbHighlightUsage.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbHighlightUsage.Size = new System.Drawing.Size(130, 17);
+            this.chbHighlightUsage.Size = new System.Drawing.Size(146, 19);
             this.chbHighlightUsage.TabIndex = 7;
             this.chbHighlightUsage.Text = "Highlight references";
             this.chbHighlightUsage.UseVisualStyleBackColor = true;
@@ -211,11 +214,11 @@ namespace FSharpVSPowerTools
             this.chbRenameRefactoring.AutoSize = true;
             this.chbRenameRefactoring.Checked = true;
             this.chbRenameRefactoring.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbRenameRefactoring.Location = new System.Drawing.Point(3, 87);
+            this.chbRenameRefactoring.Location = new System.Drawing.Point(3, 121);
             this.chbRenameRefactoring.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbRenameRefactoring.Name = "chbRenameRefactoring";
             this.chbRenameRefactoring.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbRenameRefactoring.Size = new System.Drawing.Size(129, 17);
+            this.chbRenameRefactoring.Size = new System.Drawing.Size(145, 19);
             this.chbRenameRefactoring.TabIndex = 8;
             this.chbRenameRefactoring.Text = "Rename refactoring";
             this.chbRenameRefactoring.UseVisualStyleBackColor = true;
@@ -223,11 +226,11 @@ namespace FSharpVSPowerTools
             // chbDepthColorizer
             // 
             this.chbDepthColorizer.AutoSize = true;
-            this.chbDepthColorizer.Location = new System.Drawing.Point(3, 108);
+            this.chbDepthColorizer.Location = new System.Drawing.Point(3, 144);
             this.chbDepthColorizer.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbDepthColorizer.Name = "chbDepthColorizer";
             this.chbDepthColorizer.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbDepthColorizer.Size = new System.Drawing.Size(176, 17);
+            this.chbDepthColorizer.Size = new System.Drawing.Size(196, 19);
             this.chbDepthColorizer.TabIndex = 9;
             this.chbDepthColorizer.Text = "Indent guides/Depth colorizer";
             this.chbDepthColorizer.UseVisualStyleBackColor = true;
@@ -237,11 +240,11 @@ namespace FSharpVSPowerTools
             this.chbNavigateTo.AutoSize = true;
             this.chbNavigateTo.Checked = true;
             this.chbNavigateTo.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbNavigateTo.Location = new System.Drawing.Point(3, 129);
+            this.chbNavigateTo.Location = new System.Drawing.Point(3, 167);
             this.chbNavigateTo.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbNavigateTo.Name = "chbNavigateTo";
             this.chbNavigateTo.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbNavigateTo.Size = new System.Drawing.Size(92, 17);
+            this.chbNavigateTo.Size = new System.Drawing.Size(98, 19);
             this.chbNavigateTo.TabIndex = 10;
             this.chbNavigateTo.Text = "NavigateTo";
             this.chbNavigateTo.UseVisualStyleBackColor = true;
@@ -255,7 +258,7 @@ namespace FSharpVSPowerTools
             this.tblLayoutPanelSyntax.Controls.Add(this.chbSyntaxColoring, 0, 0);
             this.tblLayoutPanelSyntax.Controls.Add(this.chbUnusedReferences, 0, 2);
             this.tblLayoutPanelSyntax.Controls.Add(this.chbUnusedOpens, 0, 1);
-            this.tblLayoutPanelSyntax.Location = new System.Drawing.Point(0, 147);
+            this.tblLayoutPanelSyntax.Location = new System.Drawing.Point(202, 0);
             this.tblLayoutPanelSyntax.Margin = new System.Windows.Forms.Padding(0);
             this.tblLayoutPanelSyntax.Name = "tblLayoutPanelSyntax";
             this.tblLayoutPanelSyntax.RowCount = 2;
@@ -263,7 +266,7 @@ namespace FSharpVSPowerTools
             this.tblLayoutPanelSyntax.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
             this.tblLayoutPanelSyntax.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
             this.tblLayoutPanelSyntax.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 13F));
-            this.tblLayoutPanelSyntax.Size = new System.Drawing.Size(204, 63);
+            this.tblLayoutPanelSyntax.Size = new System.Drawing.Size(225, 69);
             this.tblLayoutPanelSyntax.TabIndex = 11;
             // 
             // chbSyntaxColoring
@@ -275,7 +278,7 @@ namespace FSharpVSPowerTools
             this.chbSyntaxColoring.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbSyntaxColoring.Name = "chbSyntaxColoring";
             this.chbSyntaxColoring.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbSyntaxColoring.Size = new System.Drawing.Size(108, 17);
+            this.chbSyntaxColoring.Size = new System.Drawing.Size(119, 19);
             this.chbSyntaxColoring.TabIndex = 11;
             this.chbSyntaxColoring.Text = "Syntax coloring";
             this.chbSyntaxColoring.UseVisualStyleBackColor = true;
@@ -285,11 +288,11 @@ namespace FSharpVSPowerTools
             this.chbUnusedReferences.AutoSize = true;
             this.chbUnusedReferences.Checked = true;
             this.chbUnusedReferences.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbUnusedReferences.Location = new System.Drawing.Point(27, 45);
+            this.chbUnusedReferences.Location = new System.Drawing.Point(27, 49);
             this.chbUnusedReferences.Margin = new System.Windows.Forms.Padding(27, 3, 3, 1);
             this.chbUnusedReferences.Name = "chbUnusedReferences";
             this.chbUnusedReferences.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbUnusedReferences.Size = new System.Drawing.Size(174, 17);
+            this.chbUnusedReferences.Size = new System.Drawing.Size(195, 19);
             this.chbUnusedReferences.TabIndex = 17;
             this.chbUnusedReferences.Text = "Gray out unused declarations";
             this.chbUnusedReferences.UseVisualStyleBackColor = true;
@@ -299,11 +302,11 @@ namespace FSharpVSPowerTools
             this.chbUnusedOpens.AutoSize = true;
             this.chbUnusedOpens.Checked = true;
             this.chbUnusedOpens.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbUnusedOpens.Location = new System.Drawing.Point(27, 24);
+            this.chbUnusedOpens.Location = new System.Drawing.Point(27, 26);
             this.chbUnusedOpens.Margin = new System.Windows.Forms.Padding(27, 3, 3, 1);
             this.chbUnusedOpens.Name = "chbUnusedOpens";
             this.chbUnusedOpens.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbUnusedOpens.Size = new System.Drawing.Size(146, 17);
+            this.chbUnusedOpens.Size = new System.Drawing.Size(162, 19);
             this.chbUnusedOpens.TabIndex = 19;
             this.chbUnusedOpens.Text = "Gray out unused opens";
             this.chbUnusedOpens.UseVisualStyleBackColor = true;
@@ -311,11 +314,11 @@ namespace FSharpVSPowerTools
             // chbFolderOrganization
             // 
             this.chbFolderOrganization.AutoSize = true;
-            this.chbFolderOrganization.Location = new System.Drawing.Point(3, 213);
+            this.chbFolderOrganization.Location = new System.Drawing.Point(205, 72);
             this.chbFolderOrganization.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbFolderOrganization.Name = "chbFolderOrganization";
             this.chbFolderOrganization.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbFolderOrganization.Size = new System.Drawing.Size(125, 17);
+            this.chbFolderOrganization.Size = new System.Drawing.Size(142, 19);
             this.chbFolderOrganization.TabIndex = 12;
             this.chbFolderOrganization.Text = "Folder organization";
             this.chbFolderOrganization.UseVisualStyleBackColor = true;
@@ -325,11 +328,11 @@ namespace FSharpVSPowerTools
             this.chbFindAllReferences.AutoSize = true;
             this.chbFindAllReferences.Checked = true;
             this.chbFindAllReferences.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbFindAllReferences.Location = new System.Drawing.Point(3, 234);
+            this.chbFindAllReferences.Location = new System.Drawing.Point(205, 95);
             this.chbFindAllReferences.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbFindAllReferences.Name = "chbFindAllReferences";
             this.chbFindAllReferences.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbFindAllReferences.Size = new System.Drawing.Size(122, 17);
+            this.chbFindAllReferences.Size = new System.Drawing.Size(137, 19);
             this.chbFindAllReferences.TabIndex = 14;
             this.chbFindAllReferences.Text = "Find all references";
             this.chbFindAllReferences.UseVisualStyleBackColor = true;
@@ -339,11 +342,11 @@ namespace FSharpVSPowerTools
             this.chbInterfaceImplementation.AutoSize = true;
             this.chbInterfaceImplementation.Checked = true;
             this.chbInterfaceImplementation.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbInterfaceImplementation.Location = new System.Drawing.Point(207, 3);
+            this.chbInterfaceImplementation.Location = new System.Drawing.Point(205, 118);
             this.chbInterfaceImplementation.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbInterfaceImplementation.Name = "chbInterfaceImplementation";
             this.chbInterfaceImplementation.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbInterfaceImplementation.Size = new System.Drawing.Size(128, 17);
+            this.chbInterfaceImplementation.Size = new System.Drawing.Size(145, 19);
             this.chbInterfaceImplementation.TabIndex = 12;
             this.chbInterfaceImplementation.Text = "Implement interface";
             this.chbInterfaceImplementation.UseVisualStyleBackColor = true;
@@ -353,11 +356,11 @@ namespace FSharpVSPowerTools
             this.chbRecordStubGeneration.AutoSize = true;
             this.chbRecordStubGeneration.Checked = true;
             this.chbRecordStubGeneration.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbRecordStubGeneration.Location = new System.Drawing.Point(207, 24);
+            this.chbRecordStubGeneration.Location = new System.Drawing.Point(205, 141);
             this.chbRecordStubGeneration.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbRecordStubGeneration.Name = "chbRecordStubGeneration";
             this.chbRecordStubGeneration.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbRecordStubGeneration.Size = new System.Drawing.Size(147, 17);
+            this.chbRecordStubGeneration.Size = new System.Drawing.Size(164, 19);
             this.chbRecordStubGeneration.TabIndex = 15;
             this.chbRecordStubGeneration.Text = "Record stub generation";
             this.chbRecordStubGeneration.UseVisualStyleBackColor = true;
@@ -367,11 +370,11 @@ namespace FSharpVSPowerTools
             this.chbUnionPatternMatchCaseGeneration.AutoSize = true;
             this.chbUnionPatternMatchCaseGeneration.Checked = true;
             this.chbUnionPatternMatchCaseGeneration.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbUnionPatternMatchCaseGeneration.Location = new System.Drawing.Point(207, 45);
+            this.chbUnionPatternMatchCaseGeneration.Location = new System.Drawing.Point(205, 164);
             this.chbUnionPatternMatchCaseGeneration.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbUnionPatternMatchCaseGeneration.Name = "chbUnionPatternMatchCaseGeneration";
             this.chbUnionPatternMatchCaseGeneration.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbUnionPatternMatchCaseGeneration.Size = new System.Drawing.Size(211, 17);
+            this.chbUnionPatternMatchCaseGeneration.Size = new System.Drawing.Size(238, 19);
             this.chbUnionPatternMatchCaseGeneration.TabIndex = 16;
             this.chbUnionPatternMatchCaseGeneration.Text = "Union pattern match case generation";
             this.chbUnionPatternMatchCaseGeneration.UseVisualStyleBackColor = true;
@@ -381,11 +384,11 @@ namespace FSharpVSPowerTools
             this.chbResolveUnopenedNamespaces.AutoSize = true;
             this.chbResolveUnopenedNamespaces.Checked = true;
             this.chbResolveUnopenedNamespaces.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbResolveUnopenedNamespaces.Location = new System.Drawing.Point(207, 66);
+            this.chbResolveUnopenedNamespaces.Location = new System.Drawing.Point(205, 187);
             this.chbResolveUnopenedNamespaces.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbResolveUnopenedNamespaces.Name = "chbResolveUnopenedNamespaces";
             this.chbResolveUnopenedNamespaces.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbResolveUnopenedNamespaces.Size = new System.Drawing.Size(189, 17);
+            this.chbResolveUnopenedNamespaces.Size = new System.Drawing.Size(213, 19);
             this.chbResolveUnopenedNamespaces.TabIndex = 16;
             this.chbResolveUnopenedNamespaces.Text = "Resolve unopened namespaces";
             this.chbResolveUnopenedNamespaces.UseVisualStyleBackColor = true;
@@ -395,11 +398,11 @@ namespace FSharpVSPowerTools
             this.chbGoToMetadata.AutoSize = true;
             this.chbGoToMetadata.Checked = true;
             this.chbGoToMetadata.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbGoToMetadata.Location = new System.Drawing.Point(207, 87);
+            this.chbGoToMetadata.Location = new System.Drawing.Point(205, 210);
             this.chbGoToMetadata.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbGoToMetadata.Name = "chbGoToMetadata";
             this.chbGoToMetadata.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbGoToMetadata.Size = new System.Drawing.Size(109, 17);
+            this.chbGoToMetadata.Size = new System.Drawing.Size(120, 19);
             this.chbGoToMetadata.TabIndex = 18;
             this.chbGoToMetadata.Text = "Go to metadata";
             this.chbGoToMetadata.UseVisualStyleBackColor = true;
@@ -409,11 +412,11 @@ namespace FSharpVSPowerTools
             this.chbTaskListComments.AutoSize = true;
             this.chbTaskListComments.Checked = true;
             this.chbTaskListComments.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbTaskListComments.Location = new System.Drawing.Point(207, 108);
+            this.chbTaskListComments.Location = new System.Drawing.Point(449, 3);
             this.chbTaskListComments.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbTaskListComments.Name = "chbTaskListComments";
             this.chbTaskListComments.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbTaskListComments.Size = new System.Drawing.Size(130, 17);
+            this.chbTaskListComments.Size = new System.Drawing.Size(145, 19);
             this.chbTaskListComments.TabIndex = 18;
             this.chbTaskListComments.Text = "Task List comments";
             this.chbTaskListComments.UseVisualStyleBackColor = true;
@@ -423,11 +426,11 @@ namespace FSharpVSPowerTools
             this.chbGenerateReferences.AutoSize = true;
             this.chbGenerateReferences.Checked = true;
             this.chbGenerateReferences.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbGenerateReferences.Location = new System.Drawing.Point(207, 129);
+            this.chbGenerateReferences.Location = new System.Drawing.Point(449, 26);
             this.chbGenerateReferences.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbGenerateReferences.Name = "chbGenerateReferences";
             this.chbGenerateReferences.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbGenerateReferences.Size = new System.Drawing.Size(167, 17);
+            this.chbGenerateReferences.Size = new System.Drawing.Size(186, 19);
             this.chbGenerateReferences.TabIndex = 20;
             this.chbGenerateReferences.Text = "Generate references for FSI";
             this.chbGenerateReferences.UseVisualStyleBackColor = true;
@@ -437,11 +440,11 @@ namespace FSharpVSPowerTools
             this.chbGoToSymbolSource.AutoSize = true;
             this.chbGoToSymbolSource.Checked = true;
             this.chbGoToSymbolSource.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbGoToSymbolSource.Location = new System.Drawing.Point(207, 150);
+            this.chbGoToSymbolSource.Location = new System.Drawing.Point(449, 49);
             this.chbGoToSymbolSource.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbGoToSymbolSource.Name = "chbGoToSymbolSource";
             this.chbGoToSymbolSource.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbGoToSymbolSource.Size = new System.Drawing.Size(126, 17);
+            this.chbGoToSymbolSource.Size = new System.Drawing.Size(137, 19);
             this.chbGoToSymbolSource.TabIndex = 21;
             this.chbGoToSymbolSource.Text = "Navigate to source";
             this.chbGoToSymbolSource.UseVisualStyleBackColor = true;
@@ -451,11 +454,11 @@ namespace FSharpVSPowerTools
             this.chbQuickInfoPanel.AutoSize = true;
             this.chbQuickInfoPanel.Checked = true;
             this.chbQuickInfoPanel.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbQuickInfoPanel.Location = new System.Drawing.Point(207, 171);
+            this.chbQuickInfoPanel.Location = new System.Drawing.Point(449, 72);
             this.chbQuickInfoPanel.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbQuickInfoPanel.Name = "chbQuickInfoPanel";
             this.chbQuickInfoPanel.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbQuickInfoPanel.Size = new System.Drawing.Size(113, 17);
+            this.chbQuickInfoPanel.Size = new System.Drawing.Size(124, 19);
             this.chbQuickInfoPanel.TabIndex = 22;
             this.chbQuickInfoPanel.Text = "Quick info panel";
             this.chbQuickInfoPanel.UseVisualStyleBackColor = true;
@@ -465,22 +468,34 @@ namespace FSharpVSPowerTools
             this.chbLinter.AutoSize = true;
             this.chbLinter.Checked = true;
             this.chbLinter.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.chbLinter.Location = new System.Drawing.Point(207, 192);
+            this.chbLinter.Location = new System.Drawing.Point(449, 95);
             this.chbLinter.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
             this.chbLinter.Name = "chbLinter";
             this.chbLinter.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbLinter.Size = new System.Drawing.Size(139, 17);
+            this.chbLinter.Size = new System.Drawing.Size(157, 19);
             this.chbLinter.TabIndex = 23;
             this.chbLinter.Text = "FSharpLint integration";
             this.chbLinter.UseVisualStyleBackColor = true;
             // 
+            // chbOutlining
+            // 
+            this.chbOutlining.AutoSize = true;
+            this.chbOutlining.Location = new System.Drawing.Point(449, 118);
+            this.chbOutlining.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
+            this.chbOutlining.Name = "chbOutlining";
+            this.chbOutlining.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
+            this.chbOutlining.Size = new System.Drawing.Size(117, 19);
+            this.chbOutlining.TabIndex = 23;
+            this.chbOutlining.Text = "Code Outlining";
+            this.chbOutlining.UseVisualStyleBackColor = true;
+            // 
             // lblInformation
             // 
             this.lblInformation.AutoSize = true;
-            this.lblInformation.Location = new System.Drawing.Point(3, 262);
+            this.lblInformation.Location = new System.Drawing.Point(3, 258);
             this.lblInformation.Name = "lblInformation";
             this.lblInformation.Padding = new System.Windows.Forms.Padding(5, 3, 5, 3);
-            this.lblInformation.Size = new System.Drawing.Size(234, 19);
+            this.lblInformation.Size = new System.Drawing.Size(271, 21);
             this.lblInformation.TabIndex = 13;
             this.lblInformation.Text = "*** Admin privileges required to enable/disable";
             // 
@@ -488,24 +503,38 @@ namespace FSharpVSPowerTools
             // 
             this.lblInfo.AutoSize = true;
             this.lblInfo.ForeColor = System.Drawing.SystemColors.HotTrack;
-            this.lblInfo.Location = new System.Drawing.Point(3, 281);
+            this.lblInfo.Location = new System.Drawing.Point(3, 279);
             this.lblInfo.Name = "lblInfo";
             this.lblInfo.Padding = new System.Windows.Forms.Padding(5, 3, 5, 3);
-            this.lblInfo.Size = new System.Drawing.Size(341, 19);
+            this.lblInfo.Size = new System.Drawing.Size(385, 21);
             this.lblInfo.TabIndex = 5;
             this.lblInfo.Text = "You must restart Visual Studio in order for the changes to take effect.";
             // 
-            // chbOutlining
+            // tableLayoutPanel1
             // 
-            this.chbOutlining.AutoSize = true;
-            this.chbOutlining.Location = new System.Drawing.Point(207, 213);
-            this.chbOutlining.Margin = new System.Windows.Forms.Padding(3, 3, 3, 1);
-            this.chbOutlining.Name = "chbOutlining";
-            this.chbOutlining.Padding = new System.Windows.Forms.Padding(5, 0, 5, 0);
-            this.chbOutlining.Size = new System.Drawing.Size(105, 17);
-            this.chbOutlining.TabIndex = 23;
-            this.chbOutlining.Text = "Code Outlining";
-            this.chbOutlining.UseVisualStyleBackColor = true;
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Controls.Add(this.chbHighlightUsage, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.chbHighlightPrintf, 0, 1);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 69);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(200, 49);
+            this.tableLayoutPanel1.TabIndex = 24;
+            // 
+            // chbHighlightPrintf
+            // 
+            this.chbHighlightPrintf.AutoSize = true;
+            this.chbHighlightPrintf.Location = new System.Drawing.Point(27, 27);
+            this.chbHighlightPrintf.Margin = new System.Windows.Forms.Padding(27, 3, 3, 1);
+            this.chbHighlightPrintf.Name = "chbHighlightPrintf";
+            this.chbHighlightPrintf.Size = new System.Drawing.Size(138, 19);
+            this.chbHighlightPrintf.TabIndex = 8;
+            this.chbHighlightPrintf.Text = "Highlight printf items";
+            this.chbHighlightPrintf.UseVisualStyleBackColor = true;
             // 
             // GeneralOptionsControl
             // 
@@ -522,6 +551,8 @@ namespace FSharpVSPowerTools
             this.flowLayoutPanel.PerformLayout();
             this.tblLayoutPanelSyntax.ResumeLayout(false);
             this.tblLayoutPanelSyntax.PerformLayout();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -558,5 +589,7 @@ namespace FSharpVSPowerTools
         private System.Windows.Forms.Label lblInfo;
         private System.Windows.Forms.CheckBox chbLinter;
         private System.Windows.Forms.CheckBox chbOutlining;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.CheckBox chbHighlightPrintf;
     }
 }

--- a/src/FSharpVSPowerTools/UI/GeneralOptionsControl.cs
+++ b/src/FSharpVSPowerTools/UI/GeneralOptionsControl.cs
@@ -36,6 +36,12 @@ namespace FSharpVSPowerTools
             set { chbHighlightUsage.Checked = value; }
         }
 
+        public bool HighlightPrintfUsageEnabled
+        {
+            get { return chbHighlightPrintf.Checked; }
+            set { chbHighlightPrintf.Checked = value; }
+        }
+
         public bool RenameRefactoringEnabled
         {
             get { return chbRenameRefactoring.Checked; }
@@ -155,6 +161,7 @@ namespace FSharpVSPowerTools
             FormattingEnabled = _optionsPage.FormattingEnabled;
             NavBarEnabled = _optionsPage.NavBarEnabled;
             HighlightUsageEnabled = _optionsPage.HighlightUsageEnabled;
+            HighlightPrintfUsageEnabled = _optionsPage.HighlightPrintfUsageEnabled;
             RenameRefactoringEnabled = _optionsPage.RenameRefactoringEnabled;
             DepthColorizerEnabled = _optionsPage.DepthColorizerEnabled;
             NavigateToEnabled = _optionsPage.NavigateToEnabled;

--- a/src/FSharpVSPowerTools/UI/GeneralOptionsPage.cs
+++ b/src/FSharpVSPowerTools/UI/GeneralOptionsPage.cs
@@ -13,9 +13,9 @@ namespace FSharpVSPowerTools
     [Guid("45eabfdf-0a20-4e5e-8780-c3e52360b0f0")]
     public class GeneralOptionsPage : DialogPage, IGeneralOptions
     {
-        private GeneralOptionsControl _optionsControl;
-        private const string navBarConfig = "fsharp-navigationbar-enabled";
-        private bool _navBarEnabledInAppConfig;
+        GeneralOptionsControl _optionsControl;
+        const string navBarConfig = "fsharp-navigationbar-enabled";
+        bool _navBarEnabledInAppConfig;
 
         public GeneralOptionsPage()
         {
@@ -25,6 +25,7 @@ namespace FSharpVSPowerTools
             FormattingEnabled = true;
             _navBarEnabledInAppConfig = GetNavigationBarConfig();
             HighlightUsageEnabled = true;
+            HighlightPrintfUsageEnabled = true;
             RenameRefactoringEnabled = true;
             DepthColorizerEnabled = false;
             NavigateToEnabled = true;
@@ -46,7 +47,7 @@ namespace FSharpVSPowerTools
             OutliningEnabled = false;
         }
 
-        private bool GetNavigationBarConfig()
+        bool GetNavigationBarConfig()
         {
             try
             {
@@ -62,7 +63,7 @@ namespace FSharpVSPowerTools
             }
         }
 
-        private bool IsUserAdministrator()
+        bool IsUserAdministrator()
         {
             bool isAdmin;
             try
@@ -121,6 +122,9 @@ namespace FSharpVSPowerTools
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool HighlightUsageEnabled { get; set; }
+
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public bool HighlightPrintfUsageEnabled { get; set; }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool RenameRefactoringEnabled { get; set; }
@@ -213,6 +217,7 @@ namespace FSharpVSPowerTools
                 FormattingEnabled = _optionsControl.FormattingEnabled;
 
                 HighlightUsageEnabled = _optionsControl.HighlightUsageEnabled;
+                HighlightPrintfUsageEnabled = _optionsControl.HighlightPrintfUsageEnabled;
                 RenameRefactoringEnabled = _optionsControl.RenameRefactoringEnabled;
                 DepthColorizerEnabled = _optionsControl.DepthColorizerEnabled;
                 NavigateToEnabled = _optionsControl.NavigateToEnabled;

--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.1.20" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.1.21" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A collection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>

--- a/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Core.Tests/FSharpVSPowerTools.Core.Tests.fsproj
@@ -66,6 +66,7 @@
     <Compile Include="LexerTests.fs" />
     <Compile Include="LanguageServiceTests.fs" />
     <Compile Include="GetUsesOfSymbolInFileTests.fs" />
+    <Compile Include="PrintfSpecifiersUsageGetterTests.fs" />
     <Compile Include="NavigableItemsCollectorTests.fs" />
     <Compile Include="DepthColorizerTests.fs" />
     <Compile Include="IdentifierDetectionTests.fs" />

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -58,9 +58,19 @@ let (=>) source (expected: (int * (((int * int) * (int * int)) list)) list) =
         reraise()
 
 [<Test>]
-let ``should find usages in printf``() =
+let ``simplest case``() =
     """
-let _ = printf "%+A foo %d" 1 2
+printf "%+A foo %d" 1 2
 """
-    => [2, [(16, 19), (28, 29)
-            (24, 26), (30, 31)]]
+    => [2, [(8, 11), (20, 21)
+            (16, 18), (22, 23)]]
+
+[<Test>]
+let ``printf as an argument of another printf``() =
+    """
+printf "%+A foo %s" 1 (sprintf "%d" 2)
+"""
+    => [2, [(8, 11), (20, 21)
+            (16, 18), (22, 38)
+            (32, 34), (36, 37)]]
+

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -1,0 +1,64 @@
+﻿#if INTERACTIVE
+#r "../../bin/FSharp.Compiler.Service.dll"
+#r "../../bin/FSharpVSPowerTools.Core.dll"
+#r "../../packages/NUnit/lib/nunit.framework.dll"
+#load "TestHelpers.fs"
+#else
+module FSharpVSPowerTools.Core.Tests.PrintfSpecifiersUsageGetterTests
+#endif
+
+open NUnit.Framework
+open System.IO
+open Microsoft.FSharp.Compiler.SourceCodeServices
+open FSharpVSPowerTools
+
+let fileName = Path.Combine (__SOURCE_DIRECTORY__, __SOURCE_FILE__)
+let projectFileName = Path.ChangeExtension(fileName, ".fsproj")
+let sourceFiles = [| fileName |]
+let framework = FSharpCompilerVersion.FSharp_3_1
+let languageService = LanguageService()
+
+let opts source = 
+    let opts = 
+        languageService.GetCheckerOptions (fileName, projectFileName, source, sourceFiles, LanguageServiceTestHelper.args, [||], framework) 
+        |> Async.RunSynchronously
+    { opts with LoadTime = System.DateTime.UtcNow }
+
+let (=>) source (expected: (int * ((int * int) list)) list) = 
+    let opts = opts source
+    let results = 
+        languageService.ParseAndCheckFileInProject(opts, fileName, source, AllowStaleResults.No)
+        |> Async.RunSynchronously
+
+    let actual = 
+        PrintfSpecifiersUsageGetter.getAll results
+        |> Async.RunSynchronously
+        |> Option.getOrElse [||]
+        |> Array.toList
+        |> List.collect (fun x -> [x.SpecifierRange; x.ArgumentRange])
+        |> List.groupBy (fun r -> r.StartLine)
+        |> List.map (fun (line, rs) ->
+            line, 
+            rs 
+            |> List.map (fun x -> x.StartColumn, x.EndColumn)
+            |> List.sort)
+        |> List.sortBy (fun (line, _) -> line)
+
+    let expected = 
+        expected 
+        |> List.map (fun (line, sus) -> line, List.sort sus)
+        |> List.sortBy (fun (line, _) -> line)
+    
+    try actual |> Collection.assertEquiv expected
+    with _ -> 
+        debug "AST: %A" results.ParseTree
+        for x in actual do
+            debug "Actual: %A" x
+        reraise()
+
+[<Test>]
+let ``should find usages in printf``() =
+    """
+let _ = printf "%+A foo %d" 1 2
+"""
+    => [2, [16, 18; 20, 21]]

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -107,13 +107,15 @@ System.IO.File.OpenRead (sprintf "file %d" 1) |> ignore
     => [2, [(39, 41), (43, 44)]]
 
 [<Test>]
-let ``failwithf``() =
+let ``argument backward piped``() =
     """
 failwithf "Not an object: %s" <| "foo"
 """
-    => [2, [(26, 28), (33, 48)]]
+    => [2, [(26, 28), (33, 38)]]
 
-//let f x = 
-//    match x with
-//    | 1 -> ()
-//    | _ -> failwithf "Not an object: %s" <| x.ToString()
+[<Test>]
+let ``argument forward piped``() =
+    """
+"foo" |> failwithf "Not an object: %s"
+"""
+    => [2, [(35, 37), (0, 5)]]

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -74,3 +74,19 @@ printf "%+A foo %s" 1 (sprintf "%d" 2)
             (16, 18), (22, 38)
             (32, 34), (36, 37)]]
 
+[<Test>]
+let ``partially applied printf``() =
+    """
+printf "%+A foo %s" 1
+"""
+    => [2, [(8, 11), (20, 21)]]
+
+[<Test>]
+let ``another function application above printf``() =
+    """
+let f x y = x y
+let _ = f 1 2
+printf "%+A foo" 1
+"""
+    => [4, [(8, 11), (20, 21)]]
+

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -99,3 +99,21 @@ printf "%+A foo" 1
 """
     => [3, [(8, 11), (17, 18)]]
 
+[<Test>]
+let ``printf as an argument to another function``() =
+    """
+System.IO.File.OpenRead (sprintf "file %d" 1) |> ignore
+"""
+    => [2, [(39, 41), (43, 44)]]
+
+[<Test>]
+let ``failwithf``() =
+    """
+failwithf "Not an object: %s" <| "foo"
+"""
+    => [2, [(26, 28), (33, 48)]]
+
+//let f x = 
+//    match x with
+//    | 1 -> ()
+//    | _ -> failwithf "Not an object: %s" <| x.ToString()

--- a/tests/FSharpVSPowerTools.Tests/FSharpVSPowerTools.Tests.fsproj
+++ b/tests/FSharpVSPowerTools.Tests/FSharpVSPowerTools.Tests.fsproj
@@ -97,6 +97,7 @@
     <Compile Include="VsTestSetup.fs" />
     <Compile Include="SyntaxConstructClassifierTests.fs" />
     <Compile Include="HighlightUsageTaggerTests.fs" />
+    <Compile Include="PrintfSpecifiersUsageTaggerTests.fs" />
     <Compile Include="FormattingCommandTests.fs" />
     <Compile Include="DepthTaggerTests.fs" />
     <Compile Include="FindReferencesCommandTests.fs" />

--- a/tests/FSharpVSPowerTools.Tests/HighlightUsageTaggerTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/HighlightUsageTaggerTests.fs
@@ -5,7 +5,7 @@ open Microsoft.VisualStudio.Text.Tagging
 open Microsoft.VisualStudio.Text
 open NUnit.Framework
 
-type HighlightUsageTaggerHelper() =    
+type HighlightUsageTaggerHelper() =
     inherit VsTestBase()
 
     let taggerProvider = HighlightUsageTaggerProvider(

--- a/tests/FSharpVSPowerTools.Tests/Mocks.fs
+++ b/tests/FSharpVSPowerTools.Tests/Mocks.fs
@@ -38,6 +38,7 @@ let createGeneralOptionsPage() =
             page.GoToSymbolSourceEnabled --> true
             page.LinterEnabled --> true
             page.OutliningEnabled --> true
+            page.HighlightPrintfUsageEnabled --> true
         @>)
 
 let createClassificationTypeRegistryService() =

--- a/tests/FSharpVSPowerTools.Tests/PrintfSpecifiersUsageTaggerTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/PrintfSpecifiersUsageTaggerTests.fs
@@ -1,0 +1,104 @@
+﻿namespace FSharpVSPowerTools.Tests
+
+open FSharpVSPowerTools
+open Microsoft.VisualStudio.Text.Tagging
+open Microsoft.VisualStudio.Text
+open NUnit.Framework
+
+type PrintfSpecifiersUsageTaggerHelper() =
+    inherit VsTestBase()
+
+    let taggerProvider = 
+        new PrintfSpecifiersUsageTaggerProvider(
+                fsharpVsLanguageService = base.VsLanguageService,
+                serviceProvider = base.ServiceProvider,
+                projectFactory = base.ProjectFactory,
+                textDocumentFactoryService = base.DocumentFactoryService,
+                shellEventListener = base.ShellEventListener,
+                printfColorManager = null)
+
+    member __.GetView buffer =
+        createMockTextView buffer
+
+    member __.GetTagger(buffer, view) = 
+        taggerProvider.CreateTagger<_>(view, buffer)
+
+    member __.TagsOf(buffer: ITextBuffer, tagger: ITagger<_>) =
+        let span = SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)
+        tagger.GetTags(NormalizedSnapshotSpanCollection span)
+        |> Seq.map(fun span ->
+            let snapshot = span.Span.Snapshot
+            // Use 1-based position for intuitive comparison
+            let lineStart = snapshot.GetLineNumberFromPosition(span.Span.Start.Position) + 1 
+            let lineEnd = snapshot.GetLineNumberFromPosition(span.Span.End.Position) + 1
+            let firstLine = snapshot.GetLineFromPosition(span.Span.Start.Position)
+            let lastLine = snapshot.GetLineFromPosition(span.Span.End.Position)
+            let colStart = span.Span.Start.Position - firstLine.Start.Position + 1
+            let colEnd = span.Span.End.Position - lastLine.Start.Position + 1
+            (lineStart, colStart, lineEnd, colEnd - 1))
+
+module PrintfSpecifiersUsageTaggerTests =
+    let helper = PrintfSpecifiersUsageTaggerHelper()
+    let mutable fileName = null
+
+    [<SetUp>]
+    let setUp() = 
+        // we must use unique name for each test because we use `AllowStaleResults.MatchingSource` 
+        // in HighlightUsageTagger
+        fileName <- getTempFileName ".fsx"
+
+    [<Test>]
+    let ``should display tags for printf specifiers``() = 
+        let content = """
+printf "%d foo %+A bar" 1 "str"
+"""
+        let buffer = createMockTextBuffer content fileName
+        helper.AddProject(createVirtualProject(buffer, fileName))
+        helper.SetActiveDocument(fileName, content)
+        let view = helper.GetView(buffer)
+        let tagger = helper.GetTagger(buffer, view)
+        let testEventTrigger = testEventTrigger tagger.TagsChanged "Timed out before tags changed" timeout 
+        // first tags changed event is raised by `onCaretMove`, but there are no data yet since
+        // `onBufferChanged` event handler has not finished gathering Printf specifiers.
+        testEventTrigger
+            ignore 
+            (fun () -> helper.TagsOf(buffer, tagger) |> Seq.toList |> assertEqual [])
+
+        testEventTrigger
+            (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 2 8) |> ignore)
+            (fun () -> 
+                helper.TagsOf(buffer, tagger) 
+                |> Seq.toList 
+                |> assertEqual
+                     [ (2, 9) => (2, 10)
+                       (2, 28) => (2, 28) ])
+                       
+        testEventTrigger
+            (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 2 16) |> ignore)
+            (fun () -> 
+                helper.TagsOf(buffer, tagger) 
+                |> Seq.toList 
+                |> assertEqual
+                     [ (2, 16) => (2, 18)
+                       (2, 30) => (2, 34) ])
+                       
+    [<Test>]
+    let ``should not display tags if moving to a place without a printf specifier or its argument``() = 
+        let content = """
+printf "%d foo %+A bar" 1 "str"
+"""
+        let buffer = createMockTextBuffer content fileName
+        helper.AddProject(createVirtualProject(buffer, fileName))
+        helper.SetActiveDocument(fileName, content)
+        let view = helper.GetView(buffer)
+        let tagger = helper.GetTagger(buffer, view)
+        let testEventTrigger = testEventTrigger tagger.TagsChanged "Timed out before tags changed" timeout 
+        // first tags changed event is raised by `onCaretMove`, but there are no data yet since
+        // `onBufferChanged` event handler has not finished gathering Printf specifiers.
+        testEventTrigger
+            ignore 
+            (fun () -> helper.TagsOf(buffer, tagger) |> Seq.toList |> assertEqual [])
+
+        testEventTrigger
+            (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 2 12) |> ignore)
+            (fun () -> helper.TagsOf(buffer, tagger) |> Seq.toList |> assertEqual [])

--- a/tests/FSharpVSPowerTools.Tests/PrintfSpecifiersUsageTaggerTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/PrintfSpecifiersUsageTaggerTests.fs
@@ -57,13 +57,7 @@ printf "%d foo %+A bar" 1 "str"
         helper.SetActiveDocument(fileName, content)
         let view = helper.GetView(buffer)
         let tagger = helper.GetTagger(buffer, view)
-        let testEventTrigger = testEventTrigger tagger.TagsChanged "Timed out before tags changed" timeout 
-        // first tags changed event is raised by `onCaretMove`, but there are no data yet since
-        // `onBufferChanged` event handler has not finished gathering Printf specifiers.
-        testEventTrigger
-            ignore 
-            (fun () -> helper.TagsOf(buffer, tagger) |> Seq.toList |> assertEqual [])
-
+        let testEventTrigger = testEventTrigger tagger.TagsChanged "Timed out before tags changed" 100000<ms> // timeout 
         testEventTrigger
             (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 2 8) |> ignore)
             (fun () -> 
@@ -71,7 +65,7 @@ printf "%d foo %+A bar" 1 "str"
                 |> Seq.toList 
                 |> assertEqual
                      [ (2, 9) => (2, 10)
-                       (2, 28) => (2, 28) ])
+                       (2, 25) => (2, 25) ])
                        
         testEventTrigger
             (fun () -> view.Caret.MoveTo(snapshotPoint view.TextSnapshot 2 16) |> ignore)
@@ -80,7 +74,7 @@ printf "%d foo %+A bar" 1 "str"
                 |> Seq.toList 
                 |> assertEqual
                      [ (2, 16) => (2, 18)
-                       (2, 30) => (2, 34) ])
+                       (2, 27) => (2, 31) ])
                        
     [<Test>]
     let ``should not display tags if moving to a place without a printf specifier or its argument``() = 

--- a/tests/FSharpVSPowerTools.Tests/VsTestBase.fs
+++ b/tests/FSharpVSPowerTools.Tests/VsTestBase.fs
@@ -14,7 +14,7 @@ type MockProjectFactory(serviceProvider, openDocTracker, vsLanguageService, dte:
 
 /// A base class for initializing necessary VS services
 type VsTestBase() =
-    static let serviceProvider = MockServiceProvider()        
+    static let serviceProvider = MockServiceProvider()
     
     static do serviceProvider.Services.[nameOf<SVsActivityLog>] <- MockActivityLog()
     static do serviceProvider.Services.[nameOf<SVsShell>] <- MockVsShell()


### PR DESCRIPTION
It works like this:

![6677](https://cloud.githubusercontent.com/assets/873919/11277170/6635f3fe-8ef6-11e5-8476-87efc091d228.gif)

I'd like to use different color for this tags. Currently I reuse "MarkerFormatDefinition/HighlightedReference", as `HighlightUsageTagger` does. @dungpa do you know a way to add a color (visible in settings) and specify to use it in this new tagger? If I remember correctly, we did use a custom color for tags until we found out how to use the standard one.