### PR TITLE
Remove FindProjectItem which is potentially slow

### DIFF
--- a/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/RenameCommandFilter.fs
@@ -32,9 +32,8 @@ type RenameCommandFilter(doc: ITextDocument,
         state <-
             maybe {
                 let! caretPos = view.TextBuffer.GetSnapshotPoint view.Caret.Position
-                let! doc = dte.GetCurrentDocument(doc.FilePath)
                 let! project = project()
-                return { Word = vsLanguageService.GetSymbol(caretPos, doc.FullName, project); File = doc.FullName; Project = project }
+                return { Word = vsLanguageService.GetSymbol(caretPos, doc.FilePath, project); File = doc.FilePath; Project = project }
             }
         state |> Option.bind (fun s -> s.Word) |> Option.isSome
 

--- a/src/FSharpVSPowerTools.Logic/SolutionBuildEventListener.fs
+++ b/src/FSharpVSPowerTools.Logic/SolutionBuildEventListener.fs
@@ -17,7 +17,7 @@ type SolutionBuildEventListener(serviceProvider: IServiceProvider) as self =
 
     interface IVsUpdateSolutionEvents with
         member __.OnActiveProjectCfgChange(pIVsHierarchy: IVsHierarchy): int = 
-            match getProject pIVsHierarchy with
+            match tryGetProject pIVsHierarchy with
             | Some project ->
                 activeConfigChanged.Trigger(project)
             | None ->

--- a/tests/FSharpVSPowerTools.Tests/VsTestBase.fs
+++ b/tests/FSharpVSPowerTools.Tests/VsTestBase.fs
@@ -30,7 +30,8 @@ type VsTestBase() =
     static do serviceProvider.Services.[nameOf<EnvDTE.DTE>] <- dte
     static do serviceProvider.Services.[nameOf<SDTE>] <- dte
     static do serviceProvider.Services.[nameOf<SVsResourceManager>] <- Mocks.createSVsResourceManager()
-
+    
+    static do serviceProvider.Services.[nameOf<SVsRunningDocumentTable>] <- Mocks.createSVsRunningDocumentTable(dte)
     static do serviceProvider.Services.[nameOf<ILintOptions>] <- new Linting.LintOptionsPage(dte)
 
     let vsEditorAdaptersFactoryService = Mocks.createVsEditorAdaptersFactoryService()


### PR DESCRIPTION
Related comment: https://github.com/fsprojects/VisualFSharpPowerTools/pull/1384#issuecomment-218116822

I don't have a big solution to try out the changes.

Could you try this PR on big solutions to see any performance enhancement compared to master?

