### PR TITLE
Add outlining menu items and keybindings

### DIFF
--- a/src/FSharpVSPowerTools.Logic/Constants.fs
+++ b/src/FSharpVSPowerTools.Logic/Constants.fs
@@ -59,7 +59,3 @@ let [<Literal>] guidAddReferenceInFSICmdSetString = "8c9a49dd-2d34-4d18-905b-c55
 let guidGenerateReferencesForFsiCmdSet = Guid(guidAddReferenceInFSICmdSetString)
 let [<Literal>] QuickInfoMargin = "vfpt.quickinfo.margin"
 let [<Literal>] LintTagErrorType = "F# Lint"
-
-let cmdidOutliningToggleCurrent = uint32 VSConstants.VSStd2KCmdID.OUTLN_TOGGLE_CURRENT
-let cmdidOutliningExpandAll = uint32 VSConstants.VSStd2010CmdID.OUTLN_EXPAND_ALL
-let cmdidOutliningCollapseAll = uint32 VSConstants.VSStd2010CmdID.OUTLN_COLLAPSE_ALL

--- a/src/FSharpVSPowerTools.Logic/Constants.fs
+++ b/src/FSharpVSPowerTools.Logic/Constants.fs
@@ -59,3 +59,7 @@ let [<Literal>] guidAddReferenceInFSICmdSetString = "8c9a49dd-2d34-4d18-905b-c55
 let guidGenerateReferencesForFsiCmdSet = Guid(guidAddReferenceInFSICmdSetString)
 let [<Literal>] QuickInfoMargin = "vfpt.quickinfo.margin"
 let [<Literal>] LintTagErrorType = "F# Lint"
+
+let cmdidOutliningToggleCurrent = uint32 VSConstants.VSStd2KCmdID.OUTLN_TOGGLE_CURRENT
+let cmdidOutliningExpandAll = uint32 VSConstants.VSStd2010CmdID.OUTLN_EXPAND_ALL
+let cmdidOutliningCollapseAll = uint32 VSConstants.VSStd2010CmdID.OUTLN_COLLAPSE_ALL

--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -253,6 +253,7 @@
       <Link>Linting/LintQuickInfoSource.fs</Link>
     </Compile>
     <Compile Include="Outlining\OutliningTagger.fs" />
+    <Compile Include="Outlining\OutliningFilter.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningFilter.fs
@@ -11,31 +11,27 @@ open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio
 open System.Windows.Forms
 
-type OutliningFilter(_textView: IWpfTextView, 
-                     _outliningManagerService: IOutliningManagerService) =
+type OutliningFilter() =
 
     member val IsAdded = false with get, set
     member val NextTarget: IOleCommandTarget = null with get, set
 
     interface IOleCommandTarget with
         member x.Exec (pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut) =
-            if (pguidCmdGroup = Constants.guidStandardCmdSet && nCmdId = Constants.cmdidOutliningToggleCurrent) then
-                MessageBox.Show("1") |> ignore
-            elif (pguidCmdGroup = VSConstants.VsStd2010 && nCmdId = Constants.cmdidOutliningExpandAll) then
-                MessageBox.Show("2") |> ignore
-            elif (pguidCmdGroup = VSConstants.VsStd2010 && nCmdId = Constants.cmdidOutliningCollapseAll) then
-                MessageBox.Show("3") |> ignore
-            x.NextTarget.Exec(&pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut)
+            // We don't have to do anything here since most of the things are handled by VS.
+            x.NextTarget.Exec (&pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut)
 
         member x.QueryStatus (pguidCmdGroup, cCmds, prgCmds, pCmdText) =
             if pguidCmdGroup = Constants.guidStandardCmdSet && 
