### PR TITLE
Do not cache IProjectProvider for scripts

### DIFF
--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -3,7 +3,6 @@
 open System
 open System.Diagnostics
 
-
 [<AutoOpen>]
 module Prelude =
     /// obj.ReferenceEquals
@@ -15,7 +14,6 @@ module Prelude =
     let inline isNull v = match v with | null -> true | _ -> false
     let inline isNotNull v = not (isNull v)
     let inline dispose (disposable:#IDisposable) = disposable.Dispose ()
-    
 
 [<RequireQualifiedAccess>]
 module Null =
@@ -930,6 +928,9 @@ module File =
 
     let tryGetLastWriteTime file = Option.attempt (fun _ -> FileInfo(file).LastWriteTimeUtc)
 
+    let isScript (filePath: string) =
+        isNotNull filePath && String.Equals (Path.GetExtension filePath, ".fsx", StringComparison.InvariantCultureIgnoreCase)
+
 open System.Text
 open System.Diagnostics
 
@@ -965,5 +966,3 @@ type Profiler() =
              |> string)
 
     member __.Elapsed = total.Elapsed        
-
-    

--- a/src/FSharpVSPowerTools.Logic/DepthTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/DepthTagger.fs
@@ -34,13 +34,13 @@ type DepthTagger
     // only updated on the UI thread in the GetTags method
     let mutable state = None
     let tagsChanged = Event<_,_>()
-    let project = lazy (projectFactory.CreateForDocument buffer doc.FilePath)
+    let project = projectFactory.CreateForDocumentMemoized buffer doc.FilePath
     
     let refreshTags (CallInUIContext callInUIContext) = 
         asyncMaybe { 
             let snapshot = buffer.CurrentSnapshot // this is the possibly-out-of-date snapshot everyone here works with
             
-            let! project = project.Value
+            let! project = project()
             let! parseResults = languageService.ParseFileInProject (doc.FilePath, project)
             let! source = openDocumentsTracker.TryGetDocumentText doc.FilePath
             let! ranges = DepthParser.getNonoverlappingDepthRanges (source, parseResults.ParseTree) |> liftAsync

--- a/src/FSharpVSPowerTools.Logic/FindReferencesFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/FindReferencesFilter.fs
@@ -26,14 +26,14 @@ type FindReferencesFilter
      ) =    
 
     let dte = serviceProvider.GetDte()
