### PR TITLE
Optimize on caret move

### DIFF
--- a/src/FSharpVSPowerTools.Logic.VS2015/RecordStubGeneratorSuggestedActionsSourceProvider.fs
+++ b/src/FSharpVSPowerTools.Logic.VS2015/RecordStubGeneratorSuggestedActionsSourceProvider.fs
@@ -40,10 +40,12 @@ type RecordStubGeneratorSuggestedActionsSourceProvider [<ImportingConstructor>]
                     | true, doc ->
                         let generator =
                             new RecordStubGenerator(
-                                  doc, textView,
+                                  doc, 
+                                  textView,
                                   undoHistoryRegistry.RegisterHistory(buffer),
-                                  fsharpVsLanguageService, serviceProvider,
-                                  projectFactory, Setting.getDefaultMemberBody codeGenOptions,
+                                  fsharpVsLanguageService,
+                                  projectFactory, 
+                                  Setting.getDefaultMemberBody codeGenOptions,
                                   openDocumentsTracker)
 
                         new RecordStubGeneratorSuggestedActionsSource(generator) :> _

--- a/src/FSharpVSPowerTools.Logic.VS2015/ResolveUnopenedNamespaceSuggestedActionsSourceProvider.fs
+++ b/src/FSharpVSPowerTools.Logic.VS2015/ResolveUnopenedNamespaceSuggestedActionsSourceProvider.fs
@@ -36,8 +36,8 @@ type ResolveUnopenedNamespaceSuggestedActionsSourceProvider [<ImportingConstruct
                     match textDocumentFactoryService.TryGetTextDocument(buffer) with
                     | true, doc -> 
                         let resolver =
-                            new UnopenedNamespaceResolver(doc, textView, undoHistoryRegistry.RegisterHistory(buffer),
-                                                          fsharpVsLanguageService, serviceProvider, projectFactory)
+                            new UnopenedNamespaceResolver(
+                                doc, textView, undoHistoryRegistry.RegisterHistory(buffer), fsharpVsLanguageService, projectFactory)
 
                         new ResolveUnopenedNamespaceSuggestedActionsSource(resolver) :> _
                     | _ -> null

--- a/src/FSharpVSPowerTools.Logic.VS2015/UnionPatternMatchCaseGeneratorSuggestedActionsSourceProvider.fs
+++ b/src/FSharpVSPowerTools.Logic.VS2015/UnionPatternMatchCaseGeneratorSuggestedActionsSourceProvider.fs
@@ -40,10 +40,12 @@ type UnionPatternMatchCaseSuggestedActionsSourceProvider [<ImportingConstructor>
                     | true, doc ->
                         let generator =
                             new UnionPatternMatchCaseGenerator(
-                                  doc, textView,
+                                  doc, 
+                                  textView,
                                   undoHistoryRegistry.RegisterHistory(buffer),
-                                  fsharpVsLanguageService, serviceProvider,
-                                  projectFactory, Setting.getDefaultMemberBody codeGenOptions,
+                                  fsharpVsLanguageService,
+                                  projectFactory, 
+                                  Setting.getDefaultMemberBody codeGenOptions,
                                   openDocumentsTracker)
 
                         new UnionPatternMatchCaseGeneratorSuggestedActionsSource(generator) :> _

--- a/src/FSharpVSPowerTools.Logic/CodeGenerationService.fs
+++ b/src/FSharpVSPowerTools.Logic/CodeGenerationService.fs
@@ -6,9 +6,9 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 open FSharpVSPowerTools.CodeGeneration
 open FSharpVSPowerTools.ProjectSystem
 
-type VSDocument(source: string, doc: EnvDTE.Document, snapshot: ITextSnapshot) =
+type VSDocument(source: string, filePath: FilePath, snapshot: ITextSnapshot) =
     interface IDocument with
-        member __.FullName = doc.FullName
+        member __.FullName = filePath
         member __.LineCount = snapshot.LineCount
         member __.GetText() = source
         member __.GetLineText0(line0) =

--- a/src/FSharpVSPowerTools.Logic/EventHandling.fs
+++ b/src/FSharpVSPowerTools.Logic/EventHandling.fs
@@ -16,7 +16,6 @@ module ViewChange =
     
     let viewportHeightEvent (view: ITextView) = view.ViewportHeightChanged |> Event.map ignore
     let caretEvent (view: ITextView) = view.Caret.PositionChanged |> Event.map ignore
-    let gotFocus (view: ITextView) = view.GotAggregateFocus |> Event.map ignore
     let bufferEvent (buffer: ITextBuffer) = buffer.ChangedLowPriority |> Event.map ignore
     let tagsEvent (tagAggregator: ITagAggregator<_>) = tagAggregator.TagsChanged |> Event.map ignore
 

--- a/src/FSharpVSPowerTools.Logic/FormatDocumentCommand.fs
+++ b/src/FSharpVSPowerTools.Logic/FormatDocumentCommand.fs
@@ -5,7 +5,6 @@ open Microsoft.VisualStudio.Text
 open Microsoft.VisualStudio.Text.Editor
 open Fantomas.FormatConfig
 open Fantomas
-open FSharpVSPowerTools.ProjectSystem
 open FSharpVSPowerTools
 
 type FormatDocumentCommand(getConfig: Func<FormatConfig>) =
@@ -17,9 +16,7 @@ type FormatDocumentCommand(getConfig: Func<FormatConfig>) =
 
     override x.AdjustProject(filePath, _) =
         maybe {
-            let dte = x.Services.ServiceProvider.GetDte()
-            let! document = dte.GetCurrentDocument filePath
-            let! project = x.Services.ProjectFactory.CreateForDocument x.TextBuffer document
+            let! project = x.Services.ProjectFactory.CreateForDocument x.TextBuffer filePath
             return (project, filePath)
         }
 

--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -21,7 +21,7 @@ module private Utils =
         | _ ->
             "MarkerFormatDefinition/HighlightedReference"
 
-type HighlightUsageTag(vsVersion, isDef)= 
+type HighlightUsageTag(vsVersion, isDef) = 
     inherit TextMarkerTag(getMarker vsVersion isDef)
     member __.IsFromDefinition = isDef
 
@@ -125,12 +125,7 @@ type HighlightUsageTagger(doc: ITextDocument,
         |> Async.Ignore
 
     let docEventListener = 
-        new DocumentEventListener(
-            [ViewChange.layoutEvent view
-             ViewChange.caretEvent view
-             ViewChange.gotFocus view], 
-            200us, 
-            updateAtCaretPosition)
+        new DocumentEventListener([ViewChange.layoutEvent view; ViewChange.caretEvent view], 100us, updateAtCaretPosition)
 
     let vsVersion = VisualStudioVersion.fromDTEVersion dte.Version
 

--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -90,6 +90,7 @@ type HighlightUsageTagger(doc: ITextDocument,
         }
 
     let dte = serviceProvider.GetDte()
+    let project = lazy (projectFactory.CreateForDocument buffer doc.FilePath)
 
     let updateAtCaretPosition ((CallInUIContext callInUIContext) as ciuc) =
         asyncMaybe {
@@ -100,8 +101,7 @@ type HighlightUsageTagger(doc: ITextDocument,
             | Some point, _ ->
                 requestedPoint <- point
                 let currentRequest = requestedPoint
-                let! item = dte.GetProjectItem doc.FilePath
-                let! project = projectFactory.CreateForProjectItem buffer doc.FilePath item
+                let! project = project.Value
                 return!
                     match vsLanguageService.GetSymbol(currentRequest, doc.FilePath, project) with
                     | Some (newWord, symbol) ->

--- a/src/FSharpVSPowerTools.Logic/NavigateToItem.fs
+++ b/src/FSharpVSPowerTools.Logic/NavigateToItem.fs
@@ -170,7 +170,7 @@ type NavigateToItemProvider
                         let! doc = dte.GetActiveDocument()
                         let! openDoc = openDocumentsTracker.TryFindOpenDocument doc.FullName
                         let buffer = openDoc.Document.TextBuffer
-                        return! projectFactory.CreateForDocument buffer doc 
+                        return! projectFactory.CreateForDocument buffer doc.FullName
                     } |> Option.toArray
                 | xs -> List.toArray xs
             

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -157,16 +157,15 @@ type OutliningTagger
         | Scope.Comment               -> options.CommentsEnabled
         | _ -> true
 
-    let dte = serviceProvider.GetDte()
+    let project = lazy (projectFactory.CreateForDocument buffer textDocument.FilePath)
 
     /// doUpdate -=> triggerUpdate -=> tagsChanged
     let doUpdate (CallInUIContext callInUIContext) =
         asyncMaybe {
             let snapshot = buffer.CurrentSnapshot
-            let! doc = dte.GetCurrentDocument textDocument.FilePath
-            let! project = projectFactory.CreateForDocument buffer doc
+            let! project = project.Value
             let! source = openDocumentsTracker.TryGetDocumentText textDocument.FilePath
-            let! parseFileResults = languageService.ParseFileInProject (doc.FullName, project)
+            let! parseFileResults = languageService.ParseFileInProject (textDocument.FilePath, project)
             let! ast = parseFileResults.ParseTree
             if checkAST oldAST ast then
                 oldAST <- Some ast

--- a/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
@@ -84,7 +84,7 @@ type PrintfSpecifiersUsageTagger
                             onCaretMoveListener.Force() |> ignore
             })
 
-    let bufferChangedEventListener = new DocumentEventListener ([ViewChange.bufferEvent buffer], 200us, onBufferChanged)
+    let bufferChangedEventListener = new DocumentEventListener ([ViewChange.bufferEvent buffer], 100us, onBufferChanged)
     
     let tagSpan span = TagSpan<PrintfSpecifiersUsageTag>(span, PrintfSpecifiersUsageTag()) :> ITagSpan<_>
 

--- a/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
@@ -121,41 +121,44 @@ type ProjectFactory
 
     member x.CreateForDocument buffer (filePath: FilePath) =
         maybe {
-          let! doc = dte.GetCurrentDocument filePath
-          let filePath = doc.FullName
-          let projectItem = doc.ProjectItem
-          Debug.Assert(mayReferToSameBuffer buffer filePath, sprintf "Buffer '%A' doesn't refer to the current document '%s'." buffer filePath)
-          let project = projectItem.ContainingProject
-          
-          let getText (buffer: ITextBuffer) =
-              // Try to obtain cached document text; otherwise, retrieve the text from the buffer.
-              openDocumentsTracker.TryGetDocumentText filePath
-              |> Option.getOrTry (fun _ -> buffer.CurrentSnapshot.GetText())
-          
-          if not (project === null) && not (filePath === null) && isFSharpProject project then
-              let projectProvider = x.CreateForProject project
-              // If current file doesn't have 'BuildAction = Compile', it doesn't appear in the list of source files. 
+            //let! doc = dte.GetCurrentDocument filePath
+            //let projectItem = doc.ProjectItem
+
+            let! projectItem = dte.GetProjectItem filePath
+            //let! project = projectFactory.CreateForProjectItem buffer doc.FilePath item
+
+            Debug.Assert(mayReferToSameBuffer buffer filePath, sprintf "Buffer '%A' doesn't refer to the current document '%s'." buffer filePath)
+            let project = projectItem.ContainingProject
+            
+            let getText (buffer: ITextBuffer) =
+                // Try to obtain cached document text; otherwise, retrieve the text from the buffer.
+                openDocumentsTracker.TryGetDocumentText filePath
+                |> Option.getOrTry (fun _ -> buffer.CurrentSnapshot.GetText())
+            
+            if not (project == null) && not (filePath == null) && isFSharpProject project then
+                let projectProvider = x.CreateForProject project
+                // If current file doesn't have 'BuildAction = Compile', it doesn't appear in the list of source files. 
             // Consequently, we should interpret it as a script.
-              if Array.exists ((=) filePath) projectProvider.SourceFiles then
-                  return projectProvider
-              else
-                  let ext = Path.GetExtension filePath
-                  if isSourceExtension ext then
-                      let vsVersion = VisualStudioVersion.fromDTEVersion projectItem.DTE.Version
-                      return (VirtualProjectProvider(getText buffer, filePath, vsVersion) :> _)
-                  else
-                      return! None
-          elif not (filePath === null) then
-              let ext = Path.GetExtension filePath
-              if isSourceExtension ext then
-                  let vsVersion = VisualStudioVersion.fromDTEVersion projectItem.DTE.Version
-                  return (VirtualProjectProvider(getText buffer, filePath, vsVersion) :> _)
-              elif isSignatureExtension ext then
-                  match signatureProjectData.TryGetValue(filePath) with
-                  | true, project -> return project
-                  | _ -> return! None
-              else return! None
-          else return! None
+                if Array.exists ((=) filePath) projectProvider.SourceFiles then
+                    return projectProvider
+                else
+                    let ext = Path.GetExtension filePath
+                    if isSourceExtension ext then
+                        let vsVersion = VisualStudioVersion.fromDTEVersion projectItem.DTE.Version
+                        return (VirtualProjectProvider(getText buffer, filePath, vsVersion) :> _)
+                    else
+                        return! None
+            elif not (filePath === null) then
+                let ext = Path.GetExtension filePath
+                if isSourceExtension ext then
+                    let vsVersion = VisualStudioVersion.fromDTEVersion projectItem.DTE.Version
+                    return (VirtualProjectProvider(getText buffer, filePath, vsVersion) :> _)
+                elif isSignatureExtension ext then
+                    match signatureProjectData.TryGetValue(filePath) with
+                    | true, project -> return project
+                    | _ -> return! None
+                else return! None
+            else return! None
         }
 
     member __.ListFSharpProjectsInSolution dte =

--- a/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
@@ -121,12 +121,7 @@ type ProjectFactory
 
     member x.CreateForDocument buffer (filePath: FilePath) =
         maybe {
-            //let! doc = dte.GetCurrentDocument filePath
-            //let projectItem = doc.ProjectItem
-
             let! projectItem = dte.GetProjectItem filePath
-            //let! project = projectFactory.CreateForProjectItem buffer doc.FilePath item
-
             Debug.Assert(mayReferToSameBuffer buffer filePath, sprintf "Buffer '%A' doesn't refer to the current document '%s'." buffer filePath)
             let project = projectItem.ContainingProject
             
@@ -187,7 +182,7 @@ type ProjectFactory
             let isSymbolLocalForProject = TypedAstUtils.isSymbolLocalForProject symbol 
             match Option.orElse symbol.ImplementationLocation symbol.DeclarationLocation with
             | Some loc ->
-                Logging.logInfo (fun _ -> sprintf "Trying to find symbol '%O' declared at '%O' from current file '%O'..." symbol loc.FileName currentFile)
+                //Logging.logInfo (fun _ -> sprintf "Trying to find symbol '%O' declared at '%O' from current file '%O'..." symbol loc.FileName currentFile)
                 let filePath = Path.GetFullPathSafe loc.FileName
                 if currentProject.IsForStandaloneScript && filePath = currentFile then 
                     Some SymbolDeclarationLocation.File

--- a/src/FSharpVSPowerTools.Logic/RecordStubGeneratorSmartTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/RecordStubGeneratorSmartTagger.fs
@@ -15,14 +15,17 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 type RecordStubGeneratorSmartTag(actionSets) =
     inherit SmartTag(SmartTagType.Factoid, actionSets)
 
-type RecordStubGenerator(textDocument: ITextDocument,
-                         view: ITextView,
-                         textUndoHistory: ITextUndoHistory,
-                         vsLanguageService: VSLanguageService,
-                         serviceProvider: IServiceProvider,
-                         projectFactory: ProjectFactory,
-                         defaultBody: string,
-                         openDocumentTracker: IOpenDocumentsTracker) as self =
+type RecordStubGenerator
+    (
+        textDocument: ITextDocument,
+        view: ITextView,
+        textUndoHistory: ITextUndoHistory,
+        vsLanguageService: VSLanguageService,
+        projectFactory: ProjectFactory,
+        defaultBody: string,
+        openDocumentTracker: IOpenDocumentsTracker
+    ) as self =
+
     let changed = Event<_>()
     let mutable currentWord: SnapshotSpan option = None
     let mutable suggestions: ISuggestion list = []
@@ -60,7 +63,6 @@ type RecordStubGenerator(textDocument: ITextDocument,
                   member __.Text = Resource.recordGenerationCommandName }
         ]
 
-    let dte = serviceProvider.GetDte()
     let project = lazy (projectFactory.CreateForDocument buffer textDocument.FilePath)
 
     // Try to:

--- a/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
@@ -26,13 +26,14 @@ type RenameCommandFilter(textDocument: ITextDocument,
     let mutable state = None
     let documentUpdater = DocumentUpdater(serviceProvider)
     let dte = serviceProvider.GetDte()
+    let project = lazy (projectFactory.CreateForDocument view.TextBuffer textDocument.FilePath)
 
     let canRename() = 
         state <-
             maybe {
                 let! caretPos = view.TextBuffer.GetSnapshotPoint view.Caret.Position
                 let! doc = dte.GetCurrentDocument(textDocument.FilePath)
-                let! project = projectFactory.CreateForDocument view.TextBuffer doc
+                let! project = project.Value
                 return { Word = vsLanguageService.GetSymbol(caretPos, doc.FullName, project); File = doc.FullName; Project = project }
             }
         state |> Option.bind (fun s -> s.Word) |> Option.isSome

--- a/src/FSharpVSPowerTools.Logic/SymbolClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SymbolClassifier.fs
@@ -113,6 +113,7 @@ type SymbolClassifier
         else async.Return ()
 
     let events: EnvDTE80.Events2 option = tryCast dte.Events
+
     let onBuildDoneHandler = EnvDTE._dispBuildEvents_OnBuildProjConfigDoneEventHandler (fun p _ _ _ _ ->
         maybe {
             let! selfProject = project.Value
@@ -127,7 +128,7 @@ type SymbolClassifier
     do events |> Option.iter (fun e -> e.BuildEvents.add_OnBuildProjConfigDone onBuildDoneHandler)
 
     let docEventListener =
-        new DocumentEventListener ([ViewChange.bufferEvent doc.TextBuffer], 200us, updateSyntaxConstructClassifiers false)
+        new DocumentEventListener ([ViewChange.bufferEvent doc.TextBuffer], 100us, updateSyntaxConstructClassifiers false)
 
     let getClassificationSpans (targetSnapshotSpan: SnapshotSpan) =
         match state.Value with

--- a/src/FSharpVSPowerTools.Logic/SymbolClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/SymbolClassifier.fs
@@ -40,7 +40,7 @@ type SymbolClassifier
     let classificationChanged = Event<_,_>()
     let state = Atom State.NoData
     let dte = serviceProvider.GetDte()
-    let project = lazy (projectFactory.CreateForDocument buffer doc.FilePath)
+    let project() = projectFactory.CreateForDocument buffer doc.FilePath
     
     let triggerClassificationChanged snapshot reason =
         let span = SnapshotSpan(snapshot, 0, snapshot.Length)
@@ -80,7 +80,7 @@ type SymbolClassifier
                  
         if needUpdate then
             asyncMaybe {
-                let! currentProject = project.Value
+                let! currentProject = project()
                 let! snapshot = snapshot
                 debug "Effective update"
                 let! checkResults = vsLanguageService.ParseAndCheckFileInProject(doc.FilePath, currentProject)
@@ -115,7 +115,7 @@ type SymbolClassifier
     let events: EnvDTE80.Events2 option = tryCast dte.Events
     let onBuildDoneHandler = EnvDTE._dispBuildEvents_OnBuildProjConfigDoneEventHandler (fun p _ _ _ _ ->
         maybe {
-            let! selfProject = project.Value
+            let! selfProject = project()
             let builtProjectFileName = Path.GetFileName p
             let referencedProjectFileNames = selfProject.GetAllReferencedProjectFileNames()
             if referencedProjectFileNames |> List.exists ((=) builtProjectFileName) then

--- a/src/FSharpVSPowerTools.Logic/UnusedSymbolClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/UnusedSymbolClassifier.fs
@@ -251,7 +251,7 @@ type UnusedSymbolClassifier
         } |> ignore)
 
     do events |> Option.iter (fun e -> e.BuildEvents.add_OnBuildProjConfigDone onBuildDoneHandler)
-    let docEventListener = new DocumentEventListener ([ViewChange.bufferEvent doc.TextBuffer], 200us, onBufferChanged false)
+    let docEventListener = new DocumentEventListener ([ViewChange.bufferEvent doc.TextBuffer], 100us, onBufferChanged false)
 
     let projectCheckedSubscription =
         // project check results needed for Unused Declarations only.

--- a/src/FSharpVSPowerTools.Logic/UnusedSymbolClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/UnusedSymbolClassifier.fs
@@ -69,16 +69,10 @@ type UnusedSymbolClassifier
     let singleSymbolsProjects: Atom<CheckingProject list> = Atom []
     let unusedTasgChanged = Event<_,_>()
     let dte = serviceProvider.GetDte()
-
-    let getCurrentProject() =
-        maybe {
-            // If there is no backing document, an ITextDocument instance might be null
-            let! _ = Option.ofNull doc
-            let! item = dte.GetProjectItem doc.FilePath
-            return! projectFactory.CreateForProjectItem buffer doc.FilePath item }
-
+    let project = lazy (projectFactory.CreateForDocument buffer doc.FilePath)
+    
     let isCurrentProjectForStandaloneScript() =
-        getCurrentProject() |> Option.map (fun p -> p.IsForStandaloneScript) |> Option.getOrElse false
+        project.Value |> Option.map (fun p -> p.IsForStandaloneScript) |> Option.getOrElse false
 
     let includeUnusedOpens() =
         includeUnusedOpens
@@ -179,7 +173,7 @@ type UnusedSymbolClassifier
         } |> Async.Ignore
 
     let updateUnusedSymbolsIfNeeded (CallInUIContext callInUIContext) =
-        match getCurrentProject(), getCurrentSnapshot() with
+        match project.Value, getCurrentSnapshot() with
         | Some project, Some snapshot ->
             match state.Value with
             | State.Updating (_, oldSnapshot) when oldSnapshot = snapshot -> async.Return()
@@ -211,7 +205,7 @@ type UnusedSymbolClassifier
 
         if needUpdate then
             asyncMaybe {
-                let! currentProject = getCurrentProject()
+                let! currentProject = project.Value
                 
                 if currentProject.IsForStandaloneScript || not (includeUnusedReferences()) then
                     do! updateUnusedSymbolsIfNeeded callInUIContext |> liftAsync
@@ -246,10 +240,10 @@ type UnusedSymbolClassifier
 
     let events: EnvDTE80.Events2 option = tryCast dte.Events
     
-    let onBuildDoneHandler = EnvDTE._dispBuildEvents_OnBuildProjConfigDoneEventHandler (fun project _ _ _ _ ->
+    let onBuildDoneHandler = EnvDTE._dispBuildEvents_OnBuildProjConfigDoneEventHandler (fun p _ _ _ _ ->
         maybe {
-            let! selfProject = getCurrentProject()
-            let builtProjectFileName = Path.GetFileName project
+            let! selfProject = project.Value
+            let builtProjectFileName = Path.GetFileName p
             let referencedProjectFileNames = selfProject.GetAllReferencedProjectFileNames()
             if referencedProjectFileNames |> List.exists ((=) builtProjectFileName) then
                 debug "Referenced project %s has been built, updating classifiers..." builtProjectFileName

--- a/src/FSharpVSPowerTools/Commands/DepthColorizerManager.cs
+++ b/src/FSharpVSPowerTools/Commands/DepthColorizerManager.cs
@@ -53,8 +53,7 @@ namespace FSharpVSPowerTools
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
                 return buffer.Properties.GetOrCreateSingletonProperty(
-                        () => new DepthTagger(doc, buffer, _serviceProvider, _projectFactory,
-                                              _vsLanguageService, _openDocumentTracker) as ITagger<T>);
+                        () => new DepthTagger(doc, buffer, _projectFactory, _vsLanguageService, _openDocumentTracker) as ITagger<T>);
             }
 
             return null;

--- a/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/PrintfSpecifiersUsageTaggerProvider.cs
@@ -59,7 +59,7 @@ namespace FSharpVSPowerTools
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
                 return textView.Properties.GetOrCreateSingletonProperty(
-                    () => new PrintfSpecifiersUsageTagger(doc, textView, _fsharpVsLanguageService, _serviceProvider, _projectFactory)) as ITagger<T>;
+                    () => new PrintfSpecifiersUsageTagger(doc, textView, _fsharpVsLanguageService, _projectFactory)) as ITagger<T>;
             }
 
             return null;

--- a/src/FSharpVSPowerTools/Commands/QuickInfoMarginProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/QuickInfoMarginProvider.cs
@@ -46,7 +46,7 @@ namespace FSharpVSPowerTools.QuickInfo
 
             ITextDocument doc;
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
-                return new QuickInfoMargin(doc, textView, _vsLanguageService, _serviceProvider, _projectFactory);
+                return new QuickInfoMargin(doc, textView, _vsLanguageService, _projectFactory);
             else
                 return null;
         }

--- a/src/FSharpVSPowerTools/Commands/RecordStubGeneratorSmartTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/RecordStubGeneratorSmartTaggerProvider.cs
@@ -60,11 +60,16 @@ namespace FSharpVSPowerTools
             ITextDocument doc;
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
-                var generator = new RecordStubGenerator(doc, textView,
-                                _undoHistoryRegistry.RegisterHistory(buffer),
-                                _fsharpVsLanguageService, _serviceProvider,
-                                _projectFactory, Setting.getDefaultMemberBody(codeGenOptions),
-                                _openDocumentsTracker);
+                var generator = 
+                    new RecordStubGenerator(
+                        doc, 
+                        textView,
+                        _undoHistoryRegistry.RegisterHistory(buffer),
+                        _fsharpVsLanguageService,
+                        _projectFactory, 
+                        Setting.getDefaultMemberBody(codeGenOptions),
+                        _openDocumentsTracker);
+
                 return new RecordStubGeneratorSmartTagger(buffer, generator) as ITagger<T>;
             }
             

--- a/src/FSharpVSPowerTools/Commands/ResolveUnopenedNamespaceSmartTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/ResolveUnopenedNamespaceSmartTaggerProvider.cs
@@ -56,8 +56,10 @@ namespace FSharpVSPowerTools
             ITextDocument doc;
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
-                var resolver = new UnopenedNamespaceResolver(doc, textView, _undoHistoryRegistry.RegisterHistory(buffer),
-                                                             _fsharpVsLanguageService, _serviceProvider, _projectFactory);
+                var resolver = 
+                    new UnopenedNamespaceResolver(
+                        doc, textView, _undoHistoryRegistry.RegisterHistory(buffer), _fsharpVsLanguageService, _projectFactory);
+
                 return new ResolveUnopenedNamespaceSmartTagger(buffer, _serviceProvider, resolver) as ITagger<T>;
             }
             

--- a/src/FSharpVSPowerTools/Commands/UnionPatternMatchCaseGeneratorSmartTaggerProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/UnionPatternMatchCaseGeneratorSmartTaggerProvider.cs
@@ -61,11 +61,16 @@ namespace FSharpVSPowerTools
             ITextDocument doc;
             if (_textDocumentFactoryService.TryGetTextDocument(buffer, out doc))
             {
-                var generator = new UnionPatternMatchCaseGenerator(doc, textView,
-                                    _undoHistoryRegistry.RegisterHistory(buffer),
-                                    _fsharpVsLanguageService, _serviceProvider,
-                                    _projectFactory, Setting.getDefaultMemberBody(codeGenOptions),
-                                    _openDocumentsTracker);
+                var generator = 
+                    new UnionPatternMatchCaseGenerator(
+                        doc, 
+                        textView,
+                        _undoHistoryRegistry.RegisterHistory(buffer),
+                        _fsharpVsLanguageService,
+                        _projectFactory, 
+                        Setting.getDefaultMemberBody(codeGenOptions),
+                        _openDocumentsTracker);
+
                 return new UnionPatternMatchCaseGeneratorSmartTagger(buffer, generator) as ITagger<T>;
             }
             

--- a/src/FSharpVSPowerTools/Commands/XmlDocCommandFilterProvider.cs
+++ b/src/FSharpVSPowerTools/Commands/XmlDocCommandFilterProvider.cs
@@ -56,10 +56,7 @@ namespace FSharpVSPowerTools
 
             ITextDocument doc;
             if (_textDocumentFactoryService.TryGetTextDocument(wpfTextView.TextBuffer, out doc))
-            {
-                new XmlDocFilter(textViewAdapter, wpfTextView, doc.FilePath,
-                                 _projectFactory, _fsharpVsLanguageService, _openDocumentTracker, _serviceProvider);
-            }
+                new XmlDocFilter(textViewAdapter, wpfTextView, doc.FilePath, _projectFactory, _fsharpVsLanguageService, _openDocumentTracker);
         }
     }
 }

