### PR TITLE
Enable peek definition menus on standalone F# files

### DIFF
--- a/src/FSharpVSPowerTools.Logic/CodeGenerationUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/CodeGenerationUtils.fs
@@ -1,5 +1,5 @@
 ﻿[<AutoOpen>]
-module FSharpVSPowerTools.Refactoring.Utils
+module FSharpVSPowerTools.Refactoring.CodeGenerationUtils
 
 type ISuggestion =
     abstract Text: string

--- a/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
+++ b/src/FSharpVSPowerTools.Logic/FSharpVSPowerTools.Logic.fsproj
@@ -208,8 +208,8 @@
     <Compile Include="FolderMenuCommands.fs">
       <Link>FolderCommand/FolderMenuCommands.fs</Link>
     </Compile>
-    <Compile Include="Utils.fs">
-      <Link>CodeGeneration/Utils.fs</Link>
+    <Compile Include="CodeGenerationUtils.fs">
+      <Link>CodeGeneration/CodeGenerationUtils.fs</Link>
     </Compile>
     <Compile Include="CodeGenerationService.fs">
       <Link>CodeGeneration/CodeGenerationService.fs</Link>

--- a/src/FSharpVSPowerTools.Logic/FindReferencesFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/FindReferencesFilter.fs
@@ -125,14 +125,15 @@ type FindReferencesFilter
                 let statusBar = serviceProvider.GetService<IVsStatusbar, SVsStatusbar>()
                 statusBar.SetText(msg) |> ignore 
         } |> Async.StartImmediateSafe
-
-    member val IsAdded = false with get, set
-    member val NextTarget: IOleCommandTarget = null with get, set
-    
-    interface IOleCommandTarget with
+ 
+    interface IMenuCommand with
+        member val IsAdded = false with get, set
+        member val NextTarget = null with get, set
+   
         member x.Exec(pguidCmdGroup: byref<Guid>, nCmdId: uint32, nCmdexecopt: uint32, pvaIn: IntPtr, pvaOut: IntPtr) =
             if (pguidCmdGroup = Constants.guidOldStandardCmdSet && nCmdId = Constants.cmdidFindReferences) then
                 findReferences ()
+            let x = x :> IMenuCommand
             let nextTarget = x.NextTarget
             if nextTarget <> null then
                 nextTarget.Exec(&pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut)
@@ -145,6 +146,7 @@ type FindReferencesFilter
                 prgCmds.[0].cmdf <- (uint32 OLECMDF.OLECMDF_SUPPORTED) ||| (uint32 OLECMDF.OLECMDF_ENABLED)
                 VSConstants.S_OK
             else
+                let x = x :> IMenuCommand
                 let nextTarget = x.NextTarget
                 if nextTarget <> null then
                     nextTarget.QueryStatus(&pguidCmdGroup, cCmds, prgCmds, pCmdText)            

--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -473,14 +473,15 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
     static member ClearXmlDocCache() =
         xmlDocCache.Clear()
 
-    member val IsAdded = false with get, set
-    member val NextTarget: IOleCommandTarget = null with get, set
-
     member internal __.UrlChanged = urlChanged |> Option.map (fun event -> event.Publish)
     member internal __.CurrentUrl = currentUrl
 
-    interface IOleCommandTarget with
+    interface IMenuCommand with
+        member val IsAdded = false with get, set
+        member val NextTarget = null with get, set
+
         member x.Exec(pguidCmdGroup: byref<Guid>, nCmdId: uint32, nCmdexecopt: uint32, pvaIn: IntPtr, pvaOut: IntPtr) =
+            let x = x :> IMenuCommand
             if pguidCmdGroup = Constants.guidOldStandardCmdSet && nCmdId = Constants.cmdidGoToDefinition then
                 let nextTarget = x.NextTarget
                 let cmdGroup = ref pguidCmdGroup
