### PR TITLE
Handle 0-arity and multi-arity printf specifiers

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -4,7 +4,7 @@ NUGET
     Expression.Blend.Sdk (1.0.2)
     Fantomas (2.0.2)
       FSharp.Compiler.Service (>= 1.4.0.6)
-    FSharp.Compiler.Service (2.0.0.3)
+    FSharp.Compiler.Service (2.0.0.5)
     FSharp.Management (0.3.0)
     FSharp.ViewModule.Core (0.9.9.1)
     FSharpLint.Core (0.0.15-beta)

--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -48,8 +48,8 @@ type ParseAndCheckResults private (infoOpt: (FSharpCheckFileResults * FSharpPars
         |> Option.getOrElse [||]
         |> Array.append (x.CheckErrors |> Option.getOrElse [||])
 
-    member __.GetFormatSpecifierLocations() =
-        infoOpt |> Option.map (fun (checkResults, _) -> checkResults.GetFormatSpecifierLocations())
+    member __.GetFormatSpecifierLocationsAndArity() =
+        infoOpt |> Option.map (fun (checkResults, _) -> checkResults.GetFormatSpecifierLocationsAndArity())
 
     member __.GetNavigationItems() =
         match infoOpt with 

--- a/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
+++ b/src/FSharpVSPowerTools.Core/SourceCodeClassifier.fs
@@ -346,9 +346,9 @@ module SourceCodeClassifier =
                                EndCol = decl.DeclarationRange.EndColumn }})
     
         let printfSpecifiersRanges =
