### PR TITLE
minor clean up to build PointInDocument from Visual Studio side

### DIFF
--- a/src/FSharp.Editing.VisualStudio/Common/Utils.fs
+++ b/src/FSharp.Editing.VisualStudio/Common/Utils.fs
@@ -155,7 +155,7 @@ type SnapshotSpan with
 type ITextBuffer with
     member x.GetSnapshotPoint (position: CaretPosition) = 
         Option.ofNullable <| position.Point.GetPoint(x, position.Affinity)
-    
+
     member x.TriggerTagsChanged (sender: obj) (event: Event<_,_>) =
         let span = x.CurrentSnapshot.FullSpan
         event.Trigger(sender, SnapshotSpanEventArgs(span))
@@ -179,6 +179,8 @@ type ITextView with
           let! line, col = x.GetCaretPosition()
           return Microsoft.FSharp.Compiler.Range.mkPos (line + 1) (col + 1)
         }
+    
+    member x.SnapshotPointAtCaret = x.TextBuffer.GetSnapshotPoint x.Caret.Position
 
 open System.Runtime.InteropServices
 open Microsoft.VisualStudio

--- a/src/FSharp.Editing.VisualStudio/ProjectSystem/VSLanguageService.fs
+++ b/src/FSharp.Editing.VisualStudio/ProjectSystem/VSLanguageService.fs
@@ -20,6 +20,8 @@ open FSharp.Editing
 open FSharp.Editing.Infrastructure
 open FSharp.Editing.Features
 open FSharp.Editing.Features.Symbols
+open FSharp.Editing.VisualStudio
+open Microsoft.VisualStudio.Text.Editor
 
 [<RequireQualifiedAccess; NoComparison>]
 type SymbolDeclarationLocation = 
@@ -345,3 +347,15 @@ type VSLanguageService
 
     member __.GetCompleteTextForDocument filename =
         openDocumentsTracker.TryGetDocumentText filename
+
+    member this.MakePointInDocument (textDocument: ITextDocument, snapshotPoint: SnapshotPoint) =
+        maybe {
+            let! source = this.GetCompleteTextForDocument textDocument.FilePath
+            return snapshotPoint.MakePointInDocument textDocument.FilePath source
+        }
+
+    member this.MakePointInDocument (textDocument: ITextDocument, view: IWpfTextView) =
+        maybe {
+          let! snapshotPoint = view.SnapshotPointAtCaret
+          return this.MakePointInDocument(textDocument, snapshotPoint)
+        }


### PR DESCRIPTION
* ITextView.SnapshotPointAtCaret helper extension member
* expose VSLanguageService.MakePointInDocument to better encapsulate obtaining PointInDocument from VS editor
* GoToDefinitionFilter:
  * factorized fallback continuation code (now needing it three times)
  * simplify making PointInDocument, although since we need SnapshotPoint (to be simplified later hopefully) I'm using two steps (get snapshotpoint, then get pointindocument)