### PR TITLE
Make sure that Peek Definition menu items are disabled on VS2013

### DIFF
--- a/src/FSharpVSPowerTools.Logic.VS2013/FSharpVSPowerTools.Logic.VS2013.fsproj
+++ b/src/FSharpVSPowerTools.Logic.VS2013/FSharpVSPowerTools.Logic.VS2013.fsproj
@@ -63,9 +63,10 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildThisFileDirectory)</SolutionDir>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="paket.references" />
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="NavigateToItemDisplay2.fs" />
-    <Content Include="paket.references" />
+    <Compile Include="NoPeekDefinitionFilterProvider.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSharpVSPowerTools.Logic\FSharpVSPowerTools.Logic.fsproj">

--- a/src/FSharpVSPowerTools.Logic.VS2013/NavigateToItemDisplay2.fs
+++ b/src/FSharpVSPowerTools.Logic.VS2013/NavigateToItemDisplay2.fs
@@ -1,4 +1,4 @@
-﻿namespace FSharpVSPowerTools.ProjectSystem.VS2013
+﻿namespace FSharpVSPowerTools.Logic.VS2013
 
 open System
 open System.ComponentModel.Composition

--- a/src/FSharpVSPowerTools.Logic.VS2013/NoPeekDefinitionFilterProvider.fs
+++ b/src/FSharpVSPowerTools.Logic.VS2013/NoPeekDefinitionFilterProvider.fs
@@ -1,0 +1,85 @@
+﻿namespace FSharpVSPowerTools.Logic.VS2013
+
+open Microsoft.VisualStudio.Text
+open Microsoft.VisualStudio.Text.Editor
+open Microsoft.VisualStudio.OLE.Interop
+open FSharpVSPowerTools
+open FSharpVSPowerTools.ProjectSystem
+open Microsoft.VisualStudio.Text.Tagging
+open Microsoft.VisualStudio.Text.Outlining
+open Microsoft.VisualStudio.Shell
+open Microsoft.VisualStudio
+open System.Windows.Forms
+open System.ComponentModel.Composition
+open Microsoft.VisualStudio
+open Microsoft.VisualStudio.Editor
+open Microsoft.VisualStudio.Text.Operations
+open Microsoft.VisualStudio.TextManager.Interop
+open Microsoft.VisualStudio.Utilities
+open Microsoft.VisualStudio.Shell
+open EnvDTE
+
+type NoPeekDefinitionFilter() =
+    member val IsAdded = false with get, set
+    member val NextTarget: IOleCommandTarget = null with get, set
+
+    interface IOleCommandTarget with
+        member x.Exec (pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut) =
+            if pguidCmdGroup = VSConstants.VsStd12 && 
+                (nCmdId = uint32 VSConstants.VSStd12CmdID.PeekDefinition
+                 || nCmdId = uint32 VSConstants.VSStd12CmdID.PeekNavigateBackward
+                 || nCmdId = uint32 VSConstants.VSStd12CmdID.PeekNavigateForward) then
+                int Constants.OLECMDERR_E_NOTSUPPORTED
+            else
+                x.NextTarget.Exec(&pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut)
+
+        member x.QueryStatus (pguidCmdGroup, cCmds, prgCmds, pCmdText) =
+            if pguidCmdGroup = VSConstants.VsStd12 && 
+                prgCmds |> Seq.exists (fun x -> 
+                               x.cmdID = uint32 VSConstants.VSStd12CmdID.PeekDefinition
+                            || x.cmdID = uint32 VSConstants.VSStd12CmdID.PeekNavigateBackward
+                            || x.cmdID = uint32 VSConstants.VSStd12CmdID.PeekNavigateForward) then
+                prgCmds.[0].cmdf <- uint32 (OLECMDF.OLECMDF_SUPPORTED ||| OLECMDF.OLECMDF_INVISIBLE)
+                VSConstants.S_OK
+            else
+                x.NextTarget.QueryStatus(&pguidCmdGroup, cCmds, prgCmds, pCmdText)
+
+[<Export(typeof<IVsTextViewCreationListener>)>]
+[<ContentType("F#")>]
+[<TextViewRole(PredefinedTextViewRoles.PrimaryDocument)>]
+type NoPeekDefinitionFilterProvider [<ImportingConstructor>] 
+    ([<Import(typeof<SVsServiceProvider>)>] serviceProvider: System.IServiceProvider,
+     editorFactory: IVsEditorAdaptersFactoryService) =
+  
+    let addCommandFilter (viewAdapter: IVsTextView) (commandFilter: NoPeekDefinitionFilter) =
+        if not commandFilter.IsAdded then
+            match viewAdapter.AddCommandFilter(commandFilter) with
+            | VSConstants.S_OK, next ->
+                commandFilter.IsAdded <- true
+                match next with
+                | null -> ()
+                | _ -> commandFilter.NextTarget <- next
+            | _ -> ()
+
+    let vsVersion = 
+        lazy(let dte = serviceProvider.GetService<DTE, DTE>()
+             VisualStudioVersion.fromDTEVersion dte.Version)
+
+    interface IVsTextViewCreationListener with
+        member __.VsTextViewCreated(textViewAdapter) = 
+            let textView = editorFactory.GetWpfTextView(textViewAdapter)
+            match textView with
+            | null -> ()
+            | _ ->
+                if Setting.getGeneralOptions(serviceProvider) 
+                   |> Option.ofNull 
+                   |> Option.map (fun x -> x.PeekDefinitionEnabled) 
+                   |> Option.getOrElse false then
+                   match vsVersion.Value with
+                   | VisualStudioVersion.Unknown
+                   | VisualStudioVersion.VS2012
+                   | VisualStudioVersion.VS2013 -> 
+                        // Make sure that Peek Definition menu items are disabled on VS2013
+                        addCommandFilter textViewAdapter (new NoPeekDefinitionFilter())
+                   | _ -> ()
+        

--- a/src/FSharpVSPowerTools/UI/GeneralOptionsControl.cs
+++ b/src/FSharpVSPowerTools/UI/GeneralOptionsControl.cs
@@ -5,6 +5,7 @@ namespace FSharpVSPowerTools
 {
     public partial class GeneralOptionsControl : UserControl
     {
+        const string vs2015Suffix = " (VS2015+ only)";
         private GeneralOptionsPage _optionsPage;
         public GeneralOptionsControl(GeneralOptionsPage optionsPage)
         {
@@ -192,7 +193,8 @@ namespace FSharpVSPowerTools
             if (!_optionsPage.PeekDefinitionAvailable)
             {
                 chbPeekDefinition.Enabled = false;
-                chbPeekDefinition.Text = chbPeekDefinition.Text + " (VS2015+ only)";
+                var peekDefinitionText = chbPeekDefinition.Text;
+                chbPeekDefinition.Text = peekDefinitionText.Contains(vs2015Suffix) ? peekDefinitionText : peekDefinitionText + vs2015Suffix;
             }
         }
     }


### PR DESCRIPTION
Could you check it should not affect VS2015? I'll double check the behaviour on VS2013 tomorrow.