### PR TITLE
Updates FsXaml and FSharp.ViewModule usage

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.5.6 - February 3 2017
+* Updated FsXaml and FSharp.ViewModule to prevent type provider conflicts
+
 #### 2.5.5 - October 25 2016
 * Fixes to make sure that VFPT color scheme updates properly when VS theme is changed
 

--- a/paket.lock
+++ b/paket.lock
@@ -20,7 +20,7 @@ NUGET
       FSharp.Compiler.Service (>= 8.0)
       FSharp.Compiler.Service.ProjectCracker (>= 8.0)
     FsPickler (3.2)
-    FsXaml.Wpf (3.1.1)
+    FsXaml.Wpf (3.1.2)
     Microsoft.NETCore.Platforms (1.0.1) - framework: >= netstandard10
     Microsoft.NETCore.Targets (1.0.1) - framework: >= netstandard10
     runtime.native.System (4.0) - framework: >= netstandard13

--- a/paket.lock
+++ b/paket.lock
@@ -13,13 +13,14 @@ NUGET
     FSharp.Data (2.3.2)
       Zlib.Portable (>= 1.11) - framework: >= netstandard11, portable-net45+sl5+win8, portable-net45+win8, portable-net45+win8+wp8+wpa81
     FSharp.Management (0.4.2)
-    FSharp.ViewModule.Core (0.9.9.3)
+    FSharp.ViewModule.Core (1.0.5)
+      FSharp.Core
     FSharpLint.Core (0.4.10)
       FParsec (>= 1.0.2)
       FSharp.Compiler.Service (>= 8.0)
       FSharp.Compiler.Service.ProjectCracker (>= 8.0)
     FsPickler (3.2)
-    FsXaml.Wpf (2.1)
+    FsXaml.Wpf (3.1.1)
     Microsoft.NETCore.Platforms (1.0.1) - framework: >= netstandard10
     Microsoft.NETCore.Targets (1.0.1) - framework: >= netstandard10
     runtime.native.System (4.0) - framework: >= netstandard13

--- a/src/FSharp.Editing.VisualStudio.Tests.v2015/AssemblyInfo.fs
+++ b/src/FSharp.Editing.VisualStudio.Tests.v2015/AssemblyInfo.fs
@@ -7,8 +7,8 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyTitleAttribute("FSharp.Editing.VisualStudio.v2015")>]
 [<assembly: AssemblyProductAttribute("FSharpVSPowerTools")>]
 [<assembly: AssemblyDescriptionAttribute("A collection of additional commands for F# in Visual Studio")>]
-[<assembly: AssemblyVersionAttribute("2.5.5")>]
-[<assembly: AssemblyFileVersionAttribute("2.5.5")>]
+[<assembly: AssemblyVersionAttribute("2.5.6")>]
+[<assembly: AssemblyFileVersionAttribute("2.5.6")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,5 +16,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharp.Editing.VisualStudio.v2015"
     let [<Literal>] AssemblyProduct = "FSharpVSPowerTools"
     let [<Literal>] AssemblyDescription = "A collection of additional commands for F# in Visual Studio"
-    let [<Literal>] AssemblyVersion = "2.5.5"
-    let [<Literal>] AssemblyFileVersion = "2.5.5"
+    let [<Literal>] AssemblyVersion = "2.5.6"
+    let [<Literal>] AssemblyFileVersion = "2.5.6"

--- a/src/FSharp.Editing.VisualStudio/AssemblyInfo.fs
+++ b/src/FSharp.Editing.VisualStudio/AssemblyInfo.fs
@@ -7,8 +7,8 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyTitleAttribute("FSharp.Editing.VisualStudio")>]
 [<assembly: AssemblyProductAttribute("FSharpVSPowerTools")>]
 [<assembly: AssemblyDescriptionAttribute("A collection of additional commands for F# in Visual Studio")>]
