### PR TITLE
fixed: UnusedDeclarations.getSingleDeclarations returns actually used…

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -121,7 +121,7 @@ type WordSpan =
           Line = r.StartLine
           StartCol = r.StartColumn 
           EndCol = r.EndColumn }
-    member x.ToRange() = x.Line, x.StartCol, x.Line, x.EndCol
+    member x.Range = lazy (x.Line, x.StartCol, x.Line, x.EndCol)
 
 [<AbstractClass>]
 type LexerBase() = 

--- a/src/FSharpVSPowerTools.Core/TypedAstUtils.fs
+++ b/src/FSharpVSPowerTools.Core/TypedAstUtils.fs
@@ -299,13 +299,13 @@ module TypedAstPatterns =
 module UnusedDeclarations =
     open System.Collections.Generic
 
-    let symbolsComparer =
+    let symbolUseComparer =
         { new IEqualityComparer<FSharpSymbolUse> with
               member __.Equals (x, y) = x.Symbol.IsEffectivelySameAs y.Symbol
               member __.GetHashCode x = x.Symbol.GetHashCode() }
 
     let getSingleDeclarations (symbolsUses: SymbolUse[]): FSharpSymbol[] =
-        let symbols = Dictionary<FSharpSymbolUse, int>(symbolsComparer)
+        let symbols = Dictionary<FSharpSymbolUse, int>(symbolUseComparer)
     
         for symbolUse in symbolsUses do
             match symbols.TryGetValue symbolUse.SymbolUse with

--- a/src/FSharpVSPowerTools.Logic/ClassifierTypes.fs
+++ b/src/FSharpVSPowerTools.Logic/ClassifierTypes.fs
@@ -17,7 +17,7 @@ type internal CategorizedSnapshotSpan (columnSpan: CategorizedColumnSpan<ITextSn
         snapshotSpan.Swap (fun oldSpan ->
             oldSpan
             |> Option.orTry (fun _ -> 
-                fromRange originalSnapshot (columnSpan.WordSpan.ToRange())
+                fromRange originalSnapshot columnSpan.WordSpan.Range.Value
                 |> Option.map (fun span -> 
                     { Span = span
                       Line = span.Start.GetContainingLine().LineNumber }))

--- a/src/FSharpVSPowerTools.Logic/UnusedSymbolClassifier.fs
+++ b/src/FSharpVSPowerTools.Logic/UnusedSymbolClassifier.fs
@@ -114,17 +114,17 @@ type UnusedSymbolClassifier
             
             let! openDeclarations = OpenDeclarationGetter.getOpenDeclarations ast entities qualifyOpenDeclarations
             return
-                (entities
-                 |> Option.map (fun entities ->
-                     entities
-                     |> Seq.groupBy (fun e -> e.FullName)
-                     |> Seq.map (fun (fullName, entities) -> 
-                          fullName,
-                          entities
-                          |> Seq.map (fun e -> e.CleanedIdents) 
-                          |> Seq.toList)
-                     |> Dict.ofSeq),
-                openDeclarations)
+                entities
+                |> Option.map (fun entities ->
+                    entities
+                    |> Seq.groupBy (fun e -> e.FullName)
+                    |> Seq.map (fun (fullName, entities) -> 
+                         fullName,
+                         entities
+                         |> Seq.map (fun e -> e.CleanedIdents) 
+                         |> Seq.toList)
+                    |> Dict.ofSeq),
+                openDeclarations
         }
 
     let checkAstIsNotEmpty (ast: ParsedInput) =
@@ -265,7 +265,7 @@ type UnusedSymbolClassifier
 
                 match projects |> List.tryFind (fun p -> not p.Checked) with
                 | Some { Options = opts } ->
-                    // there is at least one yet unchecked project, start compilation on it
+                    // there is at least one yet unchecked project, start compiling it
                     vsLanguageService.CheckProjectInBackground opts
                 | None ->
                     // all the needed projects have been checked in background, let's calculate unused symbols
@@ -300,7 +300,7 @@ type UnusedSymbolClassifier
                 |> Option.map (fun data ->
                     data.Spans.Spans
                     |> Array.choose (fun wordSpan ->
-                        fromRange data.Snapshot (wordSpan.ColumnSpan.WordSpan.ToRange())
+                        fromRange data.Snapshot wordSpan.ColumnSpan.WordSpan.Range.Value
                         |> Option.map (fun span -> TagSpan(span, UnusedDeclarationTag()) :> ITagSpan<_>)))
                 |> Option.getOrElse [||]
 

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -46,7 +46,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DeployExtension>False</DeployExtension>
+    <DeployExtension>True</DeployExtension>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
+++ b/src/FSharpVSPowerTools/FSharpVSPowerTools.csproj
@@ -46,7 +46,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DeployExtension>True</DeployExtension>
+    <DeployExtension>False</DeployExtension>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">


### PR DESCRIPTION
… symbol due to wrong equality function used for grouping `FSharpSymbolUse`s

This fixes a huge bug in unused declarations searching algorithm, which caused many used symbols to be marks as unused.