### PR TITLE
Ignore any extra args to printf.

### DIFF
--- a/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
+++ b/src/FSharpVSPowerTools.Core/PrintfSpecifiersUsageGetter.fs
@@ -40,10 +40,13 @@ let getAll (input: ParseAndCheckResults) (onError: string -> unit): PrintfSpecif
                                                  l |> Array.sortBy startPos |]
                                               |> Array.concat
 
+                    let m = min func.Args.Length ownSpecifiers.Length
+
                     let uses = 
                         func.Args
                         |> prioritizeArgPos ownSpecifiers.[0].Start
-                        |> Array.zip (ownSpecifiers.[0..func.Args.Length - 1] |> Array.sortBy startPos)
+                        |> function args -> args.[0..m - 1]
+                        |> Array.zip (ownSpecifiers.[0..m - 1] |> Array.sortBy startPos)
                         |> Array.map (fun (specifier, arg) -> { SpecifierRange = specifier; ArgumentRange = arg })
                     restSpecifiers, uses :: acc
                ) (specifierRanges, [])

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -250,3 +250,17 @@ let ``too many args with forward-pipe 2 should ignore extra args``() =
 """
     => [2, [(19, 21), (26, 27)
             (22, 24), (1, 2)]]
+
+[<Test>]
+let ``backwards pipe with equal specifiers and args``() =
+    """
+ignore <| sprintf "%d" 1
+"""
+    => [2, [(19, 21), (23, 24)]]
+
+[<Test>]
+let ``backwards pipe with too many args``() =
+    """
+ignore <| sprintf "%d" 1 2
+"""
+    => [2, [(19, 21), (23, 24)]]

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -228,3 +228,25 @@ let ``forward pipe 3 deconstructs tuple with right hand argument``() =
             (27, 29), (1, 2)
             (30, 32), (4, 5)
             (33, 35), (7, 8)]]
+
+[<Test>]
+let ``too many args should ignore extra args``() =
+    """
+printf "%d" 1 2
+"""
+    => [2, [(8, 10), (12, 13)]]
+
+[<Test>]
+let ``too many args with forward-pipe should ignore extra args``() =
+    """
+3 |> printf "%d" 1 2
+"""
+    => [2, [(13, 15), (17, 18)]]
+
+[<Test>]
+let ``too many args with forward-pipe 2 should ignore extra args``() =
+    """
+(2, 3) ||> printf "%d %d" 1
+"""
+    => [2, [(19, 21), (26, 27)
+            (22, 24), (1, 2)]]


### PR DESCRIPTION
Resolves #1274. Uses the minimum length between args and specifiers for zipping them. This eliminates the "index out of bounds" exception.
![invalid-printf](https://cloud.githubusercontent.com/assets/4616153/12080649/d0220e4e-b226-11e5-946f-0ce5860910b6.PNG)
