### PR TITLE
Do not throw all calculated Printf argument highlights if some of them are erroneous

### DIFF
--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -10,7 +10,7 @@ type PrintfSpecifierUse =
 
 let private startPos (r: Range.range) = r.StartLine, r.StartColumn
 
-let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
+let getAll (input: ParseAndCheckResults) (onError: string -> unit): PrintfSpecifierUse[] option Async =
     asyncMaybe {
         let! specifierRanges = input.GetFormatSpecifierLocations()
         let specifierRanges = 
@@ -31,7 +31,8 @@ let getAll (input: ParseAndCheckResults): PrintfSpecifierUse[] option Async =
                 | [||] -> restSpecifiers, acc
                 | _ ->
                     if func.Args.Length > ownSpecifiers.Length then
-                        failwithf "Too many Printf arguments for %+A (%d > %d)" func func.Args.Length ownSpecifiers.Length
+                        onError (sprintf "Too many Printf arguments for %+A (%d > %d)" 
+                                         func func.Args.Length ownSpecifiers.Length)
                     
                     let uses = 
                         func.Args

--- a/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
@@ -70,7 +70,7 @@ type PrintfSpecifiersUsageTagger
             let! project = projectFactory.CreateForDocument buffer doc
             try
                 let! checkResults = vsLanguageService.ParseAndCheckFileInProject (doc.FullName, project)
-                return! PrintfSpecifiersUsageGetter.getAll checkResults
+                return! PrintfSpecifiersUsageGetter.getAll checkResults (fun e -> Logging.logError (fun _ -> e))
             with e ->
                 Logging.logExceptionWithContext(e, "Failed to update printf specifier usages.")
                 return! None

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -33,7 +33,7 @@ let (=>) source (expected: (int * (((int * int) * (int * int)) list)) list) =
     let actual = ref []
     try
         actual :=
-            PrintfSpecifiersUsageGetter.getAll results
+            PrintfSpecifiersUsageGetter.getAll results ignore
             |> Async.RunSynchronously
             |> Option.getOrElse [||]
             |> Array.toList


### PR DESCRIPTION
It does not fix this https://github.com/fsprojects/VisualFSharpPowerTools/issues/1274 and other possible AST forms on which the feature does not work, but it prevents loosing all Printf highlight tags to disappear if a single such error occurs. 