### PR TITLE
cache FileSystem.SafeExists and FileSystem.GetLastWriteTimeShim during single LanguageService.ParseAndCheckFileInProject

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -139,8 +139,12 @@ type FileState =
 // --------------------------------------------------------------------------------------
 // Language service 
 
+type ICachingFileSystem =
+    inherit IFileSystem
+    abstract ClearCache: unit -> unit
+
 /// Provides functionality for working with the F# interactive checker running in background
-type LanguageService (?backgroundCompilation: bool, ?projectCacheSize: int, ?fileSystem: IFileSystem) =
+type LanguageService (?backgroundCompilation: bool, ?projectCacheSize: int, ?fileSystem: ICachingFileSystem) =
 
   do Option.iter (fun fs -> Shim.FileSystem <- fs) fileSystem
   let mutable errorHandler = None
@@ -197,6 +201,7 @@ type LanguageService (?backgroundCompilation: bool, ?projectCacheSize: int, ?fil
                    
                    debug "[LanguageService] Change state for %s to `BeingChecked`" filePath
                    debug "[LanguageService] Parse and typecheck source..."
+                   fileSystem |> Option.iter (fun x -> x.ClearCache())
                    return! x.ParseAndCheckFileInProject (fixedFilePath, 0, source, options, 
                                                          IsResultObsolete (fun _ -> isResultObsolete filePath), null) 
               finally 

--- a/src/FSharpVSPowerTools.Logic/FileSystem.fs
+++ b/src/FSharpVSPowerTools.Logic/FileSystem.fs
@@ -4,6 +4,9 @@ open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library
 open System.IO
 open FSharpVSPowerTools.ProjectSystem
 open System.ComponentModel.Composition
+open System.Collections.Generic
+open System
+open System.Collections.Concurrent
 
 type Version = int
 
@@ -11,13 +14,20 @@ type Version = int
 type FileSystem [<ImportingConstructor>] (openDocumentsTracker: IOpenDocumentsTracker) =
     static let defaultFileSystem = Shim.FileSystem
 
+    let fileExistsCache = ConcurrentDictionary<string, bool>()
+    let fileLastWriteTimeCache = ConcurrentDictionary<string, DateTime>()
+
     let getOpenDocContent (fileName: string) =
         openDocumentsTracker.TryFindOpenDocument fileName
         |> Option.map (fun doc -> 
             let content = doc.Text.Value 
             content |> doc.Encoding.GetBytes)
 
-    interface IFileSystem with
+    interface ICachingFileSystem with
+        member __.ClearCache() =
+            fileExistsCache.Clear()
+            fileLastWriteTimeCache.Clear()
+
         member __.FileStreamReadShim fileName = 
             getOpenDocContent fileName
             |> Option.map (fun bytes -> new MemoryStream (bytes) :> Stream)
@@ -28,12 +38,18 @@ type FileSystem [<ImportingConstructor>] (openDocumentsTracker: IOpenDocumentsTr
             |> Option.getOrTry (fun () -> defaultFileSystem.ReadAllBytesShim fileName)
         
         member __.GetLastWriteTimeShim fileName =
-            openDocumentsTracker.TryFindOpenDocument fileName
-            |> Option.bind (fun doc ->
-                if doc.Document.IsDirty then
-                    Some doc.LastChangeTime
-                else None)
-            |> Option.getOrTry (fun () -> defaultFileSystem.GetLastWriteTimeShim fileName)
+            match fileLastWriteTimeCache.TryGetValue fileName with
+            | true, x -> x
+            | _ ->
+                let res = 
+                    openDocumentsTracker.TryFindOpenDocument fileName
+                    |> Option.bind (fun doc ->
+                        if doc.Document.IsDirty then
+                            Some doc.LastChangeTime
+                        else None)
+                    |> Option.getOrTry (fun () -> defaultFileSystem.GetLastWriteTimeShim fileName)
+                fileLastWriteTimeCache.[fileName] <- res
+                res
         
         member __.GetTempPathShim() = defaultFileSystem.GetTempPathShim()
         member __.FileStreamCreateShim fileName = defaultFileSystem.FileStreamCreateShim fileName
@@ -41,7 +57,13 @@ type FileSystem [<ImportingConstructor>] (openDocumentsTracker: IOpenDocumentsTr
         member __.GetFullPathShim fileName = defaultFileSystem.GetFullPathShim fileName
         member __.IsInvalidPathShim fileName = defaultFileSystem.IsInvalidPathShim fileName
         member __.IsPathRootedShim fileName = defaultFileSystem.IsPathRootedShim fileName
-        member __.SafeExists fileName = defaultFileSystem.SafeExists fileName
+        member __.SafeExists fileName = 
+            match fileExistsCache.TryGetValue fileName with
+            | true, x -> x
+            | _ ->
+                let res = defaultFileSystem.SafeExists fileName
+                fileExistsCache.[fileName] <- res
+                res
         member __.FileDelete fileName = defaultFileSystem.FileDelete fileName
         member __.AssemblyLoadFrom fileName = defaultFileSystem.AssemblyLoadFrom fileName
         member __.AssemblyLoad assemblyName = defaultFileSystem.AssemblyLoad assemblyName

--- a/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/VSLanguageService.fs
@@ -57,7 +57,7 @@ type VSLanguageService
     (editorFactory: IVsEditorAdaptersFactoryService, 
      fsharpLanguageService: FSharpLanguageService,
      openDocumentsTracker: IOpenDocumentsTracker,
-     [<Import(typeof<FileSystem>)>] fileSystem: IFileSystem,
+     [<Import(typeof<FileSystem>)>] fileSystem: ICachingFileSystem,
      [<Import(typeof<SVsServiceProvider>)>] serviceProvider: IServiceProvider) =
 
     let globalOptions = Setting.getGlobalOptions serviceProvider


### PR DESCRIPTION
It's temporary fix for https://github.com/fsprojects/VisualFSharpPowerTools/issues/1280 
