### PR TITLE
Updated lint settings to support user wide settings

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -7,7 +7,7 @@ NUGET
     FSharp.Compiler.Service (2.0.0.3)
     FSharp.Management (0.3.0)
     FSharp.ViewModule.Core (0.9.9.1)
-    FSharpLint.Core (0.0.13)
+    FSharpLint.Core (0.0.15-beta)
       FSharp.Compiler.Service (>= 1.4.2.1)
     FsPickler (1.5.2)
     FsXaml.Wpf (0.9.9)

--- a/src/FSharpVSPowerTools.Logic/LintTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/LintTagger.fs
@@ -22,8 +22,10 @@ type LintTagger(textDocument: ITextDocument,
     let mutable wordSpans = []
     let buffer = textDocument.TextBuffer
 
-    let lintData = lazy(
-        let lintOptions = SettingsContext.getLintOptions serviceProvider
+    let lintOptions = lazy(SettingsContext.getLintOptions serviceProvider)
+
+    let getLintData () =
+        let lintOptions = lintOptions.Value
         lintOptions.UpdateDirectories()
         let config = Path.GetDirectoryName textDocument.FilePath |> lintOptions.GetConfigurationForDirectory
         let shouldFileBeIgnored =
@@ -33,7 +35,7 @@ type LintTagger(textDocument: ITextDocument,
                     ignoreFiles.Files
                     textDocument.FilePath
             | None -> false
-        config, shouldFileBeIgnored)
+        config, shouldFileBeIgnored
 
     let dte = serviceProvider.GetDte()
     let version = dte.Version |> VisualStudioVersion.fromDTEVersion |> VisualStudioVersion.toBestMatchFSharpVersion 
@@ -44,7 +46,7 @@ type LintTagger(textDocument: ITextDocument,
             let! project = projectFactory.CreateForDocument buffer doc 
             let! parseFileResults = vsLanguageService.ParseFileInProject (doc.FullName, project)
             let! ast = parseFileResults.ParseTree
-            let config, shouldFileBeIgnored = lintData.Value
+            let config, shouldFileBeIgnored = getLintData()
             let! source = openDocumentsTracker.TryGetDocumentText doc.FullName
 
             if not shouldFileBeIgnored then

--- a/src/FSharpVSPowerTools.Logic/Linting/FileViewModel.fs
+++ b/src/FSharpVSPowerTools.Logic/Linting/FileViewModel.fs
@@ -3,14 +3,13 @@
 open System.IO
 open FSharpLint.Framework.Configuration
 open FSharpLint.Framework.Configuration.Management
-open FSharpVSPowerTools
 
-type FileViewModel(name:string, path:Path, files:FileViewModel seq, hasConfigFile:bool) =
+type FileViewModel(name:string, path:Path, childFiles:FileViewModel seq, hasConfigFile:bool, isUserWideSettings:bool) =
     member __.Name = name
 
-    member __.Path = path
+    member __.IsUserWideSettings = isUserWideSettings
 
-    member __.Files = files
+    member __.Files = childFiles
 
     member __.HasConfigFile = hasConfigFile
 
@@ -18,5 +17,4 @@ type FileViewModel(name:string, path:Path, files:FileViewModel seq, hasConfigFil
         let directorySeparator = Path.DirectorySeparatorChar.ToString()
         (String.concat directorySeparator path) + directorySeparator
 
-    member this.GetFilePath() =
-        this.GetDirectory() </> SettingsFileName
+    static member GlobalSettings(name, path) = FileViewModel(name, path, [], true, true)

--- a/src/FSharpVSPowerTools.Logic/Linting/LintOptionsPage.fs
+++ b/src/FSharpVSPowerTools.Logic/Linting/LintOptionsPage.fs
@@ -57,10 +57,6 @@ type LintOptionsPage private (dte:EnvDTE.DTE option) =
         member __.GetConfigurationForDirectory(dir) =
             getConfigForDirectory loadedConfigs dir
 
-        // TODO - placeholders
-        member __.Save () = ()
-        member __.Load () = ()
-
     member private this.Dte =
         match dte with
         | Some dte -> dte

--- a/src/FSharpVSPowerTools.Logic/Linting/LintOptionsPage.fs
+++ b/src/FSharpVSPowerTools.Logic/Linting/LintOptionsPage.fs
@@ -21,7 +21,13 @@ type LintOptionsPage private (dte:EnvDTE.DTE option) =
     [<Literal>]
     let MessageBoxRetryButtonClicked = 4
 
-    let mutable loadedConfigs = LoadedConfigs.Empty
+    let mutable loadedConfigs = 
+        let userConfig = 
+            { Name = "User Wide Settings"
+              Path = getUserSettingsDirectory () |> normalisePath
+              Configuration = None }
+
+        { LoadedConfigs.Empty with GlobalConfigs = [userConfig] }
 
     let lintOptionsPageControl = lazy LintOptionsControlProvider()
 
@@ -94,27 +100,19 @@ type LintOptionsPage private (dte:EnvDTE.DTE option) =
             loadedConfigs <- refresh tryLoadConfig loadedConfigs
 
             let lintOptions =
-                match getInitialPath dte loadedConfigs with
-                | Some(path) ->
-                    let files = getFileHierarchy loadedConfigs
+                let files = getFileHierarchy loadedConfigs
 
-                    let rec getFileViewModel files =
-                        let getFile (file: FileViewModel) =
-                            if file.Path = path then Some file 
-                            else getFileViewModel file.Files
+                let fileSelectedByDefault = 
+                    files |> List.tryFind (fun (file:FileViewModel) -> file.IsUserWideSettings)
 
-                        Seq.tryPick getFile files
-
-                    match getFileViewModel files with
-                    | Some file ->
-                        OptionsViewModel(
-                            (getConfigForDirectory loadedConfigs),
-                            files,
-                            file) |> Some
-                    | None -> 
-                        Debug.Assert(false, "No file view model for the initial file found.")
-                        None
+                match fileSelectedByDefault with
+                | Some file ->
+                    OptionsViewModel(
+                        getConfigForDirectory loadedConfigs,
+                        files,
+                        file) |> Some
                 | None -> 
+                    Debug.Assert(false, "No file view model for the initial file found.")
                     None
 
             lintOptionsPageControl.Value.DataContext <- 

--- a/src/FSharpVSPowerTools.Logic/Linting/LintUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/Linting/LintUtils.fs
@@ -51,9 +51,6 @@ module LintUtils =
     let updateLoadedConfigs dte loadedConfigs =
         updatePaths tryLoadConfig loadedConfigs (getProjectPaths dte)
 
-    let getInitialLoadedConfigs dte =
-        updateLoadedConfigs dte LoadedConfigs.Empty
-
     let private directorySeparator = Path.DirectorySeparatorChar.ToString()
 
     let rec private listStartsWith = function
@@ -70,25 +67,21 @@ module LintUtils =
                 if List.length path = List.length currentPath + 1 && listStartsWith (path, currentPath) then
                     let lastSegment = Seq.last path + directorySeparator
                     let hasConfig = Option.isSome config
-                    yield FileViewModel(lastSegment, path, createFileViewModel path, hasConfig)]
+                    yield FileViewModel(lastSegment, path, createFileViewModel path, hasConfig, false)]
 
-        [ for (path, config) in files do
+        [ for globalConfig in loadedConfigs.GlobalConfigs do 
+            yield FileViewModel.GlobalSettings(globalConfig.Name, globalConfig.Path)
+
+          for (path, config) in files do
             match path with
             | [root] -> 
                 let hasConfig = Option.isSome config
                 yield FileViewModel(root + directorySeparator, 
                                     path,
                                     createFileViewModel path, 
-                                    hasConfig)
+                                    hasConfig,
+                                    false)
             | _ -> () ]
-                    
-    let getInitialPath dte loadedConfigs =
-        getSolutionPath dte
-        |> Option.bind (fun solutionPath ->
-            commonPath loadedConfigs solutionPath
-            |> Option.orElse (Some solutionPath))
-        |> Option.orTry (fun _ ->
-            getProjectPaths dte |> List.tryHead)
 
     let getConfigForDirectory loadedConfigs directory =
         normalisePath directory

--- a/src/FSharpVSPowerTools.Logic/Linting/OptionsViewModel.fs
+++ b/src/FSharpVSPowerTools.Logic/Linting/OptionsViewModel.fs
@@ -202,8 +202,6 @@ type OptionsViewModel(getConfigForDirectory, files, selectedFile:FileViewModel) 
     let rules = SetupViewModels.ruleViewModelsFromConfig config
     
     let selectedRule = this.Factory.Backing(<@ this.SelectedRule @>, None)
-
-    let currentFilePath = this.Factory.Backing(<@ this.CurrentFilePath @>, selectedDirectory)
     
     let selectedFile = this.Factory.Backing(<@ this.SelectedFile @>, selectedFile)
 
@@ -211,7 +209,11 @@ type OptionsViewModel(getConfigForDirectory, files, selectedFile:FileViewModel) 
         with get() : RuleViewModel option = selectedRule.Value
         and set (value) = selectedRule.Value <- value
 
-    member __.CurrentFilePath = currentFilePath.Value
+    member __.FullName =
+        if selectedFile.Value.IsUserWideSettings then selectedFile.Value.Name
+        else selectedDirectory
+
+    member __.CurrentFilePath = selectedDirectory
     
     member __.Files = files
 

--- a/src/FSharpVSPowerTools.Logic/Setting.fs
+++ b/src/FSharpVSPowerTools.Logic/Setting.fs
@@ -40,11 +40,15 @@ module StoreUtils =
 
         Path.Combine (folder, filename)
 
+    let getUserSettingsDirectory () =
+        let dir = Path.Combine(Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), @".config/.vfpt")
+        if not (Directory.Exists dir) then Directory.CreateDirectory dir |> ignore
+        dir        
+
     let defaultSettingsPath = configurePath ""
 
     let writerSettings =
         XmlWriterSettings (Indent=true, NewLineOnAttributes=true, Async=true, WriteEndDocumentOnClose=true)
-
 
 type ISettingsStore =
     abstract member Get : name:string -> string option

--- a/src/FSharpVSPowerTools.Logic/Setting.fs
+++ b/src/FSharpVSPowerTools.Logic/Setting.fs
@@ -513,9 +513,6 @@ type GlobalOptions  () as self =
 type ILintOptions =
     abstract UpdateDirectories: unit -> unit
     abstract GetConfigurationForDirectory: string -> FSharpLint.Framework.Configuration.Configuration
-    abstract Load : unit -> unit
-    abstract Save : unit -> unit
-
 
 type IOutliningOptions =
     abstract OpensEnabled                           :   bool with get, set

--- a/src/FSharpVSPowerTools/PowerToolsCommandsPackage.cs
+++ b/src/FSharpVSPowerTools/PowerToolsCommandsPackage.cs
@@ -53,6 +53,10 @@ namespace FSharpVSPowerTools
             var generalOptions = SettingsContext.GeneralOptions;
             PerformRegistrations(generalOptions);
 
+            IServiceContainer serviceContainer = this;
+            serviceContainer.AddService(typeof(ILintOptions),
+                delegate { return GetDialogPage(typeof(Linting.LintOptionsPage)); }, promote: true);
+
             library = new FSharpLibrary(Constants.guidSymbolLibrary);
             library.LibraryCapabilities = (_LIB_FLAGS2)_LIB_FLAGS.LF_PROJECT;
 


### PR DESCRIPTION
Work on @cloudRoutine's branch to move the lint settings towards using the user wide location that the new xml settings use. I've kept the addition of the lint settings into the container in: `PowerToolsCommandsPackage.cs` to get the lint settings interface into the lint settings dialog (instantiated by VS) 