### PR TITLE
Fix for bug #1302

### DIFF
--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -1324,6 +1324,12 @@ module Printf =
                     result.Add res
                 | _ -> ()
                 appStack := []
+            | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.Ident op, e1, _), e2, _) ->
+                addAppWithArg { Range = e.Range; Arg = e2.Range }
+                if op.idText <> Microsoft.FSharp.Compiler.PrettyNaming.opNameEquals then
+                    addAppWithArg { Range = e.Range; Arg = e1.Range }
+                walkExpr e2
+                walkExpr e1
             | SynExpr.App (_, _, SynExpr.App(_, true, _, e1, _), e2, _) ->
                 addAppWithArg { Range = e.Range; Arg = e2.Range }
                 addAppWithArg { Range = e.Range; Arg = e1.Range }

--- a/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/UntypedAstUtils.fs
@@ -1326,7 +1326,9 @@ module Printf =
                 appStack := []
             | SynExpr.App (_, _, SynExpr.App(_, true, SynExpr.Ident op, e1, _), e2, _) ->
                 addAppWithArg { Range = e.Range; Arg = e2.Range }
-                if op.idText <> Microsoft.FSharp.Compiler.PrettyNaming.opNameEquals then
+                if op.idText = (PrettyNaming.CompileOpName "|>")
+                        || op.idText = (PrettyNaming.CompileOpName "||>")
+                        || op.idText = (PrettyNaming.CompileOpName "|||>") then
                     addAppWithArg { Range = e.Range; Arg = e1.Range }
                 walkExpr e2
                 walkExpr e1

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -119,3 +119,24 @@ let ``argument forward piped``() =
 "foo" |> failwithf "Not an object: %s"
 """
     => [2, [(35, 37), (0, 5)]]
+
+[<Test>]
+let ``class property initialiazer``() =
+    """
+System.Exception(message = sprintf "%d" 1) |> ignore
+"""
+    => [2, [(36, 38), (40, 41)]]
+
+[<Test>]
+let ``equality to forward piped``() =
+    """
+1 = 1 |> printf "%b"
+"""
+    => [2, [(17, 19), (0, 5)]]
+
+[<Test>]
+let ``constructor parameter with piped equality``() =
+    """
+System.Exception(1 = 1 |> sprintf "%b") |> ignore
+"""
+    => [2, [(35, 37), (17, 22)]]

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -128,6 +128,13 @@ System.Exception(message = sprintf "%d" 1) |> ignore
     => [2, [(36, 38), (40, 41)]]
 
 [<Test>]
+let ``class property initialiazer with infix to forward pipe``() =
+    """
+System.Exception(message = (1 * 1 |> sprintf "%d")) |> ignore
+"""
+    => [2, [(46, 48), (28, 33)]]
+
+[<Test>]
 let ``equality to forward piped``() =
     """
 1 = 1 |> printf "%b"
@@ -140,3 +147,31 @@ let ``constructor parameter with piped equality``() =
 System.Exception(1 = 1 |> sprintf "%b") |> ignore
 """
     => [2, [(35, 37), (17, 22)]]
+
+[<Test>]
+let ``constructor argument with greater than``() =
+    """
+System.Exception(("" > sprintf "%d" 1).ToString())
+"""
+    => [2, [(32, 34), (36, 37)]]
+
+[<Test>]
+let ``constructor argument with addition than``() =
+    """
+System.Exception(("" + sprintf "%d" 1).ToString())
+"""
+    => [2, [(32, 34), (36, 37)]]
+
+[<Test>]
+let ``division to forward piped``() =
+    """
+1 / 1 |> printf "%d"
+"""
+    => [2, [(17, 19), (0, 5)]]
+
+[<Test>]
+let ``multiply and division to forward piped``() =
+    """
+1 * 1 / 1 |> printf "%d"
+"""
+    => [2, [(21, 23), (0, 9)]]


### PR DESCRIPTION
Resolves #1302. No longer add the individual argument when the expression is an equality operation when evaluating `Printf.getAll`. Added some other tests which identified an issue of `Printf.getAll` not returning any functions when the equality operator is present.