@@ -496,6 +497,7 @@ type GoToDefinitionFilter(textDocument: ITextDocument,
                 prgCmds.[0].cmdf <- (uint32 OLECMDF.OLECMDF_SUPPORTED) ||| (uint32 OLECMDF.OLECMDF_ENABLED)
                 VSConstants.S_OK
             else
+                let x = x :> IMenuCommand
                 x.NextTarget.QueryStatus(&pguidCmdGroup, cCmds, prgCmds, pCmdText)
                 
     interface IDisposable with

--- a/src/FSharpVSPowerTools.Logic/NoPeekDefinitionFilterProvider.fs
+++ b/src/FSharpVSPowerTools.Logic/NoPeekDefinitionFilterProvider.fs
@@ -12,11 +12,6 @@ open Microsoft.VisualStudio.Utilities
 open Microsoft.VisualStudio.Shell
 open EnvDTE
 
-type IMenuCommand =
-    inherit IOleCommandTarget
-    abstract IsAdded: bool with get, set
-    abstract NextTarget: IOleCommandTarget with get, set
-
 type NoPeekDefinitionFilter() =
     interface IMenuCommand with
         member val IsAdded = false with get, set
@@ -101,7 +96,7 @@ type NoPeekDefinitionFilterProvider [<ImportingConstructor>]
                    | VisualStudioVersion.VS2012
                    | VisualStudioVersion.VS2013 -> 
                         // Make sure that Peek Definition menu items are disabled on VS2013
-                        addCommandFilter textViewAdapter (new NoPeekDefinitionFilter())
+                        addCommandFilter textViewAdapter (NoPeekDefinitionFilter())
                    | _ -> 
-                        addCommandFilter textViewAdapter (new AlwaysPeekDefinitionFilter())
+                        addCommandFilter textViewAdapter (AlwaysPeekDefinitionFilter())
         

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningFilter.fs
@@ -5,12 +5,13 @@ open FSharpVSPowerTools
 open Microsoft.VisualStudio
 
 type OutliningFilter() =
-    member val IsAdded = false with get, set
-    member val NextTarget: IOleCommandTarget = null with get, set
+    interface IMenuCommand with
+        member val IsAdded = false with get, set
+        member val NextTarget = null with get, set
 
-    interface IOleCommandTarget with
         member x.Exec (pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut) =
             // We don't have to do anything here since most of the things are handled by VS.
+            let x = x :> IMenuCommand
             x.NextTarget.Exec (&pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut)
 
         member x.QueryStatus (pguidCmdGroup, cCmds, prgCmds, pCmdText) =
@@ -26,4 +27,5 @@ type OutliningFilter() =
                 prgCmds.[0].cmdf <- uint32 (OLECMDF.OLECMDF_SUPPORTED ||| OLECMDF.OLECMDF_ENABLED)
                 VSConstants.S_OK
             else
+                let x = x :> IMenuCommand
                 x.NextTarget.QueryStatus(&pguidCmdGroup, cCmds, prgCmds, pCmdText)

--- a/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
@@ -145,13 +145,14 @@ type RenameCommandFilter(textDocument: ITextDocument,
         finally
             vsShell.EnableModeless(1) |> ignore
 
-    member val IsAdded = false with get, set
-    member val NextTarget: IOleCommandTarget = null with get, set
+    interface IMenuCommand with
+        member val IsAdded = false with get, set
+        member val NextTarget = null with get, set
 
-    interface IOleCommandTarget with
         member x.Exec (pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut) =
             if (pguidCmdGroup = Constants.guidStandardCmdSet && nCmdId = Constants.cmdidStandardRenameCommand) && canRename() then
                 x.HandleRename() |> ignore
+            let x = x :> IMenuCommand
             x.NextTarget.Exec(&pguidCmdGroup, nCmdId, nCmdexecopt, pvaIn, pvaOut)
 
         member x.QueryStatus (pguidCmdGroup, cCmds, prgCmds, pCmdText) =
@@ -160,4 +161,5 @@ type RenameCommandFilter(textDocument: ITextDocument,
                 prgCmds.[0].cmdf <- (uint32 OLECMDF.OLECMDF_SUPPORTED) ||| (uint32 OLECMDF.OLECMDF_ENABLED)
                 VSConstants.S_OK
             else
+                let x = x :> IMenuCommand
                 x.NextTarget.QueryStatus(&pguidCmdGroup, cCmds, prgCmds, pCmdText)

--- a/src/FSharpVSPowerTools.Logic/Setting.fs
+++ b/src/FSharpVSPowerTools.Logic/Setting.fs
@@ -96,7 +96,7 @@ type IOutliningOptions =
     abstract TooltipZoomLevel: int with get, set
 
 [<AutoOpen>]
-module Utils =
+module ServiceProviderUtils =
     type System.IServiceProvider with
         member x.GetService<'T>() = x.GetService(typeof<'T>) :?> 'T
         member x.GetService<'T, 'S>() = x.GetService(typeof<'S>) :?> 'T

--- a/src/FSharpVSPowerTools.Logic/TaskListManager.fs
+++ b/src/FSharpVSPowerTools.Logic/TaskListManager.fs
@@ -3,7 +3,7 @@
 open Microsoft.VisualStudio.Shell
 open Microsoft.VisualStudio
 open System
-open FSharpVSPowerTools.ProjectSystem
+open FSharpVSPowerTools
 open System.ComponentModel.Composition
 
 [<Export>]

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -1,5 +1,5 @@
 ﻿[<AutoOpen>]
-module FSharpVSPowerTools.ProjectSystem.VSUtils
+module FSharpVSPowerTools.VSUtils
 
 open System
 open FSharpVSPowerTools
@@ -12,7 +12,7 @@ type String with
     /// Return substring starting at index, returns the same string if given a negative index
     /// if given an index > string.Length returns empty string
     member self.SubstringSafe index =
-        if   index < 0 then self elif index > self.Length then "" else self.Substring index
+        if index < 0 then self elif index > self.Length then "" else self.Substring index
 
 open System.Diagnostics
 open Microsoft.VisualStudio.Text
@@ -525,3 +525,10 @@ let listFSharpProjectsInSolution (dte: DTE) =
 
     [ for p in dte.Solution.Projects do
         yield! handleProject p ]
+
+open Microsoft.VisualStudio.OLE.Interop
+
+type IMenuCommand =
+    inherit IOleCommandTarget
+    abstract IsAdded: bool with get, set
+    abstract NextTarget: IOleCommandTarget with get, set

--- a/src/FSharpVSPowerTools/Commands/FindReferencesFilterProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/FindReferencesFilterProvider.cs
@@ -57,7 +57,7 @@ namespace FSharpVSPowerTools
             {
                 var filter = new FindReferencesFilter(doc, textView, _fsharpVsLanguageService,
                                                 _serviceProvider, _projectFactory, showProgress, _fileSystem);
-                AddCommandFilter(textViewAdapter, filter);
+                Utils.AddCommandFilter(textViewAdapter, filter);
                 return filter;
             }
             return null;
@@ -66,23 +66,6 @@ namespace FSharpVSPowerTools
         public void TextViewCreated(IWpfTextView textView)
         {
             RegisterCommandFilter(textView, showProgress: true);
-        }
-
-        private static void AddCommandFilter(IVsTextView viewAdapter, FindReferencesFilter commandFilter)
-        {
-            if (!commandFilter.IsAdded)
-            {
-                // Get the view adapter from the editor factory
-                IOleCommandTarget next;
-                int hr = viewAdapter.AddCommandFilter(commandFilter, out next);
-
-                if (hr == VSConstants.S_OK)
-                {
-                    commandFilter.IsAdded = true;
-                    // You'll need the next target for Exec and QueryStatus
-                    if (next != null) commandFilter.NextTarget = next;
-                }
-            }
         }
     }
 }

--- a/src/FSharpVSPowerTools/Commands/GotoDefinitionFilterProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/GotoDefinitionFilterProvider.cs
@@ -106,27 +106,10 @@ namespace FSharpVSPowerTools
                 if (!_referenceSourceProvider.IsActivated && generalOptions.GoToSymbolSourceEnabled)
                     _referenceSourceProvider.Activate();
                 textView.Properties.AddProperty(serviceType, commandFilter);
-                AddCommandFilter(textViewAdapter, commandFilter);
+                Utils.AddCommandFilter(textViewAdapter, commandFilter);
                 return commandFilter;
             }
             return null;
