### PR TITLE
[wip] Refactor GoToDefinitionFilter 

### DIFF
--- a/src/FSharpVSPowerTools.Core/LanguageService.fs
+++ b/src/FSharpVSPowerTools.Core/LanguageService.fs
@@ -82,7 +82,10 @@ type ParseAndCheckResults private (infoOpt: (FSharpCheckFileResults * FSharpPars
             | Some (checkResults, _parseResults) -> 
                 return! checkResults.GetDeclarationLocationAlternate(line+1, col, lineStr, [ident], preferSignature)
         }
-            
+
+    member __.GetDeclarationLocation(symbol, lineStr, preferSignature) =
+        __.GetDeclarationLocation(symbol.Line, symbol.RightColumn, lineStr, symbol.Text, preferSignature)
+
     member __.GetIdentTooltip (line, colAtEndOfNames, lineText, names) =
         Debug.Assert(names <> [], "The names should not be empty (for which GetToolTip raises exceptions).")
         asyncMaybe {

--- a/src/FSharpVSPowerTools.Core/Lexer.fs
+++ b/src/FSharpVSPowerTools.Core/Lexer.fs
@@ -89,7 +89,7 @@ module Lexer =
         loop (queryLexState source defines line) []
 
     // Returns symbol at a given position.
-    let getSymbolFromTokens (tokens: FSharpTokenInfo list) line col (lineStr: string) lookupKind: Symbol option =
+    let getSymbolFromTokens (tokens: FSharpTokenInfo list) line col (lineStr: string) lookupKind : Symbol option =
         let isIdentifier t = t.CharClass = FSharpTokenCharKind.Identifier
         let isOperator t = t.ColorClass = FSharpTokenColorKind.Operator
     
@@ -198,6 +198,7 @@ module Lexer =
                   RightColumn = token.RightColumn + 1
                   Text = lineStr.Substring(token.Token.LeftColumn, token.Token.FullMatchedLength) })
     
+    
     let getSymbol source line col lineStr lookupKind (args: string[]) queryLexState =
         let tokens = tokenizeLine source args line lineStr queryLexState
         try
@@ -206,6 +207,5 @@ module Lexer =
             debug "Getting lex symbols failed with %O" e
             None
 
-    let getSymbolAtPoint point lookupKind (args) queryLexState =
-        let line, col = point.Point
-        getSymbol point.Document line col point.Line lookupKind args queryLexState
+    let getSymbolAtPoint point lookupKind args queryLexState =
+        getSymbol point.Document point.Point.Line point.Point.Column point.Line lookupKind args queryLexState

--- a/src/FSharpVSPowerTools.Core/Lexer.fs
+++ b/src/FSharpVSPowerTools.Core/Lexer.fs
@@ -16,7 +16,7 @@ type Symbol =
       LeftColumn: int
       RightColumn: int
       Text: string }
-    member x.Range : Range<FCS> = { From = Point.make x.Line x.LeftColumn; To = Point.make x.Line x.RightColumn }
+    member x.Range : Range<FCS> = { Start = Point.make x.Line x.LeftColumn; End = Point.make x.Line x.RightColumn }
 
 [<RequireQualifiedAccess>]
 type SymbolLookupKind =

--- a/src/FSharpVSPowerTools.Core/Lexer.fs
+++ b/src/FSharpVSPowerTools.Core/Lexer.fs
@@ -16,7 +16,7 @@ type Symbol =
       LeftColumn: int
       RightColumn: int
       Text: string }
-    member x.Range = x.Line, x.LeftColumn, x.Line, x.RightColumn
+    member x.Range : Range<FCS> = { From = Point.make x.Line x.LeftColumn; To = Point.make x.Line x.RightColumn }
 
 [<RequireQualifiedAccess>]
 type SymbolLookupKind =

--- a/src/FSharpVSPowerTools.Core/Symbols/HighlightUsageInFile.fs
+++ b/src/FSharpVSPowerTools.Core/Symbols/HighlightUsageInFile.fs
@@ -14,17 +14,7 @@ module Symbols =
             |> Seq.map snd 
             |> Seq.distinctBy (fun s -> s.RangeAlternate))
         |> Seq.toArray