--- a/tests/FSharpVSPowerTools.Tests/HighlightUsageTaggerTests.fs
+++ b/tests/FSharpVSPowerTools.Tests/HighlightUsageTaggerTests.fs
@@ -15,11 +15,8 @@ type HighlightUsageTaggerHelper() =
                             projectFactory = base.ProjectFactory,
                             textDocumentFactoryService = base.DocumentFactoryService)
 
-    member __.GetView(buffer) =
-        createMockTextView buffer
-
-    member __.GetTagger(buffer, view) = 
-        taggerProvider.CreateTagger<_>(view, buffer)
+    member __.GetView(buffer) = createMockTextView buffer
+    member __.GetTagger(buffer, view) = taggerProvider.CreateTagger<_>(view, buffer)
 
     member __.TagsOf(buffer: ITextBuffer, tagger: ITagger<_>) =
         let span = SnapshotSpan(buffer.CurrentSnapshot, 0, buffer.CurrentSnapshot.Length)


### PR DESCRIPTION
Moving cursor with keyboard was a bit sluggish compared to C# editor, so I profiled and found that `dte.GetProjectItem` is the problem and add caching `IProjectProvider` in all places with `lazy`.

While I was at it, I tried to fix bug where symbol is not initially highlighted if you launch Go to definition. I found that `view.Caret.Position` here https://github.com/vasily-kirichenko/FSharpVSPowerTools/blob/optimize-on-caret-move/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs#L97 is zero, so the feature does not work.

@dungpa Any ideas? It seems the caret moved event is not fired if the caret is moved with Go to definition.