-[<assembly: AssemblyVersionAttribute("2.5.5")>]
-[<assembly: AssemblyFileVersionAttribute("2.5.5")>]
+[<assembly: AssemblyVersionAttribute("2.5.6")>]
+[<assembly: AssemblyFileVersionAttribute("2.5.6")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,5 +16,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharp.Editing.VisualStudio"
     let [<Literal>] AssemblyProduct = "FSharpVSPowerTools"
     let [<Literal>] AssemblyDescription = "A collection of additional commands for F# in Visual Studio"
-    let [<Literal>] AssemblyVersion = "2.5.5"
-    let [<Literal>] AssemblyFileVersion = "2.5.5"
+    let [<Literal>] AssemblyVersion = "2.5.6"
+    let [<Literal>] AssemblyFileVersion = "2.5.6"

--- a/src/FSharp.Editing.VisualStudio/Common/Status.fs
+++ b/src/FSharp.Editing.VisualStudio/Common/Status.fs
@@ -3,7 +3,10 @@
 open System
 open Microsoft.VisualStudio.Shell.Interop
 open FSharp.Editing
-open FSharp.ViewModule.Progress
+open ViewModule
+open ViewModule.FSharp
+open ViewModule.Progress
+open ViewModule.Progress.FSharp
 
 /// Union of the available Visual Studio icons used for animation in the status bar
 type StatusIcon =

--- a/src/FSharp.Editing.VisualStudio/Folders/FolderNameDialog.fs
+++ b/src/FSharp.Editing.VisualStudio/Folders/FolderNameDialog.fs
@@ -2,8 +2,9 @@
 
 open System.IO
 open FSharp.Editing.VisualStudio
-open FSharp.ViewModule
-open FSharp.ViewModule.Validation
+open ViewModule
+open ViewModule.FSharp
+open ViewModule.Validation.FSharp
 
 type NewFolderNameDialog = FsXaml.XAML< @"Gui/FolderNameDialog.xaml">
 

--- a/src/FSharp.Editing.VisualStudio/Folders/MoveToFolderDialog.fs
+++ b/src/FSharp.Editing.VisualStudio/Folders/MoveToFolderDialog.fs
@@ -2,8 +2,10 @@
 
 open System.IO
 open FSharp.Editing.VisualStudio
-open FSharp.ViewModule
-open FSharp.ViewModule.Validation
+open ViewModule
+open ViewModule.FSharp
+open ViewModule.Validation
+open ViewModule.Validation.FSharp
 
 type MoveToFolderDialog = FsXaml.XAML< @"Gui/MoveToFolderDialog.xaml">
 

--- a/src/FSharp.Editing.VisualStudio/Linting/OptionsViewModel.fs
+++ b/src/FSharp.Editing.VisualStudio/Linting/OptionsViewModel.fs
@@ -6,7 +6,9 @@ open FSharp.Editing
 open FSharpLint.Framework
 open Configuration
 open FParsec
-open FSharp.ViewModule
+open ViewModule
+open ViewModule.FSharp
+open ViewModule.Validation.FSharp
 
 type BoolViewModel(name, isChecked) as this =
     inherit ViewModelBase()

--- a/src/FSharp.Editing.VisualStudio/Linting/RuleViewModel.fs
+++ b/src/FSharp.Editing.VisualStudio/Linting/RuleViewModel.fs
@@ -2,7 +2,8 @@
 
 open System
 open System.ComponentModel
-open FSharp.ViewModule
+open ViewModule
+open ViewModule.FSharp
 
 type RuleViewModel(name:string, rules:RuleViewModel seq, settings, isChecked:bool) as this =
     inherit ViewModelBase()

--- a/src/FSharp.Editing.VisualStudio/ProjectSystem/VSLanguageService.fs
+++ b/src/FSharp.Editing.VisualStudio/ProjectSystem/VSLanguageService.fs
@@ -1,7 +1,8 @@
 ﻿namespace FSharp.Editing.VisualStudio.ProjectSystem
 
 open FSharp.Editing.VisualStudio
-open FSharp.ViewModule.Progress
+open ViewModule.Progress
+open ViewModule.Progress.FSharp
 open Microsoft.VisualStudio.Editor
 open System.ComponentModel.Composition
 open Microsoft.VisualStudio.Text

--- a/src/FSharp.Editing.VisualStudio/Symbol/FindReferencesFilter.fs
+++ b/src/FSharp.Editing.VisualStudio/Symbol/FindReferencesFilter.fs
@@ -8,7 +8,8 @@ open Microsoft.VisualStudio.OLE.Interop
 open Microsoft.VisualStudio.Shell.Interop
 open FSharp.Editing
 open FSharp.Editing.VisualStudio
-open FSharp.ViewModule.Progress
+open ViewModule.Progress
+open ViewModule.Progress.FSharp
 open Microsoft.VisualStudio.Text
 open System.Diagnostics
 open Microsoft.FSharp.Compiler.AbstractIL.Internal.Library

--- a/src/FSharp.Editing.VisualStudio/Symbol/QuickInfoMargin.fs
+++ b/src/FSharp.Editing.VisualStudio/Symbol/QuickInfoMargin.fs
@@ -6,7 +6,8 @@ open Microsoft.VisualStudio.Text.Editor
 open Microsoft.VisualStudio.Text
 open FSharp.Editing
 open FSharp.Editing.VisualStudio
-open FSharp.ViewModule
+open ViewModule
+open ViewModule.FSharp
 open Microsoft.FSharp.Compiler
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open FSharp.Editing.VisualStudio.ProjectSystem

--- a/src/FSharp.Editing.VisualStudio/Symbol/RenameCommandFilter.fs
+++ b/src/FSharp.Editing.VisualStudio/Symbol/RenameCommandFilter.fs
@@ -10,7 +10,8 @@ open Microsoft.VisualStudio.Shell.Interop
 open Microsoft.FSharp.Compiler.Range
 open FSharp.Editing
 open FSharp.Editing.VisualStudio
-open FSharp.ViewModule.Progress
+open ViewModule.Progress
+open ViewModule.Progress.FSharp
 open FSharp.Editing.Infrastructure
 open FSharp.Editing.VisualStudio.ProjectSystem
 

--- a/src/FSharp.Editing.VisualStudio/Symbol/RenameDialog.fs
+++ b/src/FSharp.Editing.VisualStudio/Symbol/RenameDialog.fs
@@ -7,9 +7,12 @@ open Microsoft.FSharp.Compiler.SourceCodeServices
 open FSharp.Editing
 open FSharp.Editing.VisualStudio
 open FSharp.Editing.VisualStudio.ProjectSystem
-open FSharp.ViewModule
-open FSharp.ViewModule.Progress
-open FSharp.ViewModule.Validation
+open ViewModule
+open ViewModule.FSharp
+open ViewModule.Validation
+open ViewModule.Validation.FSharp
+open ViewModule.Progress
+open ViewModule.Progress.FSharp
 open FSharp.Editing.IdentifierUtils
 open FSharp.Editing.Features
 

--- a/src/FSharp.Editing/AssemblyInfo.fs
+++ b/src/FSharp.Editing/AssemblyInfo.fs
@@ -7,8 +7,8 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyTitleAttribute("FSharp.Editing")>]
 [<assembly: AssemblyProductAttribute("FSharpVSPowerTools")>]
 [<assembly: AssemblyDescriptionAttribute("A collection of additional commands for F# in Visual Studio")>]
