### PR TITLE
Prevent Dispose being called in outlining tagger at wrong time

### DIFF
--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -446,6 +446,9 @@ type OutliningTagger
             |> Seq.filter (fun s -> normalizedSnapshotSpans.IntersectsWith s.SnapSpan)
             |> Seq.choose createTagSpan
 
+    // prevent compilation error, docEventListener must have some code that 
+    // references it.
+    member private x.DocEventListener = docEventListener
 
     interface ITagger<IOutliningRegionTag> with
         member __.GetTags spans =
@@ -453,9 +456,3 @@ type OutliningTagger
 
         [<CLIEvent>]
         member __.TagsChanged = tagsChanged.Publish
-
-
-    interface IDisposable with
-        member __.Dispose () =
-            docEventListener.Dispose ()
-            scopedSnapSpans <- [||]

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -180,7 +180,7 @@ type OutliningTagger
         |> Async.Ignore
 
     /// viewUpdate -=> doUpdate -=> triggerUpdate -=> tagsChanged
-    let docEventListener =
+    let _docEventListener =
         new DocumentEventListener ([ViewChange.bufferEvent buffer], UpdateDelay, doUpdate) :> IDisposable
 
     /// Find the length of the shortest whitespace indentation in the textblock used for the outlining
@@ -445,10 +445,6 @@ type OutliningTagger
             scopedSnapSpans
             |> Seq.filter (fun s -> normalizedSnapshotSpans.IntersectsWith s.SnapSpan)
             |> Seq.choose createTagSpan
-
-    // prevent compilation error, docEventListener must have some code that 
-    // references it.
-    member private x.DocEventListener = docEventListener
 
     interface ITagger<IOutliningRegionTag> with
         member __.GetTags spans =


### PR DESCRIPTION
This is some serious Voodoo business.

One time you open a view with a file, and everything works well. `Dispose` is called on the Outlining Tagger as hoped when the view is closed.

The second time?
`Dispose` is called.
When?
After we have calculated what to outline, and alerted VS that there are tags that it needs to show.

Here's a callstack of said event:
![screenshot 26](https://cloud.githubusercontent.com/assets/9697324/11320734/4f9e350e-90ac-11e5-894a-5d97f780a7fd.png)

The fix? Removing the `IDisposable` imeplementation from the tagger. Not ideal, obviously, but it seems to solve this bug.
