### PR TITLE
GoToDefinition refactors first pass

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -74,6 +74,9 @@ type ParseAndCheckResults private (infoOpt: (FSharpCheckFileResults * FSharpPars
             return symbolUse.Symbol, ident, refs
         }
 
+    member __.GetDeclarationLocation(symbol, lineStr, preferSignature) =
+        __.GetDeclarationLocation(symbol.Line, symbol.RightColumn, lineStr, symbol.Text, preferSignature)
+
     member __.GetDeclarationLocation(line, col, lineStr, ident, preferSignature) =
         async {
             match infoOpt with 


### PR DESCRIPTION
I want to change a bit the logic split in getDocumentState and where it used (matching over large tuple, and more logic if not matching).