-[<assembly: AssemblyVersionAttribute("2.5.5")>]
-[<assembly: AssemblyFileVersionAttribute("2.5.5")>]
+[<assembly: AssemblyVersionAttribute("2.5.6")>]
+[<assembly: AssemblyFileVersionAttribute("2.5.6")>]
 do ()
 
 module internal AssemblyVersionInformation =
@@ -16,5 +16,5 @@ module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "FSharp.Editing"
     let [<Literal>] AssemblyProduct = "FSharpVSPowerTools"
     let [<Literal>] AssemblyDescription = "A collection of additional commands for F# in Visual Studio"
-    let [<Literal>] AssemblyVersion = "2.5.5"
-    let [<Literal>] AssemblyFileVersion = "2.5.5"
+    let [<Literal>] AssemblyVersion = "2.5.6"
+    let [<Literal>] AssemblyFileVersion = "2.5.6"

--- a/src/FSharpVSPowerTools/Properties/AssemblyInfo.cs
+++ b/src/FSharpVSPowerTools/Properties/AssemblyInfo.cs
@@ -6,15 +6,15 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitleAttribute("FSharpVSPowerTools")]
 [assembly: AssemblyProductAttribute("FSharpVSPowerTools")]
 [assembly: AssemblyDescriptionAttribute("A collection of additional commands for F# in Visual Studio")]
-[assembly: AssemblyVersionAttribute("2.5.5")]
-[assembly: AssemblyFileVersionAttribute("2.5.5")]
+[assembly: AssemblyVersionAttribute("2.5.6")]
+[assembly: AssemblyFileVersionAttribute("2.5.6")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String InternalsVisibleTo = "FSharp.Editing.VisualStudio.Tests";
         internal const System.String AssemblyTitle = "FSharpVSPowerTools";
         internal const System.String AssemblyProduct = "FSharpVSPowerTools";
         internal const System.String AssemblyDescription = "A collection of additional commands for F# in Visual Studio";
-        internal const System.String AssemblyVersion = "2.5.5";
-        internal const System.String AssemblyFileVersion = "2.5.5";
+        internal const System.String AssemblyVersion = "2.5.6";
+        internal const System.String AssemblyFileVersion = "2.5.6";
     }
 }

--- a/src/FSharpVSPowerTools/source.extension.vsixmanifest
+++ b/src/FSharpVSPowerTools/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.5.5" Language="en-US" Publisher="fsharp.org" />
+    <Identity Id="FSharpVSPowerTools.68b42cfe-c752-4094-8dba-ed48aa81cac8" Version="2.5.6" Language="en-US" Publisher="fsharp.org" />
     <DisplayName>Visual F# Power Tools</DisplayName>
     <Description xml:space="preserve">A collection of additional commands for F# in Visual Studio</Description>
     <MoreInfo>https://github.com/fsprojects/VisualFSharpPowerTools</MoreInfo>


### PR DESCRIPTION
With the new release of FsXaml, anybody using Visual F# Power Tools will get errors in any projects using FsXaml, since it's loading an older, binary incompatible version into the VS process.

This updates to the latest releases of these two projects, and migrates the code across to match (without changing any functionality).

