### PR TITLE
Prioritize the args on the right side of printf statement.

### DIFF
--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -34,9 +34,15 @@ let getAll (input: ParseAndCheckResults) (onError: string -> unit): PrintfSpecif
                         onError (sprintf "Too many Printf arguments for %+A (%d > %d)" 
                                          func func.Args.Length ownSpecifiers.Length)
                     
+                    let prioritizeArgPos pos = 
+                        Array.partition (fun a -> Range.rangeBeforePos a pos)
+                        >> function (l, r) -> [| r |> Array.sortBy startPos
+                                                 l |> Array.sortBy startPos |]
+                                              |> Array.concat
+
                     let uses = 
                         func.Args
-                        |> Array.sortBy startPos
+                        |> prioritizeArgPos ownSpecifiers.[0].Start
                         |> Array.zip (ownSpecifiers.[0..func.Args.Length - 1] |> Array.sortBy startPos)
                         |> Array.map (fun (specifier, arg) -> { SpecifierRange = specifier; ArgumentRange = arg })
                     restSpecifiers, uses :: acc

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -192,3 +192,39 @@ let ``forward pipe 3 deconstructs tuple``() =
     => [2, [(24, 26), (1, 2)
             (27, 29), (4, 5)
             (30, 32), (7, 8)]]
+
+[<Test>]
+let ``forward pipe with right hand argument``() =
+    """
+2 |> sprintf "%d %d" 1
+"""
+    => [2, [(14, 16), (21, 22)
+            (17, 19), (0, 1)]]
+
+[<Test>]
+let ``forward pipe with multiple right hand arguments``() =
+    """
+3 |> sprintf "%d %d %d" 1 2
+"""
+    => [2, [(14, 16), (24, 25)
+            (17, 19), (26, 27)
+            (20, 22), (0, 1)]]
+
+[<Test>]
+let ``forward pipe 2 deconstructs tuple with right hand argument``() =
+    """
+(2, 3) ||> sprintf "%d %d %d" 1
+"""
+    => [2, [(20, 22), (30, 31)
+            (23, 25), (1, 2)
+            (26, 28), (4, 5)]]
+
+[<Test>]
+let ``forward pipe 3 deconstructs tuple with right hand argument``() =
+    """
+(2, 3, 4) |||> sprintf "%d %d %d %d" 1
+"""
+    => [2, [(24, 26), (37, 38)
+            (27, 29), (1, 2)
+            (30, 32), (4, 5)
+            (33, 35), (7, 8)]]


### PR DESCRIPTION
Resolves #1308. Partitioning the args into left and right side, sorting each side, and combining them right side first. (With tests)
![prioritize-args-right-of](https://cloud.githubusercontent.com/assets/4616153/12076217/fe64b808-b166-11e5-9176-01ada9367e03.PNG)
