### PR TITLE
Deconstruct tuples when using foward pipe 2/3 with printf.

### DIFF
--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -175,3 +175,20 @@ let ``multiply and division to forward piped``() =
 1 * 1 / 1 |> printf "%d"
 """
     => [2, [(21, 23), (0, 9)]]
+
+[<Test>]
+let ``forward pipe 2 deconstructs tuple``() =
+    """
+(1, 2) ||> sprintf "%d %d"
+"""
+    => [2, [(20, 22), (1, 2)
+            (23, 25), (4, 5)]]
+
+[<Test>]
+let ``forward pipe 3 deconstructs tuple``() =
+    """
+(1, 2, 3) |||> sprintf "%d %d %d"
+"""
+    => [2, [(24, 26), (1, 2)
+            (27, 29), (4, 5)
+            (30, 32), (7, 8)]]


### PR DESCRIPTION
Resolves #1306
![deconstructed](https://cloud.githubusercontent.com/assets/4616153/12075331/2a9b303e-b142-11e5-8d12-a68903e4e39c.PNG)

