### PR TITLE
Refactor HighlightUsageTagger

### DIFF
--- a/src/FSharpVSPowerTools.Core/FSharpVSPowerTools.Core.fsproj
+++ b/src/FSharpVSPowerTools.Core/FSharpVSPowerTools.Core.fsproj
@@ -91,6 +91,7 @@
     <Compile Include="SignatureGenerator.fs" />
     <Compile Include="TaskListCommentExtractor.fs" />
     <Compile Include="PrintfSpecifiersUsageGetter.fs" />
+    <Compile Include="Symbols/HighlightUsageInFile.fs" />
     <None Include="Scratchpad.fsx" />
     <Content Include="paket.references" />
   </ItemGroup>

--- a/src/FSharpVSPowerTools.Core/Symbols/HighlightUsageInFile.fs
+++ b/src/FSharpVSPowerTools.Core/Symbols/HighlightUsageInFile.fs
@@ -17,9 +17,9 @@ module Symbols =
 
 type FileName = string
 type GetCheckResults = FileName -> Async<ParseAndCheckResults option>
-type FCSZeroBasedRange = int * int * int * int
+type ZeroBasedRange = int * int * int * int
 
-type CurrentLine = {Line: string; File: FileName; Range: FCSZeroBasedRange}
+type CurrentLine = { Line: string; File: FileName; Range: ZeroBasedRange }
     with
         member x.EndLine =
             let _, _, endLine, _ = x.Range
@@ -28,9 +28,10 @@ type CurrentLine = {Line: string; File: FileName; Range: FCSZeroBasedRange}
 module HighlightUsageInFile =
     open FSharpVSPowerTools
     open Microsoft.FSharp.Compiler.SourceCodeServices
-    [<NoComparisonAttribute(* due to FSharpSymbol*) >]
+    
+    [<NoComparisonAttribute(* due to FSharpSymbol *)>]
     type HighlightUsageInFileResult =
-    | UsageInFile of FSharpSymbol * string * FSharpSymbolUse array
+        | UsageInFile of FSharpSymbol * string * FSharpSymbolUse array
 
     let findUsageInFile (currentLine: CurrentLine) (symbol: Symbol) (getCheckResults: GetCheckResults) = 
         asyncMaybe {

--- a/src/FSharpVSPowerTools.Core/Symbols/HighlightUsageInFile.fs
+++ b/src/FSharpVSPowerTools.Core/Symbols/HighlightUsageInFile.fs
@@ -1,0 +1,41 @@
+namespace FSharpPowerTools.Core
+open FSharpVSPowerTools
+module Symbols = 
+    open System.IO
+    
+    open Microsoft.FSharp.Compiler.SourceCodeServices
+    
+    let filterSymbolUsesDuplicates (uses: FSharpSymbolUse []) =
+        uses
+        |> Seq.map (fun symbolUse -> (symbolUse.FileName, symbolUse))
+        |> Seq.groupBy (fst >> Path.GetFullPathSafe)
+        |> Seq.collect (fun (_, symbolUses) -> 
+            symbolUses 
+            |> Seq.map snd 
+            |> Seq.distinctBy (fun s -> s.RangeAlternate))
+        |> Seq.toArray
+
+type FileName = string
+type GetCheckResults = FileName -> Async<ParseAndCheckResults option>
+type FCSZeroBasedRange = int * int * int * int
+
+type CurrentLine = {Line: string; File: FileName; Range: FCSZeroBasedRange}
+    with
+        member x.EndLine =
+            let _, _, endLine, _ = x.Range
+            endLine
+
+module HighlightUsageInFile =
+    open FSharpVSPowerTools
+    open Microsoft.FSharp.Compiler.SourceCodeServices
+    [<NoComparisonAttribute(* due to FSharpSymbol*) >]
+    type HighlightUsageInFileResult =
+    | UsageInFile of FSharpSymbol * string * FSharpSymbolUse array
+
+    let findUsageInFile (currentLine: CurrentLine) (symbol: Symbol) (getCheckResults: GetCheckResults) = 
+        asyncMaybe {
+            let! parseAndCheckResults = getCheckResults currentLine.File
+            let! _ = parseAndCheckResults.GetSymbolUseAtLocation (currentLine.EndLine+1, symbol.RightColumn, currentLine.Line, [symbol.Text])
+            let! (symbol, ident, refs) = parseAndCheckResults.GetUsesOfSymbolInFileAtLocation (currentLine.EndLine, symbol.RightColumn, currentLine.Line, symbol.Text)
+            return UsageInFile (symbol, ident, Symbols.filterSymbolUsesDuplicates refs)
+        }

--- a/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/HighlightUsageTagger.fs
@@ -5,6 +5,7 @@ open System.IO
 open Microsoft.VisualStudio.Text
 open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text.Tagging
+open FSharpPowerTools.Core.HighlightUsageInFile
 open FSharpVSPowerTools
 open FSharpVSPowerTools.AsyncMaybe
 open FSharpVSPowerTools.ProjectSystem
@@ -67,22 +68,15 @@ type HighlightUsageTagger(doc: ITextDocument,
         async {
             if currentRequest = requestedPoint then
                 try
-                    let! res = vsLanguageService.GetFSharpSymbolUse (newWord, symbol, fileName, projectProvider, AllowStaleResults.MatchingSource)
+                    let! res = vsLanguageService.FindUsagesInFile (newWord, symbol, fileName, projectProvider, AllowStaleResults.MatchingSource)
                     match res with
-                    | Some (_, checkResults) ->
-                        let! results = vsLanguageService.FindUsagesInFile (newWord, symbol, checkResults)
-                        let refSpans =
-                            results |> Option.map (fun (_, lastIdent, refs) -> symbolUsesToSpans newWord fileName lastIdent refs)
-
-                        match refSpans with
-                        | Some references -> 
-                            // Ignore symbols without any use
-                            let word = if List.isEmpty references then None else Some newWord
-                            do! callInUIContext <| fun _ -> synchronousUpdate (currentRequest, references, word)
-                        | None ->
-                            // Return empty values in order to clear up markers
-                            do! callInUIContext <| fun _ -> synchronousUpdate (currentRequest, [], None)
-                    | None -> 
+                    | Some (UsageInFile (_, lastIdent, refs)) -> 
+                        let references = symbolUsesToSpans newWord fileName lastIdent refs
+                        // Ignore symbols without any use
+                        let word = if List.isEmpty references then None else Some newWord
+                        do! callInUIContext <| fun _ -> synchronousUpdate (currentRequest, references, word)
+                    | _ -> 
+                        // Return empty values in order to clear up markers
                         do! callInUIContext <| fun _ -> synchronousUpdate (currentRequest, [], None)
                 with e ->
                     Logging.logExceptionWithContext(e, "Failed to update highlight references.")


### PR DESCRIPTION
So that logic is separated from FSharpVSPowerTools.Logic project with a new HighlightUsageInFile module in FSharpVSPowerTools.Core project