### PR TITLE
use ordinal comparison

### DIFF
--- a/src/FSharpVSPowerTools.Logic/NavigableItemCache.fs
+++ b/src/FSharpVSPowerTools.Logic/NavigableItemCache.fs
@@ -25,7 +25,7 @@ type FileNavigableItems =
       Items: NavigableItem[] }
 
 type NavigableItemCache (serviceProvider: System.IServiceProvider) =
-    let cache = ConcurrentDictionary<FilePath, FileNavigableItems>()
+    let cache = ConcurrentDictionary<FilePath, FileNavigableItems>(StringComparer.Ordinal)
     let dirty = ref false
     let pickler = FsPickler.CreateBinarySerializer()
 


### PR DESCRIPTION
faster than default string comparison
```
        Method | IntParam |     AvrTime |     Error |
-------------- |--------- |------------ |---------- |
 OrdinalLookup |      100 |   7.7663 us | 0.0590 us |
StandardLookup |      100 |   8.2045 us | 0.0783 us |
 OrdinalLookup |      500 |  39.7000 us | 0.3316 us |
StandardLookup |      500 |  43.7694 us | 0.5245 us |
 OrdinalLookup |     1000 |  83.1213 us | 0.7483 us |
StandardLookup |     1000 |  88.5324 us | 0.8636 us |
 OrdinalLookup |     2000 | 176.3799 us | 1.4058 us |
StandardLookup |     2000 | 192.9319 us | 2.2289 us |
```