### PR TITLE
Fix broken link to Contributing.md

### DIFF
--- a/codeformatting.html
+++ b/codeformatting.html
@@ -110,7 +110,7 @@ could be adjusted under "Tools --&gt; Options --&gt; Text Editor --&gt; F# --&gt
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/depthcolorizer.html
+++ b/depthcolorizer.html
@@ -66,7 +66,7 @@ and two other schemes for dark theme: <a href="img/FSDCDarkDefault.reg">Default<
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/faq.html
+++ b/faq.html
@@ -97,7 +97,7 @@ You can workaround by disabling the ReSharper option "Hide overridden Visual Stu
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/findallreferences.html
+++ b/findallreferences.html
@@ -56,7 +56,7 @@ The feature can be triggered by Find All References context menu or Shift + F12 
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/folderorganization.html
+++ b/folderorganization.html
@@ -97,7 +97,7 @@ Alternatively you can move files out of the folder and move them into the folder
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/generatereferences.html
+++ b/generatereferences.html
@@ -63,7 +63,7 @@ When being integrated to VFPT, the feature has been modified as follows:</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/gotometadata.html
+++ b/gotometadata.html
@@ -75,7 +75,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/highlightusage.html
+++ b/highlightusage.html
@@ -76,7 +76,7 @@ These key bindings can be changed by searching for <code>Edit.NextHighlightedRef
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/implementinterface.html
+++ b/implementinterface.html
@@ -63,7 +63,7 @@ We recommend users to generate interfaces while the code is parseable e.g. after
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@ redistribution for both commercial and non-commercial purposes. For more informa
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/lint.html
+++ b/lint.html
@@ -79,7 +79,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/navigateto.html
+++ b/navigateto.html
@@ -56,7 +56,7 @@ It performs quick search to navigate between different locations in the source f
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/navigatetosource.html
+++ b/navigatetosource.html
@@ -74,7 +74,7 @@ In the subsequent uses of F12 Navigate to Source, VFPT will pick up and use thes
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/outlining.html
+++ b/outlining.html
@@ -68,7 +68,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/peekdefinition.html
+++ b/peekdefinition.html
@@ -59,7 +59,7 @@ versions.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/quickinfopanel.html
+++ b/quickinfopanel.html
@@ -56,7 +56,7 @@ cursor, eliminating the need to use mouses to see tooltips with the same info.</
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/recordstubgeneration.html
+++ b/recordstubgeneration.html
@@ -67,7 +67,7 @@ We recommend users to generate field stubs while the code is parseable e.g. afte
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-allowstaleresults.html
+++ b/reference/fsharpvspowertools-allowstaleresults.html
@@ -132,7 +132,7 @@ regardless of whether if has been recently checked or not.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-arraymodule.html
+++ b/reference/fsharpvspowertools-arraymodule.html
@@ -481,7 +481,7 @@ to satisfy the predicate</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-assemblycontentprovider-assemblycontentcacheentry.html
+++ b/reference/fsharpvspowertools-assemblycontentprovider-assemblycontentcacheentry.html
@@ -119,7 +119,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-assemblycontentprovider-iassemblycontentcache.html
+++ b/reference/fsharpvspowertools-assemblycontentprovider-iassemblycontentcache.html
@@ -103,7 +103,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-assemblycontentprovider.html
+++ b/reference/fsharpvspowertools-assemblycontentprovider.html
@@ -126,7 +126,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-assemblycontenttype.html
+++ b/reference/fsharpvspowertools-assemblycontenttype.html
@@ -100,7 +100,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-assemblypath.html
+++ b/reference/fsharpvspowertools-assemblypath.html
@@ -92,7 +92,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-asyncmaybebuilder.html
+++ b/reference/fsharpvspowertools-asyncmaybebuilder.html
@@ -324,7 +324,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-asyncmaybemodule.html
+++ b/reference/fsharpvspowertools-asyncmaybemodule.html
@@ -85,7 +85,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-asyncmodule-array.html
+++ b/reference/fsharpvspowertools-asyncmodule-array.html
@@ -131,7 +131,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-asyncmodule-list.html
+++ b/reference/fsharpvspowertools-asyncmodule-list.html
@@ -89,7 +89,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-asyncmodule.html
+++ b/reference/fsharpvspowertools-asyncmodule.html
@@ -129,7 +129,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-categorizedcolumnspan-1.html
+++ b/reference/fsharpvspowertools-categorizedcolumnspan-1.html
@@ -100,7 +100,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-category.html
+++ b/reference/fsharpvspowertools-category.html
@@ -280,7 +280,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-icodegenerationservice-3.html
+++ b/reference/fsharpvspowertools-codegeneration-icodegenerationservice-3.html
@@ -159,7 +159,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-idocument.html
+++ b/reference/fsharpvspowertools-codegeneration-idocument.html
@@ -159,7 +159,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-interfacedata.html
+++ b/reference/fsharpvspowertools-codegeneration-interfacedata.html
@@ -147,7 +147,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-interfacestubgenerator.html
+++ b/reference/fsharpvspowertools-codegeneration-interfacestubgenerator.html
@@ -220,7 +220,7 @@ positions of 'member', which indicate the indentation for generating new members
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-irange.html
+++ b/reference/fsharpvspowertools-codegeneration-irange.html
@@ -140,7 +140,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-line0.html
+++ b/reference/fsharpvspowertools-codegeneration-line0.html
@@ -56,7 +56,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-line1.html
+++ b/reference/fsharpvspowertools-codegeneration-line1.html
@@ -56,7 +56,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-recordstubgenerator-positionkind.html
+++ b/reference/fsharpvspowertools-codegeneration-recordstubgenerator-positionkind.html
@@ -128,7 +128,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-recordstubgenerator-recordexpr.html
+++ b/reference/fsharpvspowertools-codegeneration-recordstubgenerator-recordexpr.html
@@ -119,7 +119,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-recordstubgenerator-recordstubsinsertionparams.html
+++ b/reference/fsharpvspowertools-codegeneration-recordstubgenerator-recordstubsinsertionparams.html
@@ -145,7 +145,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-recordstubgenerator.html
+++ b/reference/fsharpvspowertools-codegeneration-recordstubgenerator.html
@@ -204,7 +204,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-signaturegenerator-blanklines.html
+++ b/reference/fsharpvspowertools-codegeneration-signaturegenerator-blanklines.html
@@ -253,7 +253,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-signaturegenerator-filterer.html
+++ b/reference/fsharpvspowertools-codegeneration-signaturegenerator-filterer.html
@@ -127,7 +127,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-signaturegenerator-opendeclaration.html
+++ b/reference/fsharpvspowertools-codegeneration-signaturegenerator-opendeclaration.html
@@ -93,7 +93,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-signaturegenerator-xmldoc.html
+++ b/reference/fsharpvspowertools-codegeneration-signaturegenerator-xmldoc.html
@@ -157,7 +157,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-signaturegenerator-xmldocsig.html
+++ b/reference/fsharpvspowertools-codegeneration-signaturegenerator-xmldocsig.html
@@ -93,7 +93,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-signaturegenerator.html
+++ b/reference/fsharpvspowertools-codegeneration-signaturegenerator.html
@@ -183,7 +183,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-unionpatternmatchcasegenerator-patternmatchexpr.html
+++ b/reference/fsharpvspowertools-codegeneration-unionpatternmatchcasegenerator-patternmatchexpr.html
@@ -125,7 +125,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-unionpatternmatchcasegenerator-unionmatchcasesinsertionparams.html
+++ b/reference/fsharpvspowertools-codegeneration-unionpatternmatchcasegenerator-unionmatchcasesinsertionparams.html
@@ -101,7 +101,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-codegeneration-unionpatternmatchcasegenerator.html
+++ b/reference/fsharpvspowertools-codegeneration-unionpatternmatchcasegenerator.html
@@ -252,7 +252,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-depthparser.html
+++ b/reference/fsharpvspowertools-depthparser.html
@@ -90,7 +90,7 @@ Note: The 'filename' is only used e.g. to look at the filename extension (e.g. "
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-dict.html
+++ b/reference/fsharpvspowertools-dict.html
@@ -139,7 +139,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-entity.html
+++ b/reference/fsharpvspowertools-entity.html
@@ -136,7 +136,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-entitykind.html
+++ b/reference/fsharpvspowertools-entitykind.html
@@ -136,7 +136,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-entitymodule.html
+++ b/reference/fsharpvspowertools-entitymodule.html
@@ -121,7 +121,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-file.html
+++ b/reference/fsharpvspowertools-file.html
@@ -85,7 +85,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-filestate.html
+++ b/reference/fsharpvspowertools-filestate.html
@@ -136,7 +136,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-fsharpcompilerversion.html
+++ b/reference/fsharpvspowertools-fsharpcompilerversion.html
@@ -165,7 +165,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-fsharptargetframework.html
+++ b/reference/fsharpvspowertools-fsharptargetframework.html
@@ -175,7 +175,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-identifierutils.html
+++ b/reference/fsharpvspowertools-identifierutils.html
@@ -214,7 +214,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-idents.html
+++ b/reference/fsharpvspowertools-idents.html
@@ -56,7 +56,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-iinsertcontextdocument-1.html
+++ b/reference/fsharpvspowertools-iinsertcontextdocument-1.html
@@ -102,7 +102,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-insertcontext.html
+++ b/reference/fsharpvspowertools-insertcontext.html
@@ -100,7 +100,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-insertcontextmodule.html
+++ b/reference/fsharpvspowertools-insertcontextmodule.html
@@ -109,7 +109,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-isautoopen.html
+++ b/reference/fsharpvspowertools-isautoopen.html
@@ -56,7 +56,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-languageservice.html
+++ b/reference/fsharpvspowertools-languageservice.html
@@ -457,7 +457,7 @@ returns the results of checking the file.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-lexer.html
+++ b/reference/fsharpvspowertools-lexer.html
@@ -142,7 +142,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-lexerbase.html
+++ b/reference/fsharpvspowertools-lexerbase.html
@@ -183,7 +183,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-list.html
+++ b/reference/fsharpvspowertools-list.html
@@ -178,7 +178,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-longident.html
+++ b/reference/fsharpvspowertools-longident.html
@@ -92,7 +92,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-maybebuilder.html
+++ b/reference/fsharpvspowertools-maybebuilder.html
@@ -256,7 +256,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-modulekind.html
+++ b/reference/fsharpvspowertools-modulekind.html
@@ -100,7 +100,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-index-builder.html
+++ b/reference/fsharpvspowertools-navigation-index-builder.html
@@ -127,7 +127,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-index-iindexednavigableitems.html
+++ b/reference/fsharpvspowertools-navigation-index-iindexednavigableitems.html
@@ -84,7 +84,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-index-matchkind.html
+++ b/reference/fsharpvspowertools-navigation-index-matchkind.html
@@ -160,7 +160,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-index-navigableitemprocessor.html
+++ b/reference/fsharpvspowertools-navigation-index-navigableitemprocessor.html
@@ -57,7 +57,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-index.html
+++ b/reference/fsharpvspowertools-navigation-index.html
@@ -94,7 +94,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-navigableitem.html
+++ b/reference/fsharpvspowertools-navigation-navigableitem.html
@@ -154,7 +154,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-navigableitemkind.html
+++ b/reference/fsharpvspowertools-navigation-navigableitemkind.html
@@ -262,7 +262,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-navigableitempos.html
+++ b/reference/fsharpvspowertools-navigation-navigableitempos.html
@@ -100,7 +100,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-navigableitemrange.html
+++ b/reference/fsharpvspowertools-navigation-navigableitemrange.html
@@ -126,7 +126,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-navigation-navigableitemscollector.html
+++ b/reference/fsharpvspowertools-navigation-navigableitemscollector.html
@@ -85,7 +85,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-null.html
+++ b/reference/fsharpvspowertools-null.html
@@ -103,7 +103,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-opendeclaration.html
+++ b/reference/fsharpvspowertools-opendeclaration.html
@@ -136,7 +136,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-opendeclarationgetter-endcolumn.html
+++ b/reference/fsharpvspowertools-opendeclarationgetter-endcolumn.html
@@ -57,7 +57,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-opendeclarationgetter-line.html
+++ b/reference/fsharpvspowertools-opendeclarationgetter-line.html
@@ -57,7 +57,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-opendeclarationgetter.html
+++ b/reference/fsharpvspowertools-opendeclarationgetter.html
@@ -216,7 +216,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-opendeclarationmodule.html
+++ b/reference/fsharpvspowertools-opendeclarationmodule.html
@@ -85,7 +85,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-opendeclwithautoopens.html
+++ b/reference/fsharpvspowertools-opendeclwithautoopens.html
@@ -118,7 +118,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-opendeclwithautoopensmodule.html
+++ b/reference/fsharpvspowertools-opendeclwithautoopensmodule.html
@@ -85,7 +85,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-optionmodule.html
+++ b/reference/fsharpvspowertools-optionmodule.html
@@ -280,7 +280,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-parent.html
+++ b/reference/fsharpvspowertools-parent.html
@@ -224,7 +224,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-parseandcheckresults.html
+++ b/reference/fsharpvspowertools-parseandcheckresults.html
@@ -391,7 +391,7 @@ empty/negative results if information is missing.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-parsedinput-col.html
+++ b/reference/fsharpvspowertools-parsedinput-col.html
@@ -57,7 +57,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-parsedinput-scope.html
+++ b/reference/fsharpvspowertools-parsedinput-scope.html
@@ -101,7 +101,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-parsedinput.html
+++ b/reference/fsharpvspowertools-parsedinput.html
@@ -126,7 +126,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-pervasivemodule-atom-1.html
+++ b/reference/fsharpvspowertools-pervasivemodule-atom-1.html
@@ -127,7 +127,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-pervasivemodule.html
+++ b/reference/fsharpvspowertools-pervasivemodule.html
@@ -279,7 +279,7 @@ Not yet sure if this works for scripts.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-pos.html
+++ b/reference/fsharpvspowertools-pos.html
@@ -100,7 +100,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-prelude.html
+++ b/reference/fsharpvspowertools-prelude.html
@@ -199,7 +199,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-printfspecifiersusagegetter-printfspecifieruse.html
+++ b/reference/fsharpvspowertools-printfspecifiersusagegetter-printfspecifieruse.html
@@ -101,7 +101,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-printfspecifiersusagegetter.html
+++ b/reference/fsharpvspowertools-printfspecifiersusagegetter.html
@@ -102,7 +102,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-profiler.html
+++ b/reference/fsharpvspowertools-profiler.html
@@ -180,7 +180,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-rawentity.html
+++ b/reference/fsharpvspowertools-rawentity.html
@@ -198,7 +198,7 @@ Note: <em>all</em> parts are cleaned, not the last one.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-rawopendeclaration.html
+++ b/reference/fsharpvspowertools-rawopendeclaration.html
@@ -100,7 +100,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-reflection.html
+++ b/reference/fsharpvspowertools-reflection.html
@@ -211,7 +211,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-scopekind.html
+++ b/reference/fsharpvspowertools-scopekind.html
@@ -154,7 +154,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-seqmodule.html
+++ b/reference/fsharpvspowertools-seqmodule.html
@@ -103,7 +103,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-sourcecodeclassifier.html
+++ b/reference/fsharpvspowertools-sourcecodeclassifier.html
@@ -127,7 +127,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-stringbuildermodule.html
+++ b/reference/fsharpvspowertools-stringbuildermodule.html
@@ -151,7 +151,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-stringmodule.html
+++ b/reference/fsharpvspowertools-stringmodule.html
@@ -266,7 +266,7 @@ return null if the string is null</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-symbol.html
+++ b/reference/fsharpvspowertools-symbol.html
@@ -180,7 +180,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-symbolkind.html
+++ b/reference/fsharpvspowertools-symbolkind.html
@@ -154,7 +154,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-symbollookupkind.html
+++ b/reference/fsharpvspowertools-symbollookupkind.html
@@ -118,7 +118,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-symboluse.html
+++ b/reference/fsharpvspowertools-symboluse.html
@@ -118,7 +118,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-tasklist-comment.html
+++ b/reference/fsharpvspowertools-tasklist-comment.html
@@ -154,7 +154,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-tasklist-commentextractor.html
+++ b/reference/fsharpvspowertools-tasklist-commentextractor.html
@@ -85,7 +85,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-tasklist-commentoption.html
+++ b/reference/fsharpvspowertools-tasklist-commentoption.html
@@ -126,7 +126,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-typedastextensionhelpers.html
+++ b/reference/fsharpvspowertools-typedastextensionhelpers.html
@@ -283,7 +283,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-typedastpatterns.html
+++ b/reference/fsharpvspowertools-typedastpatterns.html
@@ -753,7 +753,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-typedastutils.html
+++ b/reference/fsharpvspowertools-typedastutils.html
@@ -193,7 +193,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-hashdirectiveinfo-directive.html
+++ b/reference/fsharpvspowertools-untypedastutils-hashdirectiveinfo-directive.html
@@ -101,7 +101,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-hashdirectiveinfo-includedirective.html
+++ b/reference/fsharpvspowertools-untypedastutils-hashdirectiveinfo-includedirective.html
@@ -83,7 +83,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-hashdirectiveinfo-loaddirective.html
+++ b/reference/fsharpvspowertools-untypedastutils-hashdirectiveinfo-loaddirective.html
@@ -101,7 +101,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-hashdirectiveinfo.html
+++ b/reference/fsharpvspowertools-untypedastutils-hashdirectiveinfo.html
@@ -140,7 +140,7 @@ based on #I and #load directives</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-outlining-collapse.html
+++ b/reference/fsharpvspowertools-untypedastutils-outlining-collapse.html
@@ -108,7 +108,7 @@ following a binding or the right hand side of a pattern, e.g. <code>let x = ...<
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-outlining-scope.html
+++ b/reference/fsharpvspowertools-untypedastutils-outlining-scope.html
@@ -923,7 +923,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-outlining-scoperange.html
+++ b/reference/fsharpvspowertools-untypedastutils-outlining-scoperange.html
@@ -145,7 +145,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-outlining.html
+++ b/reference/fsharpvspowertools-untypedastutils-outlining.html
@@ -178,7 +178,7 @@ following a binding or the right hand side of a pattern, e.g. <code>let x = ...<
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-printf-printffunction.html
+++ b/reference/fsharpvspowertools-untypedastutils-printf-printffunction.html
@@ -101,7 +101,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils-printf.html
+++ b/reference/fsharpvspowertools-untypedastutils-printf.html
@@ -77,7 +77,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-untypedastutils.html
+++ b/reference/fsharpvspowertools-untypedastutils.html
@@ -251,7 +251,7 @@ from an untyped AST for the purposes of outlining.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-unuseddeclarations.html
+++ b/reference/fsharpvspowertools-unuseddeclarations.html
@@ -103,7 +103,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-wordspan.html
+++ b/reference/fsharpvspowertools-wordspan.html
@@ -206,7 +206,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-xmldocable.html
+++ b/reference/fsharpvspowertools-xmldocable.html
@@ -85,7 +85,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-xmldoccomment.html
+++ b/reference/fsharpvspowertools-xmldoccomment.html
@@ -85,7 +85,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/fsharpvspowertools-xmldocparser.html
+++ b/reference/fsharpvspowertools-xmldocparser.html
@@ -88,7 +88,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/reference/index.html
+++ b/reference/index.html
@@ -666,7 +666,7 @@ empty/negative results if information is missing.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./../faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/rename.html
+++ b/rename.html
@@ -56,7 +56,7 @@ Rename dialog can be activated via Edit --&gt; Refactor --&gt; Rename menu, cont
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/resolveunopenednamespaces.html
+++ b/resolveunopenednamespaces.html
@@ -57,7 +57,7 @@ the namespace / module or suggests to use the fully qualified name.</p>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/syntaxcoloring.html
+++ b/syntaxcoloring.html
@@ -112,7 +112,7 @@ You can navigate to lines consisting of unused items by clicking on these marker
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/tasklistcomments.html
+++ b/tasklistcomments.html
@@ -81,7 +81,7 @@
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/unionpatternmatchcasegeneration.html
+++ b/unionpatternmatchcasegeneration.html
@@ -73,7 +73,7 @@ We recommend users to generate pattern match cases while the code is parseable e
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>

--- a/xmldoc.html
+++ b/xmldoc.html
@@ -89,7 +89,7 @@ and you get a blank XmlDoc template (if there wasn't already a non-empty XmlDoc 
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools">Source Code on GitHub</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/LICENSE.txt">License</a></li>
                 <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/RELEASE_NOTES.md">Release Notes</a></li>
-                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/CONTRIBUTING.md">How to contribute</a></li>
+                <li><a href="http://github.com/fsprojects/VisualFSharpPowerTools/blob/master/.github/CONTRIBUTING.md">How to contribute</a></li>
                 <li><a href="./faq.html">FAQ</a></li>
 
                 <li class="nav-header">Supported Features</li>


### PR DESCRIPTION
The link to contributing on the GH pages is broken, fixing the link to the MD file in the .github folder on the master branch.