### PR TITLE
[WIP] Add AbstractClass attribute in generated metadata (#1482)

### DIFF
--- a/tests/data/gotodef/generic-cases/go-to-abstract-class-defined-in-csharp/expected.fs
+++ b/tests/data/gotodef/generic-cases/go-to-abstract-class-defined-in-csharp/expected.fs
@@ -1,0 +1,16 @@
+namespace System
+
+/// Provides the base class for value types.
+[<System.Runtime.InteropServices.ComVisible(true)>]
+[<AbstractClass>]
+type ValueType =
+    /// Initializes a new instance of the  class. 
+    new : unit -> ValueType
+    /// Indicates whether this instance and a specified object are equal.
+    [<System.Security.SecuritySafeCritical>]
+    member Equals : obj:obj -> bool
+    /// Returns the hash code for this instance.
+    [<System.Security.SecuritySafeCritical>]
+    member GetHashCode : unit -> int
+    /// Returns the fully qualified type name of this instance.
+    member ToString : unit -> string

--- a/tests/data/gotodef/generic-cases/go-to-abstract-class-defined-in-csharp/input.fs
+++ b/tests/data/gotodef/generic-cases/go-to-abstract-class-defined-in-csharp/input.fs
@@ -1,0 +1,1 @@
+let x: System.ValueType = Unchecked.defaultof<System.ValueType>

--- a/tests/data/gotodef/generic-cases/go-to-abstract-class-defined-in-csharp/settings.json
+++ b/tests/data/gotodef/generic-cases/go-to-abstract-class-defined-in-csharp/settings.json
@@ -1,0 +1,1 @@
+{ "pos": { "line": 1, "col": 15 }, "assertType" : "eq" }


### PR DESCRIPTION
For now, this only contains the failing test for generation of the `[<AbstractClass>]` attribute in generated metadata for classes not defined in F#, as described in #1482, to see if I'm on the right track here.

This test passes if the line containing `[<AbstractClass>]` is removed from `expected.fs`.