-                prgCmds |> Seq.exists (fun x -> x.cmdID = Constants.cmdidOutliningToggleCurrent) then
-                prgCmds.[0].cmdf <- uint32 (OLECMDF.OLECMDF_SUPPORTED ||| OLECMDF.OLECMDF_ENABLED &&& ~~~ OLECMDF.OLECMDF_INVISIBLE)
-                VSConstants.S_OK
-            elif pguidCmdGroup = VSConstants.VsStd2010 && 
-                prgCmds |> Seq.exists (fun x -> x.cmdID = Constants.cmdidOutliningExpandAll 
-                                                  || x.cmdID = Constants.cmdidOutliningCollapseAll) then
-                prgCmds.[0].cmdf <- uint32 (OLECMDF.OLECMDF_SUPPORTED ||| OLECMDF.OLECMDF_ENABLED &&& ~~~ OLECMDF.OLECMDF_INVISIBLE)
+                prgCmds |> Seq.exists (fun x -> 
+                               x.cmdID = uint32 VSConstants.VSStd2KCmdID.OUTLN_COLLAPSE_TO_DEF
+                            || x.cmdID = uint32 VSConstants.VSStd2KCmdID.OUTLN_HIDE_SELECTION
+                            || x.cmdID = uint32 VSConstants.VSStd2KCmdID.OUTLN_START_AUTOHIDING
+                            || x.cmdID = uint32 VSConstants.VSStd2KCmdID.OUTLN_STOP_HIDING_ALL
+                            || x.cmdID = uint32 VSConstants.VSStd2KCmdID.OUTLN_STOP_HIDING_CURRENT
+                            || x.cmdID = uint32 VSConstants.VSStd2KCmdID.OUTLN_TOGGLE_ALL
+                            || x.cmdID = uint32 VSConstants.VSStd2KCmdID.OUTLN_TOGGLE_CURRENT) then
+                prgCmds.[0].cmdf <- uint32 (OLECMDF.OLECMDF_SUPPORTED ||| OLECMDF.OLECMDF_ENABLED)
                 VSConstants.S_OK
             else
                 x.NextTarget.QueryStatus(&pguidCmdGroup, cCmds, prgCmds, pCmdText)

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningFilter.fs
@@ -1,0 +1,41 @@
+﻿namespace FSharpVSPowerTools.Outlining
+
+open Microsoft.VisualStudio.Text
+open Microsoft.VisualStudio.Text.Editor
+open Microsoft.VisualStudio.OLE.Interop
+open FSharpVSPowerTools
+open FSharpVSPowerTools.ProjectSystem
+open Microsoft.VisualStudio.Text.Tagging
+open Microsoft.VisualStudio.Text.Outlining
+open Microsoft.VisualStudio.Shell
+open Microsoft.VisualStudio
+open System.Windows.Forms
+
+type OutliningFilter(_textView: IWpfTextView, 
+                     _outliningManagerService: IOutliningManagerService) =
+
+    member val IsAdded = false with get, set
+    member val NextTarget: IOleCommandTarget = null with get, set
+
+    interface IOleCommandTarget with
+        member x.Exec (pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut) =
+            if (pguidCmdGroup = Constants.guidStandardCmdSet && nCmdId = Constants.cmdidOutliningToggleCurrent) then
+                MessageBox.Show("1") |> ignore
+            elif (pguidCmdGroup = VSConstants.VsStd2010 && nCmdId = Constants.cmdidOutliningExpandAll) then
+                MessageBox.Show("2") |> ignore
+            elif (pguidCmdGroup = VSConstants.VsStd2010 && nCmdId = Constants.cmdidOutliningCollapseAll) then
+                MessageBox.Show("3") |> ignore
+            x.NextTarget.Exec(&pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut)
+
+        member x.QueryStatus (pguidCmdGroup, cCmds, prgCmds, pCmdText) =
+            if pguidCmdGroup = Constants.guidStandardCmdSet && 
+                prgCmds |> Seq.exists (fun x -> x.cmdID = Constants.cmdidOutliningToggleCurrent) then
+                prgCmds.[0].cmdf <- uint32 (OLECMDF.OLECMDF_SUPPORTED ||| OLECMDF.OLECMDF_ENABLED &&& ~~~ OLECMDF.OLECMDF_INVISIBLE)
+                VSConstants.S_OK
+            elif pguidCmdGroup = VSConstants.VsStd2010 && 
+                prgCmds |> Seq.exists (fun x -> x.cmdID = Constants.cmdidOutliningExpandAll 
+                                                  || x.cmdID = Constants.cmdidOutliningCollapseAll) then
+                prgCmds.[0].cmdf <- uint32 (OLECMDF.OLECMDF_SUPPORTED ||| OLECMDF.OLECMDF_ENABLED &&& ~~~ OLECMDF.OLECMDF_INVISIBLE)
+                VSConstants.S_OK
+            else
+                x.NextTarget.QueryStatus(&pguidCmdGroup, cCmds, prgCmds, pCmdText)

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningFilter.fs
@@ -12,7 +12,6 @@ open Microsoft.VisualStudio
 open System.Windows.Forms
 
 type OutliningFilter() =