-            checkResults.GetFormatSpecifierLocations()
+            checkResults.GetFormatSpecifierLocationsAndArity()
             |> Option.map (fun ranges ->
-                 ranges |> Array.map (fun r -> 
+                 ranges |> Array.map (fun (r, _) -> 
                     { Category = Category.Printf
                       WordSpan = 
                         { SymbolKind = SymbolKind.Other

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -132,16 +132,13 @@ module Array =
             else false
         loop 0 index
 
-
     /// Returns true if one array has another as its subset from index 0.
     let startsWith (prefix: _ []) (whole: _ []) =
         isSubArray prefix whole 0
-            
 
     /// Returns true if one array has trailing elements equal to another's.
     let endsWith (suffix: _ []) (whole: _ []) =
         isSubArray suffix whole (whole.Length-suffix.Length)
-            
 
     /// Returns a new array with an element replaced with a given value.
     let replace index value (array: _ []) =
@@ -151,12 +148,10 @@ module Array =
         res.[index] <- value
         res
 
-    
     let head (array: 'T []) =
          checkNonNull "array" array
          if array.Length = 0 then invalidArg "array" "cannot get the head of an empty array"
          array.[0]
-
 
     /// Returns all heads of a given array.
     /// For [|1;2;3|] it returns [|[|1; 2; 3|]; [|1; 2|]; [|1|]|]
@@ -166,7 +161,6 @@ module Array =
         for i = array.Length - 1 downto 0 do
             res.[i] <- array.[0..i]
         res
-
 
     /// Fold over the array passing the index and element at that index to a folding function
     let foldi (folder: 'State -> int -> 'T -> 'State) (state: 'State) (array: 'T []) =
@@ -179,20 +173,17 @@ module Array =
             state <- folder.Invoke (state, i, array.[i])
         state
 
-
     /// Get the first element of the array or None if the Array is null or empty
     let tryHead array =
         match array with
         | null | [||] -> None
         | arr  -> Some arr.[0]
 
-
     /// Get the last element of the array or None if the Array is null or empty
     let tryLast array =
         match array with
         | null | [||] -> None
         | arr  -> Some arr.[arr.Length-1]
-
 
     /// Returns an array that contains no duplicate entries according to generic hash and
     /// equality comparisons on the entries.
@@ -233,7 +224,6 @@ module Array =
             array.[idx] <- t2
             array.[arrlen-idx] <- t1
 
-
     /// Return an array of elements that preceded the first element that failed
     /// to satisfy the predicate
     let takeWhile predicate (array: 'T []) =
@@ -244,7 +234,6 @@ module Array =
             count <- count + 1
         array.[0..count-1]
 
-
     /// Return an array of elements that begin at the first element that failed
     /// to satisfy the predicate
     let skipWhile predicate (array: 'T []) =
@@ -254,7 +243,6 @@ module Array =
         while count < array.Length-1 && predicate array.[count] do
             count <- count + 1
         array.[count..array.Length-1]
-
 
     /// Map all elements of the array that satisfy the predicate
     let filterMap predicate mapfn (array: 'T [])  =
@@ -268,7 +256,6 @@ module Array =
                count <- count + 1
         if count = 0 then [||] else
         result.[0..count-1]
-
 
     let groupBy (keyfn:'T->'Key) (array: 'T []) =
         checkNonNull "array" array
@@ -327,6 +314,19 @@ module Array =
             // Convert the ResizeArrays to arrays and return them.
             resultList1.ToArray (),
             resultList2.ToArray ()
+
+    let splitByChunks (chunkSizes : int[]) (arr : 'T[]) =
+        let rec loop (chunks : int[]) (arr : 'T[]) acc =
+            match chunks, arr with
+            | [||], _ 
+            | _, [||] -> acc
+            | _ ->
+                let chunk = min chunks.[0] arr.Length
+                loop chunks.[1 .. ] arr.[chunk .. ] (arr.[0..(chunk-1)] :: acc)
+
+        loop chunkSizes arr []
+        |> Array.ofList
+        |> Array.rev
 
     let toShortHexString (bytes: byte[]) =
         let length = bytes.Length

--- a/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/PrintfSpecifiersUsageGetterTests.fs
@@ -264,3 +264,75 @@ let ``backwards pipe with too many args``() =
 ignore <| sprintf "%d" 1 2
 """
     => [2, [(19, 21), (23, 24)]]
+
+[<Test>]
+let ``zero-arity specifiers mixed with normal``() =
+    """
+printf "%% %d %% %% %f %% %s %% %A" 1 2.5 "x"
+"""
+    => [2, [(11, 13), (36, 37)
+            (20, 22), (38, 41)
+            (26, 28), (42, 45)]]
+
+[<Test>]
+let ``two-arity specifiers mixed with normal``() =
+    """
+printf "%*% %d %*f %.*f %f %*s %s %*d" 1 2 3 3.3 4 4.4 5.5 6 "6"
+"""
+    => [2, [(8, 11), (39, 40)
+            (12, 14), (41, 42)
+            (15, 18), (43, 48)
+            (19, 23), (49, 54)
+            (24, 26), (55, 58)
+            (27, 30), (59, 64)]]
+
+[<Test>]
+let ``three-arity specifiers mixed with normal``() =
+    """
+printf "%d %*.*f %*.*f %f %*.*f %s" 1 2 2 2.2 3 3 3.3 4.4 5 5 5.5 "6"
+"""
+    => [2, [(8, 10), (36, 37)
+            (11, 16), (38, 45)
+            (17, 22), (46, 53)
+            (23, 25), (54, 57)
+            (26, 31), (58, 65)
+            (32, 34), (66, 69)]]
+
+[<Test>]
+let ``zero- one- two- and three- arity specifiers together increasing``() =
+    """
+printf "%% %d %a %*.*f" 1 (fun _ _ -> ()) "2" 3 3 3.3
+"""
+    => [2, [(11, 13), (24, 25)
+            (14, 16), (26, 45)
+            (17, 22), (46, 53)]]
+
+[<Test>]
+let ``zero- one- two- and three- arity specifiers together decreasing``() =
+    """
+printf "%*.*f %a %d %%" 1 1 1.1 (fun _ _ -> ()) "2" 3
+"""
+    => [2, [(8, 13), (24, 31)
+            (14, 16), (32, 51)
+            (17, 19), (52, 53)]]
+
+[<Test>]
+let ``two-arity specifier missing one arg``() =
+    """
+printf "%*d" 1
+"""
+    => [2, [(8, 11), (13, 14)]]
+
+[<Test>]
+let ``three-arity specifier missing one arg``() =
+    """
+printf "%*.*f" 1 1
+"""
+    => [2, [(8, 13), (15, 18)]]
+
+[<Test>]
+let ``three-arity specifier missing two args``() =
+    """
+printf "%*.*f" 1
+"""
+    => [2, [(8, 13), (15, 16)]]

--- a/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/SourceCodeClassifierTests.fs
@@ -1607,7 +1607,7 @@ do printfn "%6d %%  % 06d" 1 2
 """
     => [ 2, [ Cat.Operator, 6, 7; Cat.Function, 8, 15 ]
          3, [ Cat.Operator, 6, 7; Cat.Function, 8, 15; Cat.Printf, 17, 19; Cat.Printf, 20, 22 ]
-         4, [ Cat.Function, 3, 10; Cat.Printf, 12, 15; Cat.Printf, 20, 25 ]]
+         4, [ Cat.Function, 3, 10; Cat.Printf, 12, 15; Cat.Printf, 16, 18; Cat.Printf, 20, 25 ]]
 
 [<Test>]
 let ``printf formatters in try / with / finally``() =


### PR DESCRIPTION
Fixes https://github.com/fsprojects/VisualFSharpPowerTools/issues/1335

![specifiers](https://cloud.githubusercontent.com/assets/5943573/13087955/0505101c-d49f-11e5-9098-41030fe3b46e.gif)