-        }
-
-        private static void AddCommandFilter(IVsTextView viewAdapter, GoToDefinitionFilter commandFilter)
-        {
-            if (!commandFilter.IsAdded)
-            {
-                // Get the view adapter from the editor factory
-                IOleCommandTarget next;
-                int hr = viewAdapter.AddCommandFilter(commandFilter, out next);
-
-                if (hr == VSConstants.S_OK)
-                {
-                    commandFilter.IsAdded = true;
-                    // You'll need the next target for Exec and QueryStatus
-                    if (next != null) commandFilter.NextTarget = next;
-                }
-            }
         }
 
         public void SubjectBuffersConnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)

--- a/src/FSharpVSPowerTools/Commands/HighlightUsageFilterProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/HighlightUsageFilterProvider.cs
@@ -44,25 +44,8 @@ namespace FSharpVSPowerTools
             var generalOptions = Setting.getGeneralOptions(_serviceProvider);
             if (generalOptions == null || !generalOptions.HighlightUsageEnabled) return;
             
-            AddCommandFilter(textViewAdapter,
+            Utils.AddCommandFilter(textViewAdapter,
                 new HighlightUsageFilter(textView, _tagAggregator.CreateTagAggregator<TextMarkerTag>(textView)));            
-        }
-
-        private static void AddCommandFilter(IVsTextView viewAdapter, HighlightUsageFilter commandFilter)
-        {
-            if (!commandFilter.IsAdded)
-            {
-                // Get the view adapter from the editor factory
-                IOleCommandTarget next;
-                int hr = viewAdapter.AddCommandFilter(commandFilter, out next);
-
-                if (hr == VSConstants.S_OK)
-                {
-                    commandFilter.IsAdded = true;
-                    // You'll need the next target for Exec and QueryStatus
-                    if (next != null) commandFilter.NextTarget = next;
-                }
-            }
         }
     }
 }