-
     member val IsAdded = false with get, set
     member val NextTarget: IOleCommandTarget = null with get, set
 

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -423,7 +423,7 @@ type OutliningTagger
                     { new IOutliningRegionTag with
                         member __.CollapsedForm      = collapseText :> obj
                         member __.IsDefaultCollapsed = collapseByDefault scope
-                        member __.IsImplementation   = false
+                        member __.IsImplementation   = true
                         member __.CollapsedHintForm  =
                             OutliningHint (createElisionBufferView textEditorFactoryService, createBuffer) :> _
                     }) :> ITagSpan<_> 

--- a/src/FSharpVSPowerTools/Commands/OutliningFilterProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/OutliningFilterProvider.cs
@@ -1,0 +1,79 @@
+﻿using System.Diagnostics;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Text.Operations;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Utilities;
+using Microsoft.VisualStudio.Shell;
+using FSharpVSPowerTools.ProjectSystem;
+using FSharpVSPowerTools.Navigation;
+using Microsoft.VisualStudio.Text;
+
+namespace FSharpVSPowerTools.Outlining
+{
+    [Export(typeof(IWpfTextViewCreationListener))]
+    [ContentType("F#")]
+    [TextViewRole(PredefinedTextViewRoles.Editable)]
+    internal class OutliningFilterProvider : IWpfTextViewCreationListener
+    {
+        private readonly System.IServiceProvider _serviceProvider;
+        private readonly ITextDocumentFactoryService _textDocumentFactoryService;
+        private readonly ProjectFactory _projectFactory;
+        private readonly VSLanguageService _fsharpVsLanguageService;
+        private readonly IVsEditorAdaptersFactoryService _editorFactory;
+        private readonly FileSystem _fileSystem;
+
+        [ImportingConstructor]
+        public OutliningFilterProvider(
+            [Import(typeof(SVsServiceProvider))] System.IServiceProvider serviceProvider,
+            ITextDocumentFactoryService textDocumentFactoryService,
+            IVsEditorAdaptersFactoryService editorFactory,
+            FileSystem fileSystem,
+            ProjectFactory projectFactory,
+            VSLanguageService fsharpVsLanguageService)
+        {
+            _serviceProvider = serviceProvider;
+            _textDocumentFactoryService = textDocumentFactoryService;
+            _editorFactory = editorFactory;
+            _fileSystem = fileSystem;
+            _projectFactory = projectFactory;
+            _fsharpVsLanguageService = fsharpVsLanguageService;
+        }
+
+        public void TextViewCreated(IWpfTextView textView)
+        {
+            var textViewAdapter = _editorFactory.GetViewAdapter(textView);
+            if (textViewAdapter == null) return;
+
+            var generalOptions = Setting.getGeneralOptions(_serviceProvider);
+            if (generalOptions == null || !generalOptions.OutliningEnabled) return;
+
+            ITextDocument doc;
+            if (_textDocumentFactoryService.TryGetTextDocument(textView.TextBuffer, out doc))
+            {
+                var filter = new OutliningFilter(textView, null);
+                AddCommandFilter(textViewAdapter, filter);
+            }
+        }
+
+        private static void AddCommandFilter(IVsTextView viewAdapter, OutliningFilter commandFilter)
+        {
+            if (!commandFilter.IsAdded)
+            {
+                // Get the view adapter from the editor factory
+                IOleCommandTarget next;
+                int hr = viewAdapter.AddCommandFilter(commandFilter, out next);
+
+                if (hr == VSConstants.S_OK)
+                {
+                    commandFilter.IsAdded = true;
+                    // You'll need the next target for Exec and QueryStatus
+                    if (next != null) commandFilter.NextTarget = next;
+                }
+            }
+        }
+    }
+}