-
-type FileName = string
 type GetCheckResults = FileName -> Async<ParseAndCheckResults option>
-type ZeroBasedRange = int * int * int * int
-
-type CurrentLine = { Line: string; File: FileName; Range: ZeroBasedRange }
-    with
-        member x.EndLine =
-            let _, _, endLine, _ = x.Range
-            endLine
-
 module HighlightUsageInFile =
     open FSharpVSPowerTools
     open Microsoft.FSharp.Compiler.SourceCodeServices

--- a/src/FSharpVSPowerTools.Core/Symbols/HighlightUsageInFile.fs
+++ b/src/FSharpVSPowerTools.Core/Symbols/HighlightUsageInFile.fs
@@ -14,7 +14,9 @@ module Symbols =
             |> Seq.map snd 
             |> Seq.distinctBy (fun s -> s.RangeAlternate))
         |> Seq.toArray
+
 type GetCheckResults = FileName -> Async<ParseAndCheckResults option>
+
 module HighlightUsageInFile =
     open FSharpVSPowerTools
     open Microsoft.FSharp.Compiler.SourceCodeServices
@@ -23,7 +25,7 @@ module HighlightUsageInFile =
     type HighlightUsageInFileResult =
         | UsageInFile of FSharpSymbol * string * FSharpSymbolUse array
 
-    let findUsageInFile (currentLine: CurrentLine) (symbol: Symbol) (getCheckResults: GetCheckResults) = 
+    let findUsageInFile (currentLine: CurrentLine<FCS>) (symbol: Symbol) (getCheckResults: GetCheckResults) = 
         asyncMaybe {
             let! parseAndCheckResults = getCheckResults currentLine.File
             let! _ = parseAndCheckResults.GetSymbolUseAtLocation (currentLine.EndLine+1, symbol.RightColumn, currentLine.Line, [symbol.Text])

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -5,7 +5,7 @@ type FileName = string
 [<Measure>] type FCS
 
 type Point<[<Measure>]'t> = { Line : int; Column : int }
-type Range<[<Measure>]'t> = { From : Point<'t>; To: Point<'t> }
+type Range<[<Measure>]'t> = { Start : Point<'t>; End: Point<'t> }
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Point =
@@ -16,13 +16,13 @@ module Range =
 
     let make startLine startColumn endLine endColumn : Range<'t> =
         {
-          From = Point.make startLine startColumn
-          To = Point.make endLine endColumn 
+          Start = Point.make startLine startColumn
+          End = Point.make endLine endColumn 
         }
     
 type CurrentLine<[<Measure>]'t> = { Line: string; File: FileName; Range: Range<'t> }
     with
-        member x.EndLine = x.Range.To.Line 
+        member x.EndLine = x.Range.End.Line 
 
 [<NoComparison>]
 type PointInDocument<[<Measure>]'t> = {

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -9,8 +9,7 @@ type Range<[<Measure>]'t> = { From : Point<'t>; To: Point<'t> }
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Point =
-    let make    line column : Point<'t> = { Line = line; Column = column }
-    //let makeFCS line column : Point<FCS> = { Line = line; Column = column }
+    let make line column : Point<'t> = { Line = line; Column = column }
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module Range =
@@ -20,19 +19,7 @@ module Range =
           From = Point.make startLine startColumn
           To = Point.make endLine endColumn 
         }
-        (*
-    let makeVS startLine startColumn endLine endColumn =
-        { 
-          From = Point.makeVS startLine startColumn
-          To = Point.makeVS endLine endColumn 
-        }
-        
-    let makeFCS startLine startColumn endLine endColumn =
-        { 
-          From = Point.makeFCS startLine startColumn
-          To = Point.makeFCS endLine endColumn 
-        }
-        *)
+    
 type CurrentLine<[<Measure>]'t> = { Line: string; File: FileName; Range: Range<'t> }
     with
         member x.EndLine = x.Range.To.Line 

