### PR TITLE
Missing Reference: System.Threading.Tasks

### DIFF
--- a/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/GoToDefinitionFilter.fs
@@ -3,6 +3,7 @@
 open System
 open System.IO
 open System.Threading
+open System.Threading.Tasks
 open System.Security
 open System.Collections.Generic
 open Microsoft.VisualStudio.Text.Editor

--- a/src/FSharpVSPowerTools.Logic/NavigateToItem.fs
+++ b/src/FSharpVSPowerTools.Logic/NavigateToItem.fs
@@ -5,6 +5,7 @@ open System.Drawing
 open System.Collections.Generic
 open System.ComponentModel.Composition
 open System.Threading
+open System.Threading.Tasks
 open Microsoft.VisualStudio.Language.NavigateTo.Interfaces
 open Microsoft.VisualStudio.Language.Intellisense
 open Microsoft.VisualStudio.Shell

--- a/src/FSharpVSPowerTools.Logic/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/VSUtils.fs
@@ -350,6 +350,7 @@ let showDialog (wnd: Window) (shell: IVsUIShell) =
         None
 
 open System.Threading
+open System.Threading.Tasks
 open System.Windows.Input
 
 [<Literal>]


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/835976/13903861/0d9115c8-ee62-11e5-93f7-19d896359fec.png)

Error encountered when cancelling the intellisense busy window, so I searched for all instances of `CancellationToken` in the source, making sure to add a reference to `System.Threading.Tasks` where used.

3 files modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fsprojects/visualfsharppowertools/1350)
<!-- Reviewable:end -->