--- a/src/FSharpVSPowerTools/Commands/OutliningFilterProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/OutliningFilterProvider.cs
@@ -32,23 +32,6 @@ namespace FSharpVSPowerTools.Outlining
             _editorFactory = editorFactory;
         }
 
-        private static void AddCommandFilter(IVsTextView viewAdapter, OutliningFilter commandFilter)
-        {
-            if (!commandFilter.IsAdded)
-            {
-                // Get the view adapter from the editor factory
-                IOleCommandTarget next;
-                int hr = viewAdapter.AddCommandFilter(commandFilter, out next);
-
-                if (hr == VSConstants.S_OK)
-                {
-                    commandFilter.IsAdded = true;
-                    // You'll need the next target for Exec and QueryStatus
-                    if (next != null) commandFilter.NextTarget = next;
-                }
-            }
-        }
-
         public void VsTextViewCreated(IVsTextView textViewAdapter)
         {
             var textView = _editorFactory.GetWpfTextView(textViewAdapter);
@@ -57,7 +40,7 @@ namespace FSharpVSPowerTools.Outlining
             var generalOptions = Setting.getGeneralOptions(_serviceProvider);
             if (generalOptions == null || !generalOptions.OutliningEnabled) return;
 
-            AddCommandFilter(textViewAdapter, new OutliningFilter());
+            Utils.AddCommandFilter(textViewAdapter, new OutliningFilter());
         }
     }
 }

--- a/src/FSharpVSPowerTools/Commands/RenameCommandFilterProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/RenameCommandFilterProvider.cs
@@ -52,28 +52,10 @@ namespace FSharpVSPowerTools
             ITextDocument doc;
             if (_textDocumentFactoryService.TryGetTextDocument(textView.TextBuffer, out doc))
             {
-                AddCommandFilter(textViewAdapter,
+                Utils.AddCommandFilter(textViewAdapter,
                     new RenameCommandFilter(doc, textView, _fsharpVsLanguageService,
                                             _serviceProvider, _projectFactory));
             }
         }
-
-        private static void AddCommandFilter(IVsTextView viewAdapter, RenameCommandFilter commandFilter)
-        {
-            if (!commandFilter.IsAdded)
-            {
-                // Get the view adapter from the editor factory
-                IOleCommandTarget next;
-                int hr = viewAdapter.AddCommandFilter(commandFilter, out next);
-
-                if (hr == VSConstants.S_OK)
-                {
-                    commandFilter.IsAdded = true;
-                    // You'll need the next target for Exec and QueryStatus
-                    if (next != null) commandFilter.NextTarget = next;
-                }
-            }
-        }
-
     }
 }

--- a/src/FSharpVSPowerTools/Commands/Utils.cs
+++ b/src/FSharpVSPowerTools/Commands/Utils.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FSharpVSPowerTools
+{
+    public class Utils
+    {
+        public static void AddCommandFilter(IVsTextView viewAdapter, VSUtils.IMenuCommand commandFilter)
+        {
+            if (!commandFilter.IsAdded)
+            {
+                // Get the view adapter from the editor factory
+                IOleCommandTarget next;
+                int hr = viewAdapter.AddCommandFilter(commandFilter, out next);
+
+                if (hr == VSConstants.S_OK)
+                {
+                    commandFilter.IsAdded = true;
+                    // You'll need the next target for Exec and QueryStatus
+                    if (next != null) commandFilter.NextTarget = next;
+                }
+            }
+        }
+    }
+}

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Commands\OutliningFilterProvider.cs" />
     <Compile Include="Commands\PrintfSpecifiersUsageTaggerProvider.cs" />
     <Compile Include="Commands\OutliningTaggerProvider.cs" />
+    <Compile Include="Commands\Utils.cs" />
     <Compile Include="Resources\FSharpVSPowerTools.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
Fix #1313.

Only verify on VS2013 that menu items show up. I need help to check that it works properly for standalone F# files in VS2015.