--- a/src/FSharpVSPowerTools.Core/Utils.fs
+++ b/src/FSharpVSPowerTools.Core/Utils.fs
@@ -1,4 +1,28 @@
-﻿namespace FSharpVSPowerTools
+﻿namespace FSharpPowerTools.Core
+
+type FileName = string
+
+type ZeroBasedPoint = int * int
+type ZeroBasedRange = int * int * int * int
+
+type CurrentLine = { Line: string; File: FileName; Range: ZeroBasedRange }
+    with
+        member x.EndLine =
+            let _, _, endLine, _ = x.Range
+            endLine
+
+[<NoComparison>]
+type PointInDocument = {
+  Point: ZeroBasedPoint
+  Line: string
+  Document: string
+  File: FileName
+}
+    with
+        member x.LineIndex = fst x.Point
+        member x.ColumnIndex = snd x.Point
+        member x.CurrentLine = {Line = x.Line; File = x.File; Range = x.LineIndex, x.ColumnIndex, x.LineIndex, x.Line.Length }
+namespace FSharpVSPowerTools
 
 open System
 open System.Diagnostics

--- a/src/FSharpVSPowerTools.Logic.VS2015/PeekDefinition.fs
+++ b/src/FSharpVSPowerTools.Logic.VS2015/PeekDefinition.fs
@@ -74,7 +74,7 @@ type PeekableItemSource
                 | Some (fsSymbolUse, fileScopedCheckResults) ->
                     let start = span.Start
                     let lineStr = start.GetContainingLine().GetText()
-                    let! findDeclResult = fileScopedCheckResults.GetDeclarationLocation(symbol.Line, symbol.RightColumn, lineStr, symbol.Text, preferSignature=false)
+                    let! findDeclResult = fileScopedCheckResults.GetDeclarationLocation(symbol, lineStr, preferSignature = false)
                     match findDeclResult with
                     | FSharpFindDeclResult.DeclFound range -> 
                         return Some (span, range, false)

--- a/src/FSharpVSPowerTools.Logic/Common/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/Common/VSUtils.fs
@@ -149,8 +149,8 @@ type SnapshotSpan with
         { Line = x.Start.GetContainingLine().GetText(); Range = x.ToRange(); File = filename }
     
     static member MakeFromRange (snapshot: ITextSnapshot) (range:Range<FCS>) =
-        let startPos = snapshot.GetLineFromLineNumber(range.From.Line).Start.Position + range.From.Column
-        let endPos = snapshot.GetLineFromLineNumber(range.To.Line).Start.Position + range.To.Column
+        let startPos = snapshot.GetLineFromLineNumber(range.Start.Line).Start.Position + range.Start.Column
+        let endPos = snapshot.GetLineFromLineNumber(range.End.Line).Start.Position + range.End.Column
         SnapshotSpan(snapshot, startPos, endPos - startPos)
 
 type ITextBuffer with

--- a/src/FSharpVSPowerTools.Logic/Common/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/Common/VSUtils.fs
@@ -82,6 +82,13 @@ type SnapshotPoint with
         point.CompareTo span.Start >= 0 && point.CompareTo span.End <= 0
     member x.ToPoint =
         x.Snapshot.GetLineNumberFromPosition x.Position, x.Position - x.GetContainingLine().Start.Position
+    
+    member x.MakePointInDocument filename source : PointInDocument<FCS> =
+        let line = x.Snapshot.GetLineNumberFromPosition x.Position
+        let col = x.Position - x.GetContainingLine().Start.Position
+        let lineStr = x.GetContainingLine().GetText()
+        { Point = Point.make line col; Line = lineStr; File = filename; Document = source }
+
 type ITextSnapshot with
     /// SnapshotSpan of the entirety of this TextSnapshot
     member x.FullSpan =
@@ -135,8 +142,8 @@ type SnapshotSpan with
 
     /// Return corresponding zero-based FCS range
     /// (lineStart, colStart, lineEnd, colEnd)