-    let project = lazy (projectFactory.CreateForDocument view.TextBuffer textDocument.FilePath)
+    let project = projectFactory.CreateForDocumentMemoized view.TextBuffer textDocument.FilePath
 
     let getDocumentState (progress: ShowProgress) =
         async {
             let projectItem = maybe {
                 progress(OperationState.Reporting(Resource.findAllReferencesInitializingMessage))
                 let! caretPos = view.TextBuffer.GetSnapshotPoint view.Caret.Position
-                let! project = project.Value
+                let! project = project()
                 let! span, symbol = vsLanguageService.GetSymbol(caretPos, textDocument.FilePath, project)
                 return project, span, symbol }
 

--- a/src/FSharpVSPowerTools.Logic/FormatDocumentCommand.fs
+++ b/src/FSharpVSPowerTools.Logic/FormatDocumentCommand.fs
@@ -16,7 +16,7 @@ type FormatDocumentCommand(getConfig: Func<FormatConfig>) =
 
     override x.AdjustProject(filePath, _) =
         maybe {
-            let! project = x.Services.ProjectFactory.CreateForDocument x.TextBuffer filePath
+            let! project = x.Services.ProjectFactory.CreateForDocument (x.TextBuffer, filePath)
             return (project, filePath)
         }
 

--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -90,7 +90,7 @@ type HighlightUsageTagger(doc: ITextDocument,
         }
 
     let dte = serviceProvider.GetDte()
-    let project = lazy (projectFactory.CreateForDocument buffer doc.FilePath)
+    let project = projectFactory.CreateForDocumentMemoized buffer doc.FilePath
 
     let updateAtCaretPosition ((CallInUIContext callInUIContext) as ciuc) =
         asyncMaybe {
@@ -105,7 +105,7 @@ type HighlightUsageTagger(doc: ITextDocument,
             | Some point, _ ->
                 requestedPoint <- point
                 let currentRequest = requestedPoint
-                let! project = project.Value
+                let! project = project()
                 return!
                     match vsLanguageService.GetSymbol(currentRequest, doc.FilePath, project) with
                     | Some (newWord, symbol) ->

--- a/src/FSharpVSPowerTools.Logic/NavigateToItem.fs
+++ b/src/FSharpVSPowerTools.Logic/NavigateToItem.fs
@@ -170,7 +170,7 @@ type NavigateToItemProvider
                         let! doc = dte.GetActiveDocument()
                         let! openDoc = openDocumentsTracker.TryFindOpenDocument doc.FullName
                         let buffer = openDoc.Document.TextBuffer
-                        return! projectFactory.CreateForDocument buffer doc.FullName
+                        return! projectFactory.CreateForDocument (buffer, doc.FullName)
                     } |> Option.toArray
                 | xs -> List.toArray xs
             

--- a/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/PrintfSpecifiersUsageTagger.fs
@@ -61,11 +61,11 @@ type PrintfSpecifiersUsageTagger
     let onCaretMoveListener = 
         lazy (new DocumentEventListener ([ViewChange.layoutEvent view; ViewChange.caretEvent view], 200us, onCaretMove))
 
-    let project = lazy (projectFactory.CreateForDocument buffer doc.FilePath)
+    let project = projectFactory.CreateForDocumentMemoized buffer doc.FilePath
 
     let onBufferChanged ((CallInUIContext callInUIContext) as ciuc) =
         asyncMaybe {
-            let! project = project.Value
+            let! project = project()
             try
                 let! checkResults = vsLanguageService.ParseAndCheckFileInProject (doc.FilePath, project, AllowStaleResults.MatchingSource)
                 return! PrintfSpecifiersUsageGetter.getAll checkResults (fun e -> Logging.logError (fun _ -> e))

--- a/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectFactory.fs
@@ -119,7 +119,13 @@ type ProjectFactory
         cache.Get project.FullName (fun _ ->
             new ProjectProvider (project, createProjectProvider, onProjectChanged)) :> _
 
-    member x.CreateForDocument buffer (filePath: FilePath) =
+    member x.CreateForDocumentMemoized buffer filePath =
+        let creator = 
+            if File.isScript filePath then x.CreateForDocument 
+            else memoize x.CreateForDocument
+        fun() -> creator (buffer, filePath)
+
+    member x.CreateForDocument (buffer: ITextBuffer, filePath: FilePath) =
         maybe {
             let! projectItem = dte.GetProjectItem filePath
             Debug.Assert(mayReferToSameBuffer buffer filePath, sprintf "Buffer '%A' doesn't refer to the current document '%s'." buffer filePath)

--- a/src/FSharpVSPowerTools.Logic/XmlDocFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/XmlDocFilter.fs
@@ -36,7 +36,7 @@ type XmlDocFilter
     let getTypedChar(pvaIn: IntPtr) = 
         char (Marshal.GetObjectForNativeVariant(pvaIn) :?> uint16)
 
-    let project = lazy (projectFactory.CreateForDocument wpfTextView.TextBuffer fileName)
+    let project = projectFactory.CreateForDocumentMemoized wpfTextView.TextBuffer fileName
 
     interface IOleCommandTarget with
         member __.Exec(pguidCmdGroup: byref<Guid>, nCmdID: uint32, nCmdexecopt: uint32, pvaIn: IntPtr, pvaOut: IntPtr) =
@@ -54,7 +54,7 @@ type XmlDocFilter
                         asyncMaybe {
                             // XmlDocable line #1 are 1-based, editor is 0-based
                             let curLineNum = wpfTextView.Caret.Position.BufferPosition.GetContainingLine().LineNumber + 1 
-                            let! project = project.Value
+                            let! project = project()
                             let! parseResults = languageService.ParseFileInProject (fileName, project)
                             let! source = openDocumentsTracker.TryGetDocumentText fileName
                             let! xmlDocables = XmlDocParser.getXmlDocables (source, parseResults.ParseTree) |> liftAsync


### PR DESCRIPTION
It fixes the bug when changed `#r` directives in a script file were not picked up because we cached `IProjectProvider` which freezes project checker options.