--- a/src/FSharpVSPowerTools/Commands/OutliningFilterProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/OutliningFilterProvider.cs
@@ -20,27 +20,15 @@ namespace FSharpVSPowerTools.Outlining
     internal class OutliningFilterProvider : IVsTextViewCreationListener
     {
         private readonly System.IServiceProvider _serviceProvider;
-        private readonly ITextDocumentFactoryService _textDocumentFactoryService;
-        private readonly ProjectFactory _projectFactory;
-        private readonly VSLanguageService _fsharpVsLanguageService;
         private readonly IVsEditorAdaptersFactoryService _editorFactory;
-        private readonly FileSystem _fileSystem;
-
+        
         [ImportingConstructor]
         public OutliningFilterProvider(
             [Import(typeof(SVsServiceProvider))] System.IServiceProvider serviceProvider,
-            ITextDocumentFactoryService textDocumentFactoryService,
-            IVsEditorAdaptersFactoryService editorFactory,
-            FileSystem fileSystem,
-            ProjectFactory projectFactory,
-            VSLanguageService fsharpVsLanguageService)
+            IVsEditorAdaptersFactoryService editorFactory)
         {
             _serviceProvider = serviceProvider;
-            _textDocumentFactoryService = textDocumentFactoryService;
             _editorFactory = editorFactory;
-            _fileSystem = fileSystem;
-            _projectFactory = projectFactory;
-            _fsharpVsLanguageService = fsharpVsLanguageService;
         }
 
         private static void AddCommandFilter(IVsTextView viewAdapter, OutliningFilter commandFilter)
@@ -68,12 +56,7 @@ namespace FSharpVSPowerTools.Outlining
             var generalOptions = Setting.getGeneralOptions(_serviceProvider);
             if (generalOptions == null || !generalOptions.OutliningEnabled) return;
 
-            ITextDocument doc;
-            if (_textDocumentFactoryService.TryGetTextDocument(textView.TextBuffer, out doc))
-            {
-                var filter = new OutliningFilter();
-                AddCommandFilter(textViewAdapter, filter);
-            }
+            AddCommandFilter(textViewAdapter, new OutliningFilter());
         }
     }
 }

--- a/src/FSharpVSPowerTools/Commands/OutliningTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/OutliningTaggerProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Outlining;
 
-namespace FSharpVSPowerTools
+namespace FSharpVSPowerTools.Outlining
 {
     [Export(typeof(ITaggerProvider))]
     [Export(typeof(IWpfTextViewCreationListener))]
@@ -58,7 +58,7 @@ namespace FSharpVSPowerTools
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
                 return (ITagger<T>)buffer.Properties.GetOrCreateSingletonProperty(() =>
-                   new Outlining.OutliningTagger(                       
+                   new OutliningTagger(                       
                        doc,
                        _serviceProvider,
                        _textEditorFactoryService,

--- a/src/FSharpVSPowerTools/Commands/OutliningTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/OutliningTaggerProvider.cs
@@ -83,12 +83,7 @@ namespace FSharpVSPowerTools.Outlining
                 if (isFirstOutlining)
                 {
                     var fullSpan = new SnapshotSpan(textView.TextSnapshot, 0, textView.TextSnapshot.Length);
-                    // Ensure that first tags have been computed.
-                    var tags = outliningTagger.GetTags(new NormalizedSnapshotSpanCollection(fullSpan));
                     var outliningManager = _outliningManagerService.GetOutliningManager(textView);
-                    // Keep the outlining manager in the lifetime of the text view.
-                    // This prevents the outlining manager being disposed while it should still be used.
-                    textView.Properties.GetOrCreateSingletonProperty(() => outliningManager);
                     if (outliningManager != null)
                     {
                         outliningManager.CollapseAll(fullSpan, match: c => c.Tag.IsDefaultCollapsed);

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -135,6 +135,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Commands\FontColor.cs" />
+    <Compile Include="Commands\OutliningFilterProvider.cs" />
     <Compile Include="Commands\PrintfSpecifiersUsageTaggerProvider.cs" />
     <Compile Include="Commands\OutliningTaggerProvider.cs" />
     <Compile Include="Resources\FSharpVSPowerTools.Designer.cs">

--- a/tests/FSharpVSPowerTools.Tests/OutliningTaggerTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/OutliningTaggerTests.fs
@@ -1,6 +1,7 @@
 ﻿namespace FSharpVSPowerTools.Tests
 
 open FSharpVSPowerTools
+open FSharpVSPowerTools.Outlining
 open Microsoft.VisualStudio.Text.Tagging
 open Microsoft.VisualStudio.Text
 open NUnit.Framework


### PR DESCRIPTION
Close #1275.

Most of menu items are working fine. Only 'Collapse to Definitions' needs special treatment.