-    member inline x.ToRange () =
-        (x.StartLineNum, x.StartColumn, x.EndLineNum, x.EndColumn-1)
+    member inline x.ToRange () : Range<FCS> =
+        Range.make x.StartLineNum x.StartColumn x.EndLineNum (x.EndColumn - 1)
 
     member inline x.MakeCurrentLine (filename) =
         { Line = x.Start.GetContainingLine().GetText(); Range = x.ToRange(); File = filename }

--- a/src/FSharpVSPowerTools.Logic/Common/VSUtils.fs
+++ b/src/FSharpVSPowerTools.Logic/Common/VSUtils.fs
@@ -148,9 +148,9 @@ type SnapshotSpan with
     member inline x.MakeCurrentLine (filename) =
         { Line = x.Start.GetContainingLine().GetText(); Range = x.ToRange(); File = filename }
     
-    static member MakeFromRange (snapshot: ITextSnapshot) (lineStart, colStart, lineEnd, colEnd) =
-        let startPos = snapshot.GetLineFromLineNumber(lineStart).Start.Position + colStart
-        let endPos = snapshot.GetLineFromLineNumber(lineEnd).Start.Position + colEnd
+    static member MakeFromRange (snapshot: ITextSnapshot) (range:Range<FCS>) =
+        let startPos = snapshot.GetLineFromLineNumber(range.From.Line).Start.Position + range.From.Column
+        let endPos = snapshot.GetLineFromLineNumber(range.To.Line).Start.Position + range.To.Column
         SnapshotSpan(snapshot, startPos, endPos - startPos)
 
 type ITextBuffer with

--- a/src/FSharpVSPowerTools.Logic/Navigation/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/Navigation/GoToDefinitionFilter.fs
@@ -175,8 +175,8 @@ type GoToDefinitionFilter
 
     let cancellationToken = Atom None
 
-    let handleFoundExternal project parseTree (symbol: Symbol) fsSymbolUse snapshotPoint = async {        
-        let span = SnapshotSpan.MakeFromRange snapshotPoint.Snapshot (symbol.Range |> fun (a, b, c, d) Range.make a b c d)
+    let handleFoundExternal project parseTree (symbol: Symbol) (fsSymbolUse: FSharpSymbolUse) (snapshotPoint: SnapshotPoint) = async {        
+        let span = SnapshotSpan.MakeFromRange snapshotPoint.Snapshot symbol.Range
         match navigationPreference with
         | NavigationPreference.Metadata ->
             if shouldGenerateDefinition fsSymbolUse.Symbol then

--- a/src/FSharpVSPowerTools.Logic/Navigation/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/Navigation/GoToDefinitionFilter.fs
@@ -237,7 +237,11 @@ type GoToDefinitionFilter
                         serviceProvider.NavigateTo(fileToOpen, startRow=0, startCol=0, endRow=0, endCol=0)
                     | Some (FoundExternal (project, parseTree, symbol, fsSymbolUse)) ->
                         return! handleFoundExternal project parseTree symbol fsSymbolUse snapshotPoint
-                | _ -> return ()
+                | _ -> 
+                    // Run the operation on UI thread since continueCommandChain may access UI components.
+                    do! Async.SwitchToContext uiContext
+                    // Declaration location might exist so let Visual F# Tools handle it. 
+                    return continueCommandChain()
             }
         Async.StartInThreadPoolSafe (worker, cancelToken.Token)
 

--- a/src/FSharpVSPowerTools.Logic/Navigation/GoToDefinitionFilter.fs
+++ b/src/FSharpVSPowerTools.Logic/Navigation/GoToDefinitionFilter.fs
@@ -224,7 +224,6 @@ type GoToDefinitionFilter
                 match textBuffer.GetSnapshotPoint view.Caret.Position, vsLanguageService.GetCompleteTextForDocument doc.FilePath with
                 | Some snapshotPoint, Some source ->
                     let pointInDocument = snapshotPoint.MakePointInDocument doc.FilePath source
-                    // vsLanguageService.MakePointInDocument snapshotPoint doc.FilePath
                     let! symbolResult = getDocumentState pointInDocument getLexerState
                     match symbolResult with
                     | Some FoundInternal

--- a/src/FSharpVSPowerTools.Logic/Navigation/NavigateToMetadataService.fs
+++ b/src/FSharpVSPowerTools.Logic/Navigation/NavigateToMetadataService.fs
@@ -191,8 +191,8 @@ type NavigateToMetadataService [<ImportingConstructor>]
                     return None
             | false, _, _, _ ->
                 let range = span.ToRange()
-                let startLine = range.From.Line
-                let startCol = range.From.Column
+                let startLine = range.Start.Line
+                let startCol = range.Start.Column
                 let pos = mkPos (startLine+1) startCol
                 let openDeclarations = 
                     ast 

--- a/src/FSharpVSPowerTools.Logic/Navigation/NavigateToMetadataService.fs
+++ b/src/FSharpVSPowerTools.Logic/Navigation/NavigateToMetadataService.fs
@@ -190,7 +190,9 @@ type NavigateToMetadataService [<ImportingConstructor>]
                     Logging.logInfo (fun _ -> sprintf "Can't find a signature or signature project for '%s'" filePath)               
                     return None
             | false, _, _, _ ->
-                let (startLine, startCol, _, _) = span.ToRange()
+                let range = span.ToRange()
+                let startLine = range.From.Line
+                let startCol = range.From.Column
                 let pos = mkPos (startLine+1) startCol
                 let openDeclarations = 
                     ast 

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -270,7 +270,8 @@ type OutliningTagger
         let rec loop acc =
             if acc >= textshot.LineCount + firstLineNum then "" else
             let text =  if acc = firstLineNum then
-                            let _,colstart,_,_ = snapshotSpan.ToRange ()
+                            let range = snapshotSpan.ToRange ()
+                            let colstart = range.From.Column
                             textshot.LineText(acc).Substring(colstart).Trim ()
                         else textshot.LineText(acc).Trim ()
             if String.IsNullOrWhiteSpace text then loop (acc+1) else text

--- a/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
+++ b/src/FSharpVSPowerTools.Logic/Outlining/OutliningTagger.fs
@@ -271,7 +271,7 @@ type OutliningTagger
             if acc >= textshot.LineCount + firstLineNum then "" else
             let text =  if acc = firstLineNum then
                             let range = snapshotSpan.ToRange ()
-                            let colstart = range.From.Column
+                            let colstart = range.Start.Column
                             textshot.LineText(acc).Substring(colstart).Trim ()
                         else textshot.LineText(acc).Trim ()
             if String.IsNullOrWhiteSpace text then loop (acc+1) else text

--- a/src/FSharpVSPowerTools.Logic/ProjectSystem/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectSystem/VSLanguageService.fs
@@ -358,15 +358,3 @@ type VSLanguageService
 
     member __.GetCompleteTextForDocument filename =
         openDocumentsTracker.TryGetDocumentText filename
-
-    member __.MakePointInDocument (point: SnapshotPoint option) filename =
-        maybe {
-            let! point = point
-            let! source = openDocumentsTracker.TryGetDocumentText filename
-            let line = point.Snapshot.GetLineNumberFromPosition point.Position
-            let col = point.Position - point.GetContainingLine().Start.Position
-            let lineStr = point.GetContainingLine().GetText()
-            return {Point = Point.make line col; Line = lineStr; File = filename; Document = source }
-        }
-        
-        

--- a/src/FSharpVSPowerTools.Logic/ProjectSystem/VSLanguageService.fs
+++ b/src/FSharpVSPowerTools.Logic/ProjectSystem/VSLanguageService.fs
@@ -159,8 +159,8 @@ type VSLanguageService
                 sprintf "Snapshot '%A' doesn't refer to the current document '%s'." word.Snapshot currentFile)
             try
                 let range = word.ToRange()
-                let endLine = range.To.Line
-                let endCol = range.To.Column
+                let endLine = range.End.Line
+                let endCol = range.End.Column
                 let! source = openDocumentsTracker.TryGetDocumentText currentFile
                 let currentLine = word.Start.GetContainingLine().GetText()
                 let framework = currentProject.TargetFramework
@@ -197,7 +197,7 @@ type VSLanguageService
         async {
             try 
                 let range = word.ToRange()
-                let endLine = range.To.Line
+                let endLine = range.End.Line
                 let currentLine = word.Start.GetContainingLine().GetText()
             
                 debug "[Language Service] Get symbol references for '%s' at line %d col %d" (word.GetText()) endLine sym.RightColumn
@@ -235,7 +235,7 @@ type VSLanguageService
             Debug.Assert(mayReferToSameBuffer word.Snapshot currentFile, 
                 sprintf "Snapshot '%A' doesn't refer to the current document '%s'." word.Snapshot currentFile)
             let range = word.ToRange()
-            let endLine = range.To.Line
+            let endLine = range.End.Line
             let! source = openDocumentsTracker.TryGetDocumentText currentFile
             let currentLine = word.Start.GetContainingLine().GetText()
             let! opts = projectProvider.GetProjectCheckerOptions instance |> liftAsync
@@ -247,8 +247,8 @@ type VSLanguageService
     member __.CreateLexer (fileName, snapshot, args) =
         maybe {
             let range = SnapshotSpan(snapshot, 0, snapshot.Length).ToRange()
-            let lineStart = range.From.Line
-            let lineEnd = range.To.Line
+            let lineStart = range.Start.Line
+            let lineEnd = range.End.Line
             
             let getLineStr line =
                 let lineNumber = line - lineStart

--- a/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
@@ -28,11 +28,11 @@ with
         member x.StartLine: int<Line1> = x.StartLine
 
     static member FromSymbol(symbol: Symbol) =
-        let { From = { Line = startLine; Column = startColumn }; To = { Line = endLine; Column = endColumn }} = symbol.Range
-        { StartLine = LanguagePrimitives.Int32WithMeasure startLine
-          StartColumn = startColumn
-          EndLine = LanguagePrimitives.Int32WithMeasure endLine
-          EndColumn = endColumn }
+        let range = symbol.Range
+        { StartLine = LanguagePrimitives.Int32WithMeasure range.Start.Line
+          StartColumn = range.Start.Column
+          EndLine = LanguagePrimitives.Int32WithMeasure range.End.Line
+          EndColumn = range.End.Column }
 
 type CodeGenerationTestService(languageService: LanguageService, compilerOptions: string[]) =
     interface ICodeGenerationService<FSharpProjectOptions, pos, Range> with

--- a/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
+++ b/tests/FSharpVSPowerTools.Core.Tests/CodeGenerationTestInfrastructure.fs
@@ -3,6 +3,7 @@
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.Range
 open Microsoft.FSharp.Compiler.SourceCodeServices
+open FSharpPowerTools.Core
 open FSharpVSPowerTools
 open FSharpVSPowerTools.AsyncMaybe
 open FSharpVSPowerTools.CodeGeneration
@@ -27,7 +28,7 @@ with
         member x.StartLine: int<Line1> = x.StartLine
 
     static member FromSymbol(symbol: Symbol) =
-        let startLine, startColumn, endLine, endColumn = symbol.Range
+        let { From = { Line = startLine; Column = startColumn }; To = { Line = endLine; Column = endColumn }} = symbol.Range
         { StartLine = LanguagePrimitives.Int32WithMeasure startLine
           StartColumn = startColumn
           EndLine = LanguagePrimitives.Int32WithMeasure endLine


### PR DESCRIPTION
getDocumentState/gotoDefinition with more appropriate separation of logic to identify definition type and how to handle it

Tried it on paket solution, go to script, go to symbol in same file and go to symbol in FSharp